### PR TITLE
fix(governance): one cryptographic voter, one effective vote, regardless of DID spelling

### DIFF
--- a/docs/architecture/IDENTITY_SEMANTICS.md
+++ b/docs/architecture/IDENTITY_SEMANTICS.md
@@ -465,12 +465,26 @@ now, and no downstream design may violate it while remaining conformant.
 
 ### 7.5 Hard migration gate — membership and vote re-keying
 
-Vote storage is keyed by voter identity and the re-cast guard is declared but
-never constructed, so dual-keying would let the same historical person create two
-counted rows. **Before any live membership or vote re-key**, four things must be
-designed: migration ordering · alias/transition recognition · duplicate-act
-prevention · final cutover. N2 does not solve governance storage; it states the
-gate.
+Vote storage is keyed by voter identity, so dual-keying would let the same
+historical person create two counted rows. **Before any live membership or vote
+re-key**, four things must be designed: migration ordering · alias/transition
+recognition · duplicate-act prevention · final cutover. N2 does not solve
+governance storage; it states the gate.
+
+**Duplicate-act prevention is delivered** (#2641). Governance admission and
+tallying resolve a voter to the bytes its `did:icn:` identifier decodes to, via
+`icn-governance`'s `VotingPrincipal`, so one cryptographic voter contributes at
+most one effective vote whatever multibase spelling names it. `AlreadyVoted` is
+now constructed, by `ensure_has_not_voted`, on both apps/governance admission
+paths. Rows for one principal that express conflicting acts fail closed rather
+than electing a survivor, because choosing between two conflicting historical
+acts is this gate's business, not the duplicate-act guard's.
+
+The other three prerequisites — migration ordering, alias/transition
+recognition, final cutover — remain undesigned, and **no persisted vote or
+membership key has been re-keyed**. Membership lists are still compared by DID
+spelling; under a static list an alias spelling is refused at the membership
+gate, which is fail-closed but is not yet alias recognition.
 
 ---
 

--- a/docs/architecture/IDENTITY_SEMANTICS.md
+++ b/docs/architecture/IDENTITY_SEMANTICS.md
@@ -474,11 +474,28 @@ governance storage; it states the gate.
 **Duplicate-act prevention is delivered** (#2641). Governance admission and
 tallying resolve a voter to the bytes its `did:icn:` identifier decodes to, via
 `icn-governance`'s `VotingPrincipal`, so one cryptographic voter contributes at
-most one effective vote whatever multibase spelling names it. `AlreadyVoted` is
-now constructed, by `ensure_has_not_voted`, on both apps/governance admission
-paths. Rows for one principal that express conflicting acts fail closed rather
-than electing a survivor, because choosing between two conflicting historical
-acts is this gate's business, not the duplicate-act guard's.
+most one effective vote whatever multibase spelling names it. Rows for one
+principal that express conflicting acts fail closed rather than electing a
+survivor, because choosing between two conflicting historical acts is this
+gate's business, not the duplicate-act guard's.
+
+The two apps/governance admission paths reach that one-vote result under
+**different recast policies**, and a consumer must not assume either from the
+other:
+
+* the in-process `GovernanceManager` **refuses** a repeat vote, constructing
+  `GovernanceError::AlreadyVoted` via `ensure_has_not_voted`. Ballots are
+  immutable on this path;
+* the actor backend **permits a vote change**, which is its pre-existing
+  behaviour, and supersedes the principal's existing row rather than adding one.
+  A ballot is mutable on this path until the proposal closes.
+
+Both keep exactly one stored row and one effective vote per principal, which is
+what duplicate-act prevention requires; they differ on whether the voter may
+change their mind, which is a governance-policy question this gate does not
+settle. Where a principal already holds several pre-#2641 rows the actor refuses
+without mutating, since it overwrites by spelling-keyed row and cannot supersede
+them all at once.
 
 The other three prerequisites — migration ordering, alias/transition
 recognition, final cutover — remain undesigned, and **no persisted vote or

--- a/docs/architecture/n2-a0-stored-key-inventory.md
+++ b/docs/architecture/n2-a0-stored-key-inventory.md
@@ -740,14 +740,22 @@ not materialised; #2623/#2626/#2627 disclaim governance storage). **Filed by thi
 now resolves a voter to the bytes its `did:icn:` identifier decodes to (`icn-governance`'s
 `VotingPrincipal`): `AlreadyVoted` has a constructor (`ensure_has_not_voted`), both
 `GovernanceStore` implementations supersede a principal's prior row across spellings, and every
-production tally path uses `VoteTally::try_from_votes`, which collapses agreeing alias rows and
-**fails closed** on conflicting ones rather than electing a survivor. Two corrections to the note
-above, found while fixing it: the live exploit is not only #23 via `manager.rs`'s guard —
+tally path in the workspace uses `VoteTally::try_from_votes`, which collapses agreeing alias rows
+and **fails closed** on conflicting ones rather than electing a survivor. That covers the live
+actor paths — the read-only `get_vote_tally` *and* the decision-producing tally inside
+`CloseProposal`, including its close-time delegation expansion — and the `GovernanceStore` library
+surface, whose only in-workspace consumer is `ProposalCleanupTask::archive_proposal`. Three
+corrections to the note above, found while fixing it: the live exploit is not only #23 via
+`manager.rs`'s guard —
 `GovernanceManager::cast_vote` delegates to `governance_handle` as its *first* statement, so in
 actor-backed deployments the membership gate and that guard never ran, and the actor's `CastVote`
 handler had **no** duplicate-vote guard at all; and the identity used for the fix is the decoded
 identifier bytes rather than a `VerifyingKey`, because anchor-derived DIDs (`Did::from_anchor_id`)
-need not decompress to an Edwards point. Nothing was re-keyed: vote rows remain `Display`-keyed and
+need not decompress to an Edwards point. Third, the delegation hazard is not confined to
+`compute_tally_with_delegations` (which has no production caller): its production twin,
+`apply_delegation_to_tally`, was spelling-keyed, so a member could delegate from one spelling of
+their key to another, vote as the delegate, and have that single vote resolved back to them as a
+second one at close — reachable on a fresh deployment with no legacy rows. Nothing was re-keyed: vote rows remain `Display`-keyed and
 membership lists remain spelling-compared, so §7.5's re-key gate is untouched and this row stays
 `NEEDS MIGRATION` for N2-A.
 

--- a/docs/architecture/n2-a0-stored-key-inventory.md
+++ b/docs/architecture/n2-a0-stored-key-inventory.md
@@ -736,6 +736,21 @@ fix it (the rows are `Display`-keyed). **Disposition:** no issue owned it (§7.5
 not materialised; #2623/#2626/#2627 disclaim governance storage). **Filed by this review as
 #2641.**
 
+**Resolved 2026-08-28 (#2641).** The measurement above stands as taken at `798c8d54`. Governance
+now resolves a voter to the bytes its `did:icn:` identifier decodes to (`icn-governance`'s
+`VotingPrincipal`): `AlreadyVoted` has a constructor (`ensure_has_not_voted`), both
+`GovernanceStore` implementations supersede a principal's prior row across spellings, and every
+production tally path uses `VoteTally::try_from_votes`, which collapses agreeing alias rows and
+**fails closed** on conflicting ones rather than electing a survivor. Two corrections to the note
+above, found while fixing it: the live exploit is not only #23 via `manager.rs`'s guard —
+`GovernanceManager::cast_vote` delegates to `governance_handle` as its *first* statement, so in
+actor-backed deployments the membership gate and that guard never ran, and the actor's `CastVote`
+handler had **no** duplicate-vote guard at all; and the identity used for the fix is the decoded
+identifier bytes rather than a `VerifyingKey`, because anchor-derived DIDs (`Did::from_anchor_id`)
+need not decompress to an Edwards point. Nothing was re-keyed: vote rows remain `Display`-keyed and
+membership lists remain spelling-compared, so §7.5's re-key gate is untouched and this row stays
+`NEEDS MIGRATION` for N2-A.
+
 ### 10.4 `grantee_canonical_bytes` canonicalizes the *layout*, not the spelling
 `receipt_store.rs:1071` is named `*_canonical_bytes` and emits a tag byte followed by
 `did.as_str()` — the raw spelling. A lookup with a differently-spelled DID misses the grant (fails

--- a/icn/apps/governance/src/actor.rs
+++ b/icn/apps/governance/src/actor.rs
@@ -2156,12 +2156,21 @@ impl GovernanceActor {
             } => {
                 info!("Casting vote on proposal: {} by {}", proposal_id.0, voter);
 
-                // INV-6 by cryptographic principal, not by DID spelling. This
-                // path previously had no duplicate-vote guard at all, so a
-                // voter re-spelling their DID in another multibase encoding
-                // wrote a second row that every tally counted (#2641).
+                // One stored row per cryptographic principal (#2641). This path
+                // has no duplicate-vote guard, so a voter re-spelling their DID
+                // in another accepted multibase encoding used to write a second
+                // row under the second spelling, which every tally counted.
+                //
+                // Changing a vote stays allowed -- that is this path's existing
+                // semantics, and `save_vote` overwrites by key -- so instead of
+                // refusing, the update is written onto the row this principal
+                // already owns, under whatever spelling first recorded it. Fails
+                // closed if that history is already ambiguous.
                 let existing = self.load_votes(&proposal_id)?;
-                icn_governance::ensure_has_not_voted(&existing, &voter)?;
+                let voter = match icn_governance::prior_act_for(&existing, &voter)? {
+                    Some(prior) => prior.voter.clone(),
+                    None => voter,
+                };
 
                 let mut vote = Vote::new(proposal_id.clone(), voter, choice);
                 if let Some(c) = comment {

--- a/icn/apps/governance/src/actor.rs
+++ b/icn/apps/governance/src/actor.rs
@@ -2167,7 +2167,25 @@ impl GovernanceActor {
                 // already owns, under whatever spelling first recorded it. Fails
                 // closed if that history is already ambiguous.
                 let existing = self.load_votes(&proposal_id)?;
-                let voter = match icn_governance::prior_act_for(&existing, &voter)? {
+                let prior = icn_governance::acts_for(&existing, &voter)?;
+                if prior.len() > 1 {
+                    // Several pre-#2641 rows already name this principal. They
+                    // agree, or `acts_for` would have refused, but this store
+                    // overwrites by spelling-keyed row and cannot supersede all
+                    // of them at once. Writing would leave the others behind and
+                    // turn a reducible duplicate into a conflicting pair, which
+                    // fails every later tally. Refuse without mutating instead.
+                    anyhow::bail!(
+                        "{} has {} vote rows on proposal {} under different DID spellings; \
+                         the §7.5-gated vote migration must reduce them before this voter \
+                         can act again. The existing rows agree, so the proposal still \
+                         tallies correctly.",
+                        voter,
+                        prior.len(),
+                        proposal_id.0,
+                    );
+                }
+                let voter = match prior.first() {
                     Some(prior) => prior.voter.clone(),
                     None => voter,
                 };
@@ -2244,6 +2262,19 @@ impl GovernanceActor {
                 // votes from members who lost commons standing after casting are excluded.
                 // The proof records only the votes that counted in the final decision.
                 let all_votes = self.load_votes(&proposal_id)?;
+
+                // Detect principal-level conflicts across *every* stored row,
+                // before eligibility narrows the set. The standing filter is
+                // still spelling-keyed, so where a principal has conflicting
+                // pre-#2641 rows it can admit one spelling and drop the other,
+                // leaving nothing for the reduction below to notice — and the
+                // close would then finalise whichever act happened to be spelled
+                // the way the standing set names it. A conflicting pair must
+                // fail closed on the filtered path exactly as it does on the
+                // unfiltered one; which of two conflicting acts is authoritative
+                // is the §7.5 migration's decision, not a spelling's (#2641).
+                icn_governance::effective_votes(&all_votes)?;
+
                 let votes: Vec<Vote> = match &eligible_voters {
                     Some(filter) => all_votes
                         .into_iter()

--- a/icn/apps/governance/src/actor.rs
+++ b/icn/apps/governance/src/actor.rs
@@ -2156,6 +2156,13 @@ impl GovernanceActor {
             } => {
                 info!("Casting vote on proposal: {} by {}", proposal_id.0, voter);
 
+                // INV-6 by cryptographic principal, not by DID spelling. This
+                // path previously had no duplicate-vote guard at all, so a
+                // voter re-spelling their DID in another multibase encoding
+                // wrote a second row that every tally counted (#2641).
+                let existing = self.load_votes(&proposal_id)?;
+                icn_governance::ensure_has_not_voted(&existing, &voter)?;
+
                 let mut vote = Vote::new(proposal_id.clone(), voter, choice);
                 if let Some(c) = comment {
                     vote = vote.with_comment(c);
@@ -3459,7 +3466,9 @@ impl GovernanceActor {
     /// Get vote tally for a proposal
     fn get_vote_tally(&self, proposal_id: &ProposalId) -> Result<VoteTally> {
         let votes = self.load_votes(proposal_id)?;
-        Ok(VoteTally::from(votes))
+        // One effective vote per cryptographic principal; conflicting
+        // historical rows fail closed rather than double-counting (#2641).
+        Ok(VoteTally::try_from_votes(&votes)?)
     }
 
     /// Get list of voter DIDs for a proposal

--- a/icn/apps/governance/src/actor.rs
+++ b/icn/apps/governance/src/actor.rs
@@ -2299,11 +2299,7 @@ impl GovernanceActor {
                 // a membership list naming one key under two spellings would
                 // otherwise claim two electorate slots for one voter and read
                 // that voter's single vote as half turnout instead of full.
-                let mut eligible_principals = std::collections::HashSet::new();
-                for member in &eligible_members {
-                    eligible_principals.insert(VotingPrincipal::of(member)?);
-                }
-                let eligible_count = eligible_principals.len();
+                let eligible_count = icn_governance::distinct_principals(&eligible_members)?;
 
                 // Edge case: cannot evaluate proposal with zero eligible voters
                 // This prevents division issues and ensures meaningful quorum calculation
@@ -3934,9 +3930,9 @@ impl GovernanceActor {
         }
 
         // Delegate chosen for each principal, so several spellings of one member
-        // cannot each expand, and cannot disagree without being noticed.
-        let mut resolved_delegate: std::collections::HashMap<VotingPrincipal, VotingPrincipal> =
-            std::collections::HashMap::new();
+        // cannot each expand, and cannot disagree without being noticed. Shared
+        // with the library tallies so the two cannot drift apart.
+        let mut resolution = icn_governance::DelegationResolution::new();
 
         let mut delegated = 0usize;
         for member in eligible_members {
@@ -3964,21 +3960,10 @@ impl GovernanceActor {
             // delegate: otherwise the first entry in the resolver's list would
             // decide which delegated act counts, making list order the authority
             // over a vote. Fail closed instead, and expand at most once (#2641).
-            match resolved_delegate.get(&member_principal) {
-                Some(&already) if already != delegate_principal => {
-                    return Err(anyhow::anyhow!(
-                        "proposal {}: one voting principal holds competing delegations under \
-                         different DID spellings ('{}' resolves elsewhere than a previous \
-                         spelling of the same key); refusing to let membership-list order \
-                         choose which delegated act counts",
-                        proposal_id.0,
-                        member,
-                    ));
-                }
-                Some(_) => continue, // same delegate, already expanded
-                None => {
-                    resolved_delegate.insert(member_principal, delegate_principal);
-                }
+            if resolution.record(member, member_principal, delegate_principal)?
+                == icn_governance::DelegationStep::AlreadyExpanded
+            {
+                continue;
             }
 
             if let Some(delegate_vote) = vote_by_principal.get(&delegate_principal) {

--- a/icn/apps/governance/src/actor.rs
+++ b/icn/apps/governance/src/actor.rs
@@ -2293,7 +2293,17 @@ impl GovernanceActor {
                 // standing revalidation filters whose votes count but does not shrink
                 // the community for quorum purposes.
                 let eligible_members = self.resolver.resolve_members(&domain)?;
-                let eligible_count = eligible_members.len();
+
+                // The quorum denominator counts distinct voting principals, not
+                // DID spellings. The numerator is principal-reduced (#2641), so
+                // a membership list naming one key under two spellings would
+                // otherwise claim two electorate slots for one voter and read
+                // that voter's single vote as half turnout instead of full.
+                let mut eligible_principals = std::collections::HashSet::new();
+                for member in &eligible_members {
+                    eligible_principals.insert(VotingPrincipal::of(member)?);
+                }
+                let eligible_count = eligible_principals.len();
 
                 // Edge case: cannot evaluate proposal with zero eligible voters
                 // This prevents division issues and ensures meaningful quorum calculation
@@ -3923,6 +3933,11 @@ impl GovernanceActor {
             vote_by_principal.insert(principal, v);
         }
 
+        // Delegate chosen for each principal, so several spellings of one member
+        // cannot each expand, and cannot disagree without being noticed.
+        let mut resolved_delegate: std::collections::HashMap<VotingPrincipal, VotingPrincipal> =
+            std::collections::HashMap::new();
+
         let mut delegated = 0usize;
         for member in eligible_members {
             let member_principal = VotingPrincipal::of(member)?;
@@ -3944,15 +3959,33 @@ impl GovernanceActor {
                 continue; // no active delegation, whatever spelling names it
             }
 
+            // One principal delegates once. Where a membership list names it under
+            // several spellings, those spellings must resolve to the same
+            // delegate: otherwise the first entry in the resolver's list would
+            // decide which delegated act counts, making list order the authority
+            // over a vote. Fail closed instead, and expand at most once (#2641).
+            match resolved_delegate.get(&member_principal) {
+                Some(&already) if already != delegate_principal => {
+                    return Err(anyhow::anyhow!(
+                        "proposal {}: one voting principal holds competing delegations under \
+                         different DID spellings ('{}' resolves elsewhere than a previous \
+                         spelling of the same key); refusing to let membership-list order \
+                         choose which delegated act counts",
+                        proposal_id.0,
+                        member,
+                    ));
+                }
+                Some(_) => continue, // same delegate, already expanded
+                None => {
+                    resolved_delegate.insert(member_principal, delegate_principal);
+                }
+            }
+
             if let Some(delegate_vote) = vote_by_principal.get(&delegate_principal) {
                 // Create a synthetic vote for the delegating member using the delegate's choice.
                 let delegated_vote =
                     Vote::new(proposal_id.clone(), member.clone(), delegate_vote.choice);
                 tally.add_vote(&delegated_vote);
-                // Mark the delegator counted, as the `tally.rs` equivalent does, so
-                // a member list naming one principal under two spellings cannot
-                // have its delegation expanded twice (#2641).
-                direct_voters.insert(member_principal);
                 delegated += 1;
                 tracing::debug!(
                     member = %member,

--- a/icn/apps/governance/src/actor.rs
+++ b/icn/apps/governance/src/actor.rs
@@ -25,7 +25,7 @@ use icn_governance::{
     GovernanceParams, GovernanceProfile, GovernanceProfileId, MembershipAction, MembershipConfig,
     MembershipResolver, MembershipSource, PaginatedResult, ParameterChange, Proposal, ProposalId,
     ProposalOutcome, ProposalPayload, ProposalScope, ProposalState, ProtocolParameter,
-    ProtocolParameterStore, TallySnapshot, Timestamp, Vote, VoteChoice, VoteTally,
+    ProtocolParameterStore, TallySnapshot, Timestamp, Vote, VoteChoice, VoteTally, VotingPrincipal,
 };
 
 use icn_kernel_api::events::{EventEmitter, SystemEvent};
@@ -2251,10 +2251,11 @@ impl GovernanceActor {
                         .collect(),
                     None => all_votes,
                 };
-                let mut tally = VoteTally::empty();
-                for v in &votes {
-                    tally.add_vote(v);
-                }
+                // The tally that decides the outcome, so it must give one
+                // cryptographic principal one effective vote and fail closed on
+                // conflicting historical rows, exactly like the read-only
+                // `get_vote_tally` (#2641).
+                let mut tally = VoteTally::try_from_votes(&votes)?;
 
                 // Resolve eligible membership (list needed for delegation resolution).
                 // eligible_count uses the FULL member list as the quorum denominator —
@@ -2297,7 +2298,7 @@ impl GovernanceActor {
                     &proposal_id,
                     &mut tally,
                     excluded_delegators.as_ref(),
-                );
+                )?;
 
                 // Get proposal-type-specific thresholds (Issue #477)
                 // Emergency proposals (freeze, veto, rollback) require higher quorum/approval
@@ -3875,16 +3876,26 @@ impl GovernanceActor {
         proposal_id: &ProposalId,
         tally: &mut VoteTally,
         excluded_delegators: Option<&std::collections::HashSet<Did>>,
-    ) {
-        // Build a fast lookup of who voted directly
-        let direct_voters: std::collections::HashSet<&Did> =
-            votes.iter().map(|v| &v.voter).collect();
-        let vote_by_did: std::collections::HashMap<&Did, &Vote> =
-            votes.iter().map(|v| (&v.voter, v)).collect();
+    ) -> Result<()> {
+        // Keyed by cryptographic principal, not DID spelling. Keying by
+        // spelling let a member delegate from one spelling of their key to
+        // another, then vote as the delegate: the delegator looked like a
+        // non-voter, the self-delegation did not look like self-delegation, and
+        // their own vote was resolved back to them as a second one (#2641).
+        let mut direct_voters: std::collections::HashSet<VotingPrincipal> =
+            std::collections::HashSet::new();
+        let mut vote_by_principal: std::collections::HashMap<VotingPrincipal, &Vote> =
+            std::collections::HashMap::new();
+        for v in votes {
+            let principal = VotingPrincipal::of(&v.voter)?;
+            direct_voters.insert(principal);
+            vote_by_principal.insert(principal, v);
+        }
 
         let mut delegated = 0usize;
         for member in eligible_members {
-            if direct_voters.contains(member) {
+            let member_principal = VotingPrincipal::of(member)?;
+            if direct_voters.contains(&member_principal) {
                 continue; // voted directly — no delegation needed
             }
 
@@ -3897,15 +3908,20 @@ impl GovernanceActor {
             }
 
             let delegate = self.resolve_delegate_from_store(member, domain_id, proposal_id);
-            if &delegate == member {
-                continue; // no active delegation
+            let delegate_principal = VotingPrincipal::of(&delegate)?;
+            if delegate_principal == member_principal {
+                continue; // no active delegation, whatever spelling names it
             }
 
-            if let Some(delegate_vote) = vote_by_did.get(&delegate) {
+            if let Some(delegate_vote) = vote_by_principal.get(&delegate_principal) {
                 // Create a synthetic vote for the delegating member using the delegate's choice.
                 let delegated_vote =
                     Vote::new(proposal_id.clone(), member.clone(), delegate_vote.choice);
                 tally.add_vote(&delegated_vote);
+                // Mark the delegator counted, as the `tally.rs` equivalent does, so
+                // a member list naming one principal under two spellings cannot
+                // have its delegation expanded twice (#2641).
+                direct_voters.insert(member_principal);
                 delegated += 1;
                 tracing::debug!(
                     member = %member,
@@ -3924,6 +3940,8 @@ impl GovernanceActor {
                 delegated
             );
         }
+
+        Ok(())
     }
 
     /// Revoke a delegation

--- a/icn/apps/governance/src/manager.rs
+++ b/icn/apps/governance/src/manager.rs
@@ -3779,6 +3779,15 @@ impl GovernanceManager {
             })?;
 
             let raw_votes = votes.get(&proposal_id).cloned().unwrap_or_default();
+
+            // Detect principal-level conflicts across every stored row before
+            // eligibility narrows the set. The standing filter compares DID
+            // spellings, so it can retain one spelling of a conflicting pre-#2641
+            // pair and discard the other, leaving the reduction below nothing to
+            // notice — and this close would then finalise whichever act happened
+            // to be spelled the way the standing set names it (#2641).
+            icn_governance::effective_votes(&raw_votes)?;
+
             // If an eligibility filter was provided (close-time standing revalidation),
             // exclude votes from members who no longer hold active commons standing.
             let proposal_votes: Vec<_> = match eligible_voters {
@@ -3791,7 +3800,12 @@ impl GovernanceManager {
             let tally = VoteTally::try_from_votes(&proposal_votes)?;
 
             let total_members = match &domain.config.membership.source {
-                MembershipSource::StaticList(members) => members.len(),
+                // Distinct voting principals, not DID spellings: the numerator
+                // above gives one principal one vote, so the denominator must
+                // count that principal once however many spellings name it.
+                MembershipSource::StaticList(members) => {
+                    icn_governance::distinct_principals(members)?
+                }
                 MembershipSource::TrustThreshold(_) => tally.total_votes().max(1),
             };
 
@@ -9191,6 +9205,97 @@ mod tests {
         .unwrap();
 
         (mgr, domain_id, member_did)
+    }
+
+    /// #2641, standalone quorum denominator: the tally numerator gives one
+    /// principal one vote, so the electorate it is measured against must count
+    /// that principal once however many spellings name it. Otherwise a static
+    /// list naming one key twice claims two electorate slots for one voter and
+    /// reads their vote as half turnout.
+    #[tokio::test]
+    async fn standalone_quorum_denominator_counts_principals_not_spellings() {
+        let kp = icn_identity::KeyPair::generate().unwrap();
+        let member = kp.did().clone();
+        let alias = alias_spelling(&member);
+        assert_ne!(member, alias, "control: the spellings must differ");
+
+        let domain_id = GovernanceDomainId::new("quorum-alias");
+        let mgr = GovernanceManager::new();
+        mgr.create_domain(
+            domain_id.clone(),
+            "Quorum alias".to_string(),
+            "default".to_string(),
+            GovernanceParams {
+                // 100% quorum makes the difference decisive: 1/1 reaches it, 1/2 does not.
+                quorum_percentage: 100,
+                approval_threshold_percentage: 51,
+                voting_period_seconds: 86400,
+                require_deliberation: false,
+                ..GovernanceParams::default()
+            },
+            MembershipConfig {
+                source: MembershipSource::StaticList(vec![member.clone(), alias]),
+            },
+        )
+        .await
+        .unwrap();
+
+        let proposal_id = make_open_proposal(&mgr, &domain_id, &member).await;
+        mgr.cast_vote(proposal_id.clone(), member, VoteChoice::For, None)
+            .await
+            .expect("the member votes");
+        mgr.close_proposal(proposal_id.clone())
+            .await
+            .expect("close_proposal");
+
+        let closed = mgr
+            .get_proposal(&proposal_id)
+            .await
+            .unwrap()
+            .expect("proposal exists");
+        assert!(
+            matches!(closed.state, ProposalState::Accepted { .. }),
+            "the sole member voted, so turnout is 1/1 and the 100% quorum is met; \
+             NoQuorum means the denominator counted two spellings as two voters (got {:?})",
+            closed.state
+        );
+    }
+
+    /// #2641, standalone filtered close: standing revalidation compares DID
+    /// spellings, so it can retain one spelling of a conflicting pre-fix pair and
+    /// discard the other, leaving the reduction nothing to notice. Conflicts must
+    /// be detected across every stored row before eligibility narrows the set.
+    #[tokio::test]
+    async fn standalone_filtered_close_fails_closed_on_hidden_conflicts() {
+        let (mgr, domain_id, member_did) = make_manager_with_domain().await;
+        let proposal_id = make_open_proposal(&mgr, &domain_id, &member_did).await;
+        let alias = alias_spelling(&member_did);
+        assert_ne!(member_did, alias, "control: the spellings must differ");
+
+        // Two conflicting acts by one key, as a pre-#2641 binary left them.
+        {
+            let mut votes = mgr.votes.write().unwrap();
+            let rows = votes.entry(proposal_id.clone()).or_default();
+            rows.push(Vote::new(
+                proposal_id.clone(),
+                member_did.clone(),
+                VoteChoice::For,
+            ));
+            rows.push(Vote::new(proposal_id.clone(), alias, VoteChoice::Against));
+        }
+
+        // A standing set naming only the canonical spelling would drop the other.
+        let mut standing = HashSet::new();
+        standing.insert(member_did);
+
+        let err = mgr
+            .close_proposal_filtered(proposal_id.clone(), &standing)
+            .await
+            .expect_err("a conflict the standing filter would hide must still fail closed");
+        assert!(
+            err.to_string().contains("conflicting"),
+            "must fail closed naming the conflict, got: {err}"
+        );
     }
 
     /// #2641: the admission layer must reject a second vote from one

--- a/icn/apps/governance/src/manager.rs
+++ b/icn/apps/governance/src/manager.rs
@@ -3788,7 +3788,7 @@ impl GovernanceManager {
                     .collect(),
                 None => raw_votes,
             };
-            let tally = VoteTally::from(proposal_votes.clone());
+            let tally = VoteTally::try_from_votes(&proposal_votes)?;
 
             let total_members = match &domain.config.membership.source {
                 MembershipSource::StaticList(members) => members.len(),
@@ -4584,7 +4584,7 @@ impl GovernanceManager {
             .read()
             .map_err(|e| anyhow::anyhow!("Votes storage lock poisoned (concurrent panic?): {e}"))?;
         let proposal_votes = votes.get(proposal_id).cloned().unwrap_or_default();
-        Ok(VoteTally::from(proposal_votes))
+        Ok(VoteTally::try_from_votes(&proposal_votes)?)
     }
 
     /// Get list of voter DIDs for a proposal
@@ -4768,13 +4768,11 @@ impl GovernanceManager {
 
         let proposal_votes = votes.entry(proposal_id.clone()).or_insert_with(Vec::new);
 
-        if proposal_votes.iter().any(|v| v.voter == voter) {
-            anyhow::bail!(
-                "Voter {} has already voted on proposal {}",
-                voter,
-                proposal_id.0
-            );
-        }
+        // INV-6 by cryptographic principal, not by DID spelling: re-spelling a
+        // voter DID in another multibase encoding must not buy a second vote
+        // (#2641). Also fails closed if this principal already has conflicting
+        // stored acts.
+        icn_governance::ensure_has_not_voted(proposal_votes, &voter)?;
 
         let mut vote = Vote::new(proposal_id, voter, choice);
         if let Some(c) = comment {
@@ -9135,6 +9133,151 @@ mod tests {
     }
 
     /// INV-6 TEST: Duplicate vote is rejected.
+    /// Re-spell a DID as multibase base16 (`f`) over the same identifier bytes.
+    fn alias_spelling(did: &Did) -> Did {
+        let bytes = did.identifier_bytes().expect("test DID must decode");
+        let alt = format!("did:icn:f{}", hex::encode(bytes));
+        Did::from_str(&alt).expect("base16 multibase spelling must parse")
+    }
+
+    async fn make_open_proposal(
+        mgr: &GovernanceManager,
+        domain_id: &GovernanceDomainId,
+        author: &Did,
+    ) -> ProposalId {
+        let proposal_id = mgr
+            .create_proposal(
+                ProposalId(format!("prop-{}", uuid::Uuid::new_v4())),
+                domain_id.clone(),
+                author.clone(),
+                "Test".to_string(),
+                "Test proposal".to_string(),
+                ProposalPayload::Text {
+                    body: "test".to_string(),
+                },
+                ProposalScope::Local,
+            )
+            .await
+            .unwrap();
+        mgr.open_proposal(proposal_id.clone(), 86400).await.unwrap();
+        proposal_id
+    }
+
+    /// Domain whose membership gate admits any DID, so the recast guard is the
+    /// only thing standing between a re-spelled voter and a second vote. This
+    /// is the configuration under which #2641 was reachable end to end.
+    async fn make_manager_trust_threshold() -> (GovernanceManager, GovernanceDomainId, Did) {
+        let kp = icn_identity::KeyPair::generate().unwrap();
+        let member_did = kp.did().clone();
+        let domain_id = GovernanceDomainId::new("test-coop-trust");
+
+        let mgr = GovernanceManager::new();
+        mgr.create_domain(
+            domain_id.clone(),
+            "Test Coop".to_string(),
+            "default".to_string(),
+            GovernanceParams {
+                quorum_percentage: 1,
+                approval_threshold_percentage: 51,
+                voting_period_seconds: 86400,
+                require_deliberation: false,
+                ..GovernanceParams::default()
+            },
+            MembershipConfig {
+                source: MembershipSource::TrustThreshold(0.5),
+            },
+        )
+        .await
+        .unwrap();
+
+        (mgr, domain_id, member_did)
+    }
+
+    /// #2641: the admission layer must reject a second vote from one
+    /// cryptographic voter even when it arrives under a different accepted
+    /// multibase spelling of the same DID.
+    #[tokio::test]
+    async fn inv6_holds_against_alias_spelled_did() {
+        let (mgr, domain_id, member_did) = make_manager_trust_threshold().await;
+        let proposal_id = make_open_proposal(&mgr, &domain_id, &member_did).await;
+        let alias = alias_spelling(&member_did);
+
+        // Control: the two spellings really are distinct `Did` values today.
+        assert_ne!(
+            member_did, alias,
+            "control: spellings must differ under current Did equality"
+        );
+
+        mgr.cast_vote(proposal_id.clone(), member_did, VoteChoice::For, None)
+            .await
+            .expect("first vote must succeed");
+
+        let err = mgr
+            .cast_vote(proposal_id.clone(), alias, VoteChoice::Against, None)
+            .await
+            .expect_err("re-spelled DID must not buy a second vote")
+            .to_string();
+        assert!(
+            err.contains("already voted"),
+            "must be refused as a duplicate vote, got: {err}"
+        );
+
+        let tally = mgr.get_vote_tally(&proposal_id).await.unwrap();
+        assert_eq!(
+            tally.total_votes(),
+            1,
+            "one cryptographic voter contributes one effective vote"
+        );
+        assert_eq!(tally.for_votes, 1, "the first act stands");
+    }
+
+    /// Counter-control: the guard must not have become "refuse everything".
+    #[tokio::test]
+    async fn distinct_voters_still_admitted_under_trust_threshold() {
+        let (mgr, domain_id, member_did) = make_manager_trust_threshold().await;
+        let proposal_id = make_open_proposal(&mgr, &domain_id, &member_did).await;
+        let other = icn_identity::KeyPair::generate().unwrap().did().clone();
+
+        mgr.cast_vote(proposal_id.clone(), member_did, VoteChoice::For, None)
+            .await
+            .expect("first voter must be admitted");
+        mgr.cast_vote(proposal_id.clone(), other, VoteChoice::For, None)
+            .await
+            .expect("a genuinely distinct voter must still be admitted");
+
+        let tally = mgr.get_vote_tally(&proposal_id).await.unwrap();
+        assert_eq!(tally.for_votes, 2, "two distinct principals, two votes");
+    }
+
+    /// Records the live boundary: under a static member list an alias spelling
+    /// is refused earlier, by the membership gate, because that list is still
+    /// compared by spelling. That comparison is deliberately left alone here --
+    /// re-keying membership is gated by IDENTITY_SEMANTICS.md §7.5 -- and its
+    /// effect is fail-closed, so #2641 is not reachable on this path either.
+    #[tokio::test]
+    async fn static_list_membership_refuses_alias_spelling_at_the_membership_gate() {
+        let (mgr, domain_id, member_did) = make_manager_with_domain().await;
+        let proposal_id = make_open_proposal(&mgr, &domain_id, &member_did).await;
+        let alias = alias_spelling(&member_did);
+
+        mgr.cast_vote(proposal_id.clone(), member_did, VoteChoice::For, None)
+            .await
+            .expect("first vote must succeed");
+
+        let err = mgr
+            .cast_vote(proposal_id.clone(), alias, VoteChoice::Against, None)
+            .await
+            .expect_err("re-spelled DID must not buy a second vote")
+            .to_string();
+        assert!(
+            err.contains("not a member") || err.contains("already voted"),
+            "must be refused, got: {err}"
+        );
+
+        let tally = mgr.get_vote_tally(&proposal_id).await.unwrap();
+        assert_eq!(tally.total_votes(), 1, "still exactly one effective vote");
+    }
+
     #[tokio::test]
     async fn test_inv6_duplicate_vote_rejected() {
         let (mgr, domain_id, member_did) = make_manager_with_domain().await;

--- a/icn/apps/governance/tests/signed_governance_emission.rs
+++ b/icn/apps/governance/tests/signed_governance_emission.rs
@@ -1193,3 +1193,117 @@ async fn close_fails_closed_on_conflicting_alias_rows_rather_than_counting_both(
     // The evidence survives for the §7.5-gated migration to resolve.
     assert_eq!(node.state.list_votes(&proposal_id).unwrap().len(), 2);
 }
+
+/// #2641, actor admission over legacy duplicates: this store overwrites by
+/// spelling-keyed row, so when a principal already owns several pre-fix rows the
+/// actor cannot supersede them all at once. Writing onto one and leaving the
+/// others would turn an agreeing, reducible duplicate into a conflicting pair
+/// and fail every later tally. It must refuse without mutating instead.
+#[tokio::test(flavor = "current_thread")]
+async fn vote_change_over_legacy_duplicate_rows_refuses_without_mutating() {
+    let node = Node::spawn(true).await;
+    let proposal_id = node
+        .seed_static_domain("alias-dup", ProposalScope::Local)
+        .await;
+
+    let bytes = node.did.identifier_bytes().expect("node DID must decode");
+    let alias = Did::from_str(&format!("did:icn:f{}", hex::encode(bytes)))
+        .expect("base16 multibase spelling must parse");
+    assert_ne!(node.did, alias, "control: the spellings must differ");
+
+    // Two *agreeing* rows for one principal, as a pre-#2641 binary left them.
+    for voter in [node.did.clone(), alias] {
+        node.state
+            .save_vote(
+                &proposal_id,
+                &Vote::new(proposal_id.clone(), voter, VoteChoice::For),
+            )
+            .expect("legacy row");
+    }
+
+    // Agreeing duplicates still reduce, so the proposal tallies correctly.
+    let before = node
+        .ops
+        .get_vote_tally(&proposal_id)
+        .await
+        .expect("agreeing duplicates must still tally");
+    assert_eq!(before.total_votes(), 1, "one principal, one effective vote");
+
+    let err = node
+        .ops
+        .cast_vote(
+            proposal_id.clone(),
+            node.did.clone(),
+            VoteChoice::Against,
+            None,
+        )
+        .await
+        .expect_err("must not write a change it cannot apply to every row");
+    assert!(
+        err.to_string().contains("different DID spellings"),
+        "must name the duplicate rows, got: {err}"
+    );
+
+    // Nothing was mutated, so the proposal is still tallyable.
+    let rows = node.state.list_votes(&proposal_id).unwrap();
+    assert_eq!(rows.len(), 2, "the refusal must not have written a row");
+    assert!(
+        rows.iter().all(|v| v.choice == VoteChoice::For),
+        "the refusal must not have changed an existing act"
+    );
+    let after = node
+        .ops
+        .get_vote_tally(&proposal_id)
+        .await
+        .expect("still tallyable after the refusal");
+    assert_eq!(after.total_votes(), 1, "still one effective vote");
+}
+
+/// #2641, filtered close: standing revalidation is still spelling-keyed, so a
+/// standing set naming one spelling of a conflicting pre-fix pair would drop the
+/// other and leave the reduction nothing to notice — finalising whichever act
+/// happened to be spelled the way the standing set names it. Conflicts must be
+/// detected across every stored row, before eligibility narrows the set.
+#[tokio::test(flavor = "current_thread")]
+async fn filtered_close_fails_closed_on_conflicts_the_standing_filter_would_hide() {
+    let node = Node::spawn(true).await;
+    let proposal_id = node
+        .seed_static_domain("alias-filtered", ProposalScope::Local)
+        .await;
+
+    let bytes = node.did.identifier_bytes().expect("node DID must decode");
+    let alias = Did::from_str(&format!("did:icn:f{}", hex::encode(bytes)))
+        .expect("base16 multibase spelling must parse");
+    assert_ne!(node.did, alias, "control: the spellings must differ");
+
+    node.state
+        .save_vote(
+            &proposal_id,
+            &Vote::new(proposal_id.clone(), node.did.clone(), VoteChoice::For),
+        )
+        .expect("legacy row");
+    node.state
+        .save_vote(
+            &proposal_id,
+            &Vote::new(proposal_id.clone(), alias, VoteChoice::Against),
+        )
+        .expect("legacy alias row");
+
+    // A standing set that recognises only the canonical spelling: the filter
+    // would keep the For row and silently discard the conflicting Against one.
+    let mut standing = std::collections::HashSet::new();
+    standing.insert(node.did.clone());
+
+    let err = node
+        .ops
+        .close_proposal_filtered(proposal_id.clone(), &standing)
+        .await
+        .expect_err("a conflict a spelling-keyed filter would hide must still fail closed");
+    assert!(
+        err.to_string().contains("conflicting"),
+        "must fail closed naming the conflict, got: {err}"
+    );
+
+    // Both acts survive for the §7.5-gated migration to resolve.
+    assert_eq!(node.state.list_votes(&proposal_id).unwrap().len(), 2);
+}

--- a/icn/apps/governance/tests/signed_governance_emission.rs
+++ b/icn/apps/governance/tests/signed_governance_emission.rs
@@ -1307,3 +1307,167 @@ async fn filtered_close_fails_closed_on_conflicts_the_standing_filter_would_hide
     // Both acts survive for the §7.5-gated migration to resolve.
     assert_eq!(node.state.list_votes(&proposal_id).unwrap().len(), 2);
 }
+
+/// #2641, quorum denominator: the tally numerator is reduced to one vote per
+/// cryptographic principal, so the electorate it is measured against must be
+/// counted the same way. A membership list naming one key under two spellings
+/// otherwise claims two electorate slots for one voter, and that voter voting
+/// reads as half turnout instead of full.
+#[tokio::test(flavor = "current_thread")]
+async fn quorum_denominator_counts_principals_not_did_spellings() {
+    let node = Node::spawn(true).await;
+    let domain_id = GovernanceDomainId("alias-quorum".to_string());
+
+    let bytes = node.did.identifier_bytes().expect("node DID must decode");
+    let alias = Did::from_str(&format!("did:icn:f{}", hex::encode(bytes)))
+        .expect("base16 multibase spelling must parse");
+    assert_ne!(node.did, alias, "control: the spellings must differ");
+
+    // One member, named twice. Quorum 100% makes the difference decisive:
+    // 1/1 of the electorate reaches it, 1/2 does not.
+    node.ops
+        .create_domain(
+            domain_id.clone(),
+            "Alias quorum".to_string(),
+            "cooperative_default".to_string(),
+            GovernanceParams::new(100, 50, 3600),
+            MembershipConfig::static_list(vec![node.did.clone(), alias]),
+        )
+        .await
+        .expect("create_domain");
+
+    let proposal_id = node
+        .ops
+        .create_proposal(
+            ProposalId("_ignored".to_string()),
+            domain_id.clone(),
+            node.did.clone(),
+            "Alias quorum".to_string(),
+            "Alias quorum".to_string(),
+            ProposalPayload::Text {
+                body: "alias".to_string(),
+            },
+            ProposalScope::Local,
+        )
+        .await
+        .expect("create_proposal");
+    node.ops
+        .open_proposal(proposal_id.clone(), 3600)
+        .await
+        .expect("open_proposal");
+
+    node.ops
+        .cast_vote(proposal_id.clone(), node.did.clone(), VoteChoice::For, None)
+        .await
+        .expect("cast_vote");
+
+    node.ops
+        .close_proposal(proposal_id.clone())
+        .await
+        .expect("close_proposal");
+
+    let closed = node
+        .ops
+        .get_proposal(&proposal_id)
+        .await
+        .expect("get_proposal")
+        .expect("proposal exists");
+
+    assert!(
+        matches!(closed.state, ProposalState::Accepted { .. }),
+        "the sole member voted, so turnout is 1/1 and the 100% quorum is met; \
+         NoQuorum means the denominator counted two spellings as two voters (got {:?})",
+        closed.state
+    );
+}
+
+/// #2641, competing delegations: where a membership list names one principal
+/// under several spellings and those spellings hold delegations to different
+/// voters, expanding whichever entry the resolver happens to list first would
+/// make list order the authority over a vote. Fail closed instead.
+#[tokio::test(flavor = "current_thread")]
+async fn competing_delegations_across_spellings_fail_closed_at_close() {
+    let node = Node::spawn(true).await;
+    let domain_id = GovernanceDomainId("alias-delegation-conflict".to_string());
+    let delegate_a = icn_identity::KeyPair::generate().unwrap().did().clone();
+    let delegate_b = icn_identity::KeyPair::generate().unwrap().did().clone();
+
+    let bytes = node.did.identifier_bytes().expect("node DID must decode");
+    let alias = Did::from_str(&format!("did:icn:f{}", hex::encode(bytes)))
+        .expect("base16 multibase spelling must parse");
+    assert_ne!(node.did, alias, "control: the spellings must differ");
+
+    node.ops
+        .create_domain(
+            domain_id.clone(),
+            "Alias delegation conflict".to_string(),
+            "cooperative_default".to_string(),
+            GovernanceParams::new(50, 50, 3600),
+            MembershipConfig::static_list(vec![
+                node.did.clone(),
+                alias.clone(),
+                delegate_a.clone(),
+                delegate_b.clone(),
+            ]),
+        )
+        .await
+        .expect("create_domain");
+
+    let proposal_id = node
+        .ops
+        .create_proposal(
+            ProposalId("_ignored".to_string()),
+            domain_id.clone(),
+            node.did.clone(),
+            "Alias delegation conflict".to_string(),
+            "Alias delegation conflict".to_string(),
+            ProposalPayload::Text {
+                body: "alias".to_string(),
+            },
+            ProposalScope::Local,
+        )
+        .await
+        .expect("create_proposal");
+    node.ops
+        .open_proposal(proposal_id.clone(), 3600)
+        .await
+        .expect("open_proposal");
+
+    // One key, two spellings, two different delegates.
+    node.ops
+        .create_delegation(Delegation::new(
+            node.did.clone(),
+            delegate_a.clone(),
+            DelegationScope::Blanket,
+        ))
+        .await
+        .expect("delegation from the canonical spelling");
+    node.ops
+        .create_delegation(Delegation::new(
+            alias,
+            delegate_b.clone(),
+            DelegationScope::Blanket,
+        ))
+        .await
+        .expect("delegation from the alias spelling");
+
+    // Both delegates vote, and they disagree.
+    node.ops
+        .cast_vote(proposal_id.clone(), delegate_a, VoteChoice::For, None)
+        .await
+        .expect("delegate a votes");
+    node.ops
+        .cast_vote(proposal_id.clone(), delegate_b, VoteChoice::Against, None)
+        .await
+        .expect("delegate b votes");
+
+    let err = node
+        .ops
+        .close_proposal(proposal_id.clone())
+        .await
+        .expect_err("membership-list order must not choose which delegated act counts");
+    assert!(
+        err.to_string().contains("competing delegations"),
+        "must name the competing delegations, got: {err}"
+    );
+}

--- a/icn/apps/governance/tests/signed_governance_emission.rs
+++ b/icn/apps/governance/tests/signed_governance_emission.rs
@@ -38,8 +38,9 @@ use std::sync::Arc;
 use icn_gossip::{GossipActor, GossipEntry};
 use icn_governance::replication::{GovernanceOpKind, SignedGovernanceOp, GOV_OP_MAGIC};
 use icn_governance::{
-    GovernanceDomainId, GovernanceMessage, GovernanceOps, GovernanceParams, MembershipConfig,
-    ProposalId, ProposalPayload, ProposalScope, Vote, VoteChoice,
+    Delegation, DelegationScope, GovernanceDomainId, GovernanceMessage, GovernanceOps,
+    GovernanceParams, MembershipConfig, ProposalId, ProposalPayload, ProposalScope, ProposalState,
+    Vote, VoteChoice,
 };
 use icn_governance_actor::init::{init_governance_actor, GovernanceActorDeps};
 use icn_governance_actor::manager::GovernanceManager;
@@ -1039,4 +1040,156 @@ async fn alias_spelled_did_cannot_add_a_second_vote_on_the_actor_path() {
         tally.against_votes, 1,
         "the voter's later act stands, as vote changes are allowed here"
     );
+}
+
+/// #2641, close path: `CloseProposal` builds the tally that actually decides the
+/// outcome, and `apply_delegation_to_tally` expands delegations into it. Both
+/// keyed voters by DID *spelling*, so a member could delegate from one spelling
+/// of their own key to another and then vote as the delegate: the delegator
+/// looked like a non-voter, the self-delegation did not look like
+/// self-delegation, and their single vote was resolved back to them as a second
+/// one — on a fresh deployment, with no legacy rows involved.
+///
+/// Three members and a 50% quorum make the laundering outcome-visible: two
+/// laundered For votes reach quorum and Accept, one honest vote does not.
+#[tokio::test(flavor = "current_thread")]
+async fn alias_self_delegation_cannot_launder_a_second_vote_at_close() {
+    let node = Node::spawn(true).await;
+    let domain_id = GovernanceDomainId("alias-delegation".to_string());
+    let other_a = icn_identity::KeyPair::generate().unwrap().did().clone();
+    let other_b = icn_identity::KeyPair::generate().unwrap().did().clone();
+
+    node.ops
+        .create_domain(
+            domain_id.clone(),
+            "Alias delegation".to_string(),
+            "cooperative_default".to_string(),
+            GovernanceParams::new(50, 50, 3600),
+            MembershipConfig::static_list(vec![node.did.clone(), other_a.clone(), other_b.clone()]),
+        )
+        .await
+        .expect("create_domain");
+
+    let proposal_id = node
+        .ops
+        .create_proposal(
+            ProposalId("_ignored".to_string()),
+            domain_id.clone(),
+            node.did.clone(),
+            "Alias delegation".to_string(),
+            "Alias delegation".to_string(),
+            ProposalPayload::Text {
+                body: "alias".to_string(),
+            },
+            ProposalScope::Local,
+        )
+        .await
+        .expect("create_proposal");
+    node.ops
+        .open_proposal(proposal_id.clone(), 3600)
+        .await
+        .expect("open_proposal");
+
+    let bytes = node.did.identifier_bytes().expect("node DID must decode");
+    let alias = Did::from_str(&format!("did:icn:f{}", hex::encode(bytes)))
+        .expect("base16 multibase spelling must parse");
+    assert_ne!(
+        node.did, alias,
+        "control: the two spellings must differ under current Did equality"
+    );
+
+    // Delegate from the canonical spelling to an alias of the very same key.
+    node.ops
+        .create_delegation(Delegation::new(
+            node.did.clone(),
+            alias.clone(),
+            DelegationScope::Blanket,
+        ))
+        .await
+        .expect("self-delegation across spellings is accepted today");
+
+    // Vote once, as the delegate spelling.
+    node.ops
+        .cast_vote(proposal_id.clone(), alias, VoteChoice::For, None)
+        .await
+        .expect("cast_vote");
+
+    node.ops
+        .close_proposal(proposal_id.clone())
+        .await
+        .expect("close_proposal");
+
+    let closed = node
+        .ops
+        .get_proposal(&proposal_id)
+        .await
+        .expect("get_proposal")
+        .expect("proposal exists");
+
+    assert!(
+        !matches!(closed.state, ProposalState::Accepted { .. }),
+        "one key produced one vote of three eligible members, which cannot reach a 50% \
+         quorum; Accepted means the delegation expansion counted it twice (got {:?})",
+        closed.state
+    );
+    assert!(
+        matches!(closed.state, ProposalState::NoQuorum { .. }),
+        "expected the honest single vote to fall short of quorum, got {:?}",
+        closed.state
+    );
+}
+
+/// #2641, close path: the tally that decides the outcome must fail closed on
+/// conflicting historical rows, not silently sum them. `get_vote_tally` refused
+/// such a pair while `CloseProposal` counted both, so the actor could report a
+/// tally that disagreed with the decision it committed to a receipt.
+///
+/// The rows are written the way a pre-fix binary wrote them — straight to the
+/// state store, keyed by spelling — since no post-fix path can create them.
+#[tokio::test(flavor = "current_thread")]
+async fn close_fails_closed_on_conflicting_alias_rows_rather_than_counting_both() {
+    let node = Node::spawn(true).await;
+    let proposal_id = node
+        .seed_static_domain("alias-close", ProposalScope::Local)
+        .await;
+
+    let bytes = node.did.identifier_bytes().expect("node DID must decode");
+    let alias = Did::from_str(&format!("did:icn:f{}", hex::encode(bytes)))
+        .expect("base16 multibase spelling must parse");
+    assert_ne!(
+        node.did, alias,
+        "control: the two spellings must differ under current Did equality"
+    );
+
+    // Two conflicting acts by one key, as a pre-#2641 binary would have left them.
+    node.state
+        .save_vote(
+            &proposal_id,
+            &Vote::new(proposal_id.clone(), node.did.clone(), VoteChoice::For),
+        )
+        .expect("legacy row");
+    node.state
+        .save_vote(
+            &proposal_id,
+            &Vote::new(proposal_id.clone(), alias, VoteChoice::Against),
+        )
+        .expect("legacy alias row");
+    assert_eq!(
+        node.state.list_votes(&proposal_id).unwrap().len(),
+        2,
+        "control: the legacy fixture must really contain two rows"
+    );
+
+    let err = node
+        .ops
+        .close_proposal(proposal_id.clone())
+        .await
+        .expect_err("closing must not resolve conflicting historical acts by summing them");
+    assert!(
+        err.to_string().contains("conflicting"),
+        "must fail closed naming the conflict, got: {err}"
+    );
+
+    // The evidence survives for the §7.5-gated migration to resolve.
+    assert_eq!(node.state.list_votes(&proposal_id).unwrap().len(), 2);
 }

--- a/icn/apps/governance/tests/signed_governance_emission.rs
+++ b/icn/apps/governance/tests/signed_governance_emission.rs
@@ -974,3 +974,69 @@ async fn a_compressed_signed_frame_is_still_recognised_by_magic() {
         other => panic!("expected VoteCast, got {}", other.message_type()),
     }
 }
+
+/// #2641, actor path: the production `CastVote` handler persists through
+/// `save_vote`, which overwrites by key, and that key is built from the voter's
+/// DID *spelling*. Re-spelling one key in another accepted multibase encoding
+/// therefore used to write a second row that every tally counted.
+///
+/// The actor still allows a voter to change their vote — that is this path's
+/// existing behaviour, exercised by
+/// `a_second_operation_in_one_domain_advances_its_sequence` — so the property
+/// asserted here is not refusal but that one cryptographic voter keeps exactly
+/// one row and one effective vote, whichever spelling arrives.
+#[tokio::test(flavor = "current_thread")]
+async fn alias_spelled_did_cannot_add_a_second_vote_on_the_actor_path() {
+    let node = Node::spawn(true).await;
+    let proposal_id = node
+        .seed_static_domain("seq-alias", ProposalScope::Local)
+        .await;
+
+    // Re-spell the node's DID as multibase base16 over the same identifier bytes.
+    let bytes = node.did.identifier_bytes().expect("node DID must decode");
+    let alias = Did::from_str(&format!("did:icn:f{}", hex::encode(bytes)))
+        .expect("base16 multibase spelling must parse");
+
+    // Control: this is a genuinely different textual DID today, so the test
+    // cannot pass vacuously. If `Did` becomes key-equal (N2-A / #2627) this
+    // assertion fails and the proof must be re-derived rather than assumed.
+    assert_ne!(
+        node.did, alias,
+        "control: the two spellings must differ under current Did equality"
+    );
+
+    node.ops
+        .cast_vote(proposal_id.clone(), node.did.clone(), VoteChoice::For, None)
+        .await
+        .expect("first vote must succeed");
+    node.ops
+        .cast_vote(proposal_id.clone(), alias, VoteChoice::Against, None)
+        .await
+        .expect("a re-spelled vote by the same principal updates, it does not stack");
+
+    let votes = node.state.list_votes(&proposal_id).expect("votes readable");
+    assert_eq!(
+        votes.len(),
+        1,
+        "one cryptographic voter must keep exactly one stored row, got: {:?}",
+        votes
+            .iter()
+            .map(|v| v.voter.to_string())
+            .collect::<Vec<_>>()
+    );
+
+    let tally = node
+        .ops
+        .get_vote_tally(&proposal_id)
+        .await
+        .expect("tally must compute");
+    assert_eq!(
+        tally.total_votes(),
+        1,
+        "one cryptographic voter contributes at most one effective vote"
+    );
+    assert_eq!(
+        tally.against_votes, 1,
+        "the voter's later act stands, as vote changes are allowed here"
+    );
+}

--- a/icn/crates/icn-governance/src/error.rs
+++ b/icn/crates/icn-governance/src/error.rs
@@ -32,6 +32,14 @@ pub enum GovernanceError {
     #[error("already voted on proposal: {0}")]
     AlreadyVoted(String),
 
+    /// Voter DID does not decode to a cryptographic principal
+    #[error("invalid voter: {0}")]
+    InvalidVoter(String),
+
+    /// One voting principal has conflicting stored acts on a proposal
+    #[error("conflicting vote records: {0}")]
+    ConflictingVoteRecords(String),
+
     /// Proposal not open for voting
     #[error("proposal not open for voting: {0}")]
     ProposalNotOpen(String),

--- a/icn/crates/icn-governance/src/error.rs
+++ b/icn/crates/icn-governance/src/error.rs
@@ -40,6 +40,10 @@ pub enum GovernanceError {
     #[error("conflicting vote records: {0}")]
     ConflictingVoteRecords(String),
 
+    /// One voting principal holds competing delegations under different DID spellings
+    #[error("competing delegations: {0}")]
+    CompetingDelegations(String),
+
     /// Proposal not open for voting
     #[error("proposal not open for voting: {0}")]
     ProposalNotOpen(String),

--- a/icn/crates/icn-governance/src/lib.rs
+++ b/icn/crates/icn-governance/src/lib.rs
@@ -178,7 +178,9 @@ pub use tally::{
     VoteTally,
 };
 pub use vote::{Vote, VoteChoice};
-pub use vote_principal::{effective_votes, ensure_has_not_voted, prior_act_for, VotingPrincipal};
+pub use vote_principal::{
+    acts_for, effective_votes, ensure_has_not_voted, prior_act_for, VotingPrincipal,
+};
 
 // Protocol governance types (Phase 20)
 pub use protocol::{

--- a/icn/crates/icn-governance/src/lib.rs
+++ b/icn/crates/icn-governance/src/lib.rs
@@ -179,7 +179,8 @@ pub use tally::{
 };
 pub use vote::{Vote, VoteChoice};
 pub use vote_principal::{
-    acts_for, effective_votes, ensure_has_not_voted, prior_act_for, VotingPrincipal,
+    acts_for, distinct_principals, effective_votes, ensure_has_not_voted, prior_act_for,
+    DelegationResolution, DelegationStep, VotingPrincipal,
 };
 
 // Protocol governance types (Phase 20)

--- a/icn/crates/icn-governance/src/lib.rs
+++ b/icn/crates/icn-governance/src/lib.rs
@@ -81,6 +81,7 @@ pub mod store;
 pub mod tally;
 pub mod verify;
 pub mod vote;
+pub mod vote_principal;
 
 // Action items for meeting/task tracking
 pub mod action_item;
@@ -177,6 +178,7 @@ pub use tally::{
     VoteTally,
 };
 pub use vote::{Vote, VoteChoice};
+pub use vote_principal::{effective_votes, ensure_has_not_voted, prior_act_for, VotingPrincipal};
 
 // Protocol governance types (Phase 20)
 pub use protocol::{

--- a/icn/crates/icn-governance/src/store.rs
+++ b/icn/crates/icn-governance/src/store.rs
@@ -650,6 +650,14 @@ impl GovernanceStore for SledGovernanceStore {
 
         // Drop any row this same principal previously wrote under a different
         // DID spelling, so one principal never retains more than one act.
+        //
+        // Removals, the replacement row and the rewritten index go in one
+        // `sled::Batch`: applied together or not at all. Doing them as separate
+        // operations would open a window where an interrupted write leaves the
+        // index naming a row that has already been deleted, losing a recorded
+        // vote — a write path that supersedes rows must not be able to destroy
+        // one and fail to replace it.
+        let mut batch = sled::Batch::default();
         let mut retained: Vec<String> = Vec::with_capacity(voter_dids.len() + 1);
         for spelling in voter_dids {
             if spelling == voter_str {
@@ -663,19 +671,18 @@ impl GovernanceStore for SledGovernanceStore {
                 Err(_) => None,
             };
             match alias {
-                Some(did) => {
-                    self.db.remove(Self::vote_key(&vote.proposal_id, &did))?;
-                }
+                Some(did) => batch.remove(Self::vote_key(&vote.proposal_id, &did)),
                 None => retained.push(spelling),
             }
         }
         retained.push(voter_str);
 
-        self.db.insert(
+        batch.insert(
             Self::vote_key(&vote.proposal_id, &vote.voter),
             serde_json::to_vec(vote)?,
-        )?;
-        self.db.insert(&index_key, serde_json::to_vec(&retained)?)?;
+        );
+        batch.insert(index_key, serde_json::to_vec(&retained)?);
+        self.db.apply_batch(batch)?;
 
         Ok(())
     }

--- a/icn/crates/icn-governance/src/store.rs
+++ b/icn/crates/icn-governance/src/store.rs
@@ -672,7 +672,7 @@ impl GovernanceStore for SledGovernanceStore {
         retained.push(voter_str);
 
         self.db.insert(
-            &Self::vote_key(&vote.proposal_id, &vote.voter),
+            Self::vote_key(&vote.proposal_id, &vote.voter),
             serde_json::to_vec(vote)?,
         )?;
         self.db.insert(&index_key, serde_json::to_vec(&retained)?)?;
@@ -1373,6 +1373,69 @@ mod did_spelling_vote_integrity {
             msg.contains("conflicting"),
             "fail-closed error must name the conflict, got: {msg}"
         );
+    }
+
+    #[test]
+    fn lookup_finds_the_row_under_any_spelling_of_the_voter() {
+        let store = InMemoryGovernanceStore::new();
+        let (db, _tmp) = open_test_sled_db();
+        let sled_store = SledGovernanceStore::new(db);
+        let proposal_id = ProposalId::generate();
+        let kp = KeyPair::generate().unwrap();
+        let canonical = kp.did().clone();
+        let alias = alias_spelling(&canonical);
+
+        for target in [
+            &store as &dyn GovernanceStore,
+            &sled_store as &dyn GovernanceStore,
+        ] {
+            target
+                .store_vote(&Vote::new(
+                    proposal_id.clone(),
+                    canonical.clone(),
+                    VoteChoice::For,
+                ))
+                .unwrap();
+
+            let found = target
+                .get_vote(&proposal_id, &alias)
+                .unwrap()
+                .expect("an alias spelling must resolve to the same voter's row");
+            assert_eq!(found.choice, VoteChoice::For);
+        }
+    }
+
+    /// Admission must not paper over an integrity breach that already happened:
+    /// superseding two conflicting historical acts would destroy the evidence
+    /// and silently pick a winner.
+    #[test]
+    fn storing_over_conflicting_historical_alias_rows_fails_closed() {
+        let store = InMemoryGovernanceStore::new();
+        let proposal_id = ProposalId::generate();
+        let kp = KeyPair::generate().unwrap();
+        let canonical = kp.did().clone();
+        let alias = alias_spelling(&canonical);
+
+        insert_legacy_row_mem(
+            &store,
+            &Vote::new(proposal_id.clone(), canonical.clone(), VoteChoice::For),
+        );
+        insert_legacy_row_mem(
+            &store,
+            &Vote::new(proposal_id.clone(), alias, VoteChoice::Against),
+        );
+
+        let err = store
+            .store_vote(&Vote::new(
+                proposal_id.clone(),
+                canonical,
+                VoteChoice::Abstain,
+            ))
+            .expect_err("must not silently supersede conflicting historical acts");
+        assert!(err.to_string().contains("conflicting"), "got: {err}");
+
+        // The evidence is still there to be migrated.
+        assert_eq!(store.list_votes(&proposal_id).unwrap().len(), 2);
     }
 
     /// Counter-control: the fix must not be "refuse everything".

--- a/icn/crates/icn-governance/src/store.rs
+++ b/icn/crates/icn-governance/src/store.rs
@@ -6,6 +6,7 @@
 //! Poisoned locks indicate a prior panic and possibly corrupt state.
 //! Silent recovery would risk data integrity issues.
 
+use crate::vote_principal::{prior_act_for, VotingPrincipal};
 use crate::{
     Delegation, DelegationId, DelegationScope, GovernanceDomain, GovernanceDomainId, Proposal,
     ProposalId, Timestamp, Vote, VoteTally,
@@ -270,9 +271,23 @@ impl GovernanceStore for InMemoryGovernanceStore {
         })?;
         let proposal_votes = votes.entry(vote.proposal_id.0.clone()).or_default();
 
-        // Replace existing vote from same voter (allow vote changes)
-        proposal_votes.retain(|v| v.voter != vote.voter);
-        proposal_votes.push(vote.clone());
+        // A voter is a cryptographic principal, not a DID spelling (#2641).
+        // Fail closed if this principal already has conflicting stored acts:
+        // superseding them would destroy the evidence of a duplicate-vote
+        // breach and silently pick a winner.
+        prior_act_for(proposal_votes, &vote.voter)?;
+
+        // Replace any existing vote from the same principal (allow vote
+        // changes), including rows written under a different DID spelling.
+        let principal = VotingPrincipal::of(&vote.voter)?;
+        let mut kept = Vec::with_capacity(proposal_votes.len() + 1);
+        for existing in proposal_votes.iter() {
+            if VotingPrincipal::of(&existing.voter)? != principal {
+                kept.push(existing.clone());
+            }
+        }
+        kept.push(vote.clone());
+        *proposal_votes = kept;
 
         Ok(())
     }
@@ -282,9 +297,12 @@ impl GovernanceStore for InMemoryGovernanceStore {
             error!("Votes lock poisoned in get_vote: {e}");
             anyhow::anyhow!("Lock poisoned in get_vote - store may contain corrupt state")
         })?;
-        Ok(votes
-            .get(&proposal_id.0)
-            .and_then(|v| v.iter().find(|vote| vote.voter == *voter).cloned()))
+        // Look up by cryptographic principal so any accepted spelling of the
+        // voter's DID finds the row (#2641).
+        match votes.get(&proposal_id.0) {
+            Some(rows) => Ok(prior_act_for(rows, voter)?.cloned()),
+            None => Ok(None),
+        }
     }
 
     fn list_votes(&self, proposal_id: &ProposalId) -> Result<Vec<Vote>> {
@@ -297,7 +315,10 @@ impl GovernanceStore for InMemoryGovernanceStore {
 
     fn compute_tally(&self, proposal_id: &ProposalId) -> Result<VoteTally> {
         let votes = self.list_votes(proposal_id)?;
-        Ok(VoteTally::from(votes))
+        // One cryptographic voter contributes at most one effective vote,
+        // whatever spelling named it; conflicting historical rows fail
+        // closed rather than being resolved by storage order (#2641).
+        Ok(VoteTally::try_from_votes(&votes)?)
     }
 
     // === Delegation Methods ===
@@ -400,6 +421,18 @@ impl SledGovernanceStore {
     /// Create a new Sled-based governance store
     pub fn new(db: sled::Db) -> Self {
         Self { db }
+    }
+
+    /// Read the row stored under exactly this DID spelling.
+    ///
+    /// Spelling-exact by design: it is the raw row accessor `list_votes` walks
+    /// the index with. Principal-level resolution belongs to `get_vote`.
+    fn read_vote_row(&self, proposal_id: &ProposalId, voter: &Did) -> Result<Option<Vote>> {
+        let key = Self::vote_key(proposal_id, voter);
+        match self.db.get(&key)? {
+            Some(data) => Ok(Some(serde_json::from_slice(&data)?)),
+            None => Ok(None),
+        }
     }
 
     fn domain_key(id: &GovernanceDomainId) -> Vec<u8> {
@@ -597,34 +630,61 @@ impl GovernanceStore for SledGovernanceStore {
     }
 
     fn store_vote(&self, vote: &Vote) -> Result<()> {
-        let key = Self::vote_key(&vote.proposal_id, &vote.voter);
-        let value = serde_json::to_vec(vote)?;
-        self.db.insert(&key, value)?;
+        // A voter is a cryptographic principal, not a DID spelling (#2641).
+        let principal = VotingPrincipal::of(&vote.voter)?;
 
-        // Update index
+        // Fail closed if this principal already has conflicting stored acts:
+        // superseding them would destroy the evidence of a duplicate-vote
+        // breach and silently pick which historical act won.
+        let existing = self.list_votes(&vote.proposal_id)?;
+        prior_act_for(&existing, &vote.voter)?;
+
         let index_key = Self::vote_index_key(&vote.proposal_id);
-        let mut voter_dids: Vec<String> = self
+        let voter_dids: Vec<String> = self
             .db
             .get(&index_key)?
             .map(|v| serde_json::from_slice(&v).unwrap_or_default())
             .unwrap_or_default();
 
         let voter_str = vote.voter.to_string();
-        if !voter_dids.contains(&voter_str) {
-            voter_dids.push(voter_str);
-            self.db
-                .insert(&index_key, serde_json::to_vec(&voter_dids)?)?;
+
+        // Drop any row this same principal previously wrote under a different
+        // DID spelling, so one principal never retains more than one act.
+        let mut retained: Vec<String> = Vec::with_capacity(voter_dids.len() + 1);
+        for spelling in voter_dids {
+            if spelling == voter_str {
+                continue; // re-added below, keeping index entries unique
+            }
+            let alias = match spelling.parse::<Did>() {
+                Ok(did) => match VotingPrincipal::of(&did) {
+                    Ok(other) if other == principal => Some(did),
+                    _ => None,
+                },
+                Err(_) => None,
+            };
+            match alias {
+                Some(did) => {
+                    self.db.remove(Self::vote_key(&vote.proposal_id, &did))?;
+                }
+                None => retained.push(spelling),
+            }
         }
+        retained.push(voter_str);
+
+        self.db.insert(
+            &Self::vote_key(&vote.proposal_id, &vote.voter),
+            serde_json::to_vec(vote)?,
+        )?;
+        self.db.insert(&index_key, serde_json::to_vec(&retained)?)?;
 
         Ok(())
     }
 
     fn get_vote(&self, proposal_id: &ProposalId, voter: &Did) -> Result<Option<Vote>> {
-        let key = Self::vote_key(proposal_id, voter);
-        match self.db.get(&key)? {
-            Some(data) => Ok(Some(serde_json::from_slice(&data)?)),
-            None => Ok(None),
-        }
+        // Look up by cryptographic principal so any accepted spelling of the
+        // voter's DID finds the row, and conflicting rows fail closed (#2641).
+        let votes = self.list_votes(proposal_id)?;
+        Ok(prior_act_for(&votes, voter)?.cloned())
     }
 
     fn list_votes(&self, proposal_id: &ProposalId) -> Result<Vec<Vote>> {
@@ -637,8 +697,8 @@ impl GovernanceStore for SledGovernanceStore {
 
         let mut votes = Vec::new();
         for voter_str in voter_dids {
-            if let Ok(voter_did) = voter_str.parse() {
-                if let Some(vote) = self.get_vote(proposal_id, &voter_did)? {
+            if let Ok(voter_did) = voter_str.parse::<Did>() {
+                if let Some(vote) = self.read_vote_row(proposal_id, &voter_did)? {
                     votes.push(vote);
                 }
             }
@@ -649,7 +709,10 @@ impl GovernanceStore for SledGovernanceStore {
 
     fn compute_tally(&self, proposal_id: &ProposalId) -> Result<VoteTally> {
         let votes = self.list_votes(proposal_id)?;
-        Ok(VoteTally::from(votes))
+        // One cryptographic voter contributes at most one effective vote,
+        // whatever spelling named it; conflicting historical rows fail
+        // closed rather than being resolved by storage order (#2641).
+        Ok(VoteTally::try_from_votes(&votes)?)
     }
 
     // === Delegation Methods ===

--- a/icn/crates/icn-governance/src/store.rs
+++ b/icn/crates/icn-governance/src/store.rs
@@ -1061,3 +1061,314 @@ mod tests {
         );
     }
 }
+
+#[cfg(test)]
+mod did_spelling_vote_integrity {
+    //! Adversarial proof for #2641.
+    //!
+    //! `Did::from_str` accepts any multibase encoding of a 32-byte Ed25519 key and
+    //! retains the submitted spelling, while `Did` equality/hashing is string
+    //! equality. Vote storage and tallying must nevertheless treat one decoded
+    //! cryptographic principal as one voter.
+
+    use super::*;
+    use crate::VoteChoice;
+    use icn_identity::KeyPair;
+
+    /// Re-spell `did` as multibase base16 (`f` prefix) of the same public key.
+    fn alias_spelling(did: &Did) -> Did {
+        let key = did.to_verifying_key().expect("test DID must decode");
+        let alt = format!("did:icn:f{}", hex::encode(key.as_bytes()));
+        Did::from_str(&alt).expect("base16 multibase spelling must parse")
+    }
+
+    fn open_test_sled_db() -> (sled::Db, tempfile::TempDir) {
+        let base = std::env::var_os("ICN_TEST_TMPDIR")
+            .or_else(|| std::env::var_os("TMPDIR"))
+            .map(std::path::PathBuf::from)
+            .unwrap_or_else(|| std::path::PathBuf::from("/tmp"));
+        let tempdir = tempfile::Builder::new()
+            .prefix("icn-governance-vote-spelling-")
+            .tempdir_in(base)
+            .expect("temp db directory");
+        let db = sled::Config::new()
+            .path(tempdir.path().join("sled"))
+            .temporary(true)
+            .open()
+            .expect("temp db");
+        (db, tempdir)
+    }
+
+    /// Write a vote the way a pre-#2641 binary did: keyed purely by spelling,
+    /// with no principal-level de-duplication. Used to synthesise historical rows.
+    fn insert_legacy_row_mem(store: &InMemoryGovernanceStore, vote: &Vote) {
+        let mut votes = store.votes.write().expect("votes lock");
+        votes
+            .entry(vote.proposal_id.0.clone())
+            .or_default()
+            .push(vote.clone());
+    }
+
+    fn insert_legacy_row_sled(store: &SledGovernanceStore, vote: &Vote) {
+        let key = SledGovernanceStore::vote_key(&vote.proposal_id, &vote.voter);
+        store
+            .db
+            .insert(&key, serde_json::to_vec(vote).expect("serialize vote"))
+            .expect("insert vote row");
+        let index_key = SledGovernanceStore::vote_index_key(&vote.proposal_id);
+        let mut voter_dids: Vec<String> = store
+            .db
+            .get(&index_key)
+            .expect("read index")
+            .map(|v| serde_json::from_slice(&v).unwrap_or_default())
+            .unwrap_or_default();
+        let spelling = vote.voter.to_string();
+        if !voter_dids.contains(&spelling) {
+            voter_dids.push(spelling);
+        }
+        store
+            .db
+            .insert(
+                &index_key,
+                serde_json::to_vec(&voter_dids).expect("serialize index"),
+            )
+            .expect("insert index");
+    }
+
+    /// Anti-vacuity control. If this ever fails, `Did` gained key equality
+    /// (N2-A / #2627) and every proof below must be re-derived rather than
+    /// assumed still adversarial.
+    #[test]
+    fn control_alias_spellings_are_distinct_dids_over_one_key() {
+        let kp = KeyPair::generate().unwrap();
+        let canonical = kp.did().clone();
+        let alias = alias_spelling(&canonical);
+
+        assert_ne!(
+            canonical.as_str(),
+            alias.as_str(),
+            "control requires two different textual spellings"
+        );
+        assert_eq!(
+            canonical.to_verifying_key().unwrap().as_bytes(),
+            alias.to_verifying_key().unwrap().as_bytes(),
+            "control requires both spellings to decode to one key"
+        );
+        assert_ne!(
+            canonical, alias,
+            "control requires the spellings to be distinct under today's Did equality; \
+             if this fails, Did is already key-equal and #2641's premise changed"
+        );
+    }
+
+    #[test]
+    fn in_memory_alias_spelled_second_vote_does_not_add_voting_weight() {
+        let store = InMemoryGovernanceStore::new();
+        let proposal_id = ProposalId::generate();
+        let kp = KeyPair::generate().unwrap();
+        let canonical = kp.did().clone();
+        let alias = alias_spelling(&canonical);
+
+        store
+            .store_vote(&Vote::new(proposal_id.clone(), canonical, VoteChoice::For))
+            .unwrap();
+        store
+            .store_vote(&Vote::new(proposal_id.clone(), alias, VoteChoice::For))
+            .unwrap();
+
+        let tally = store.compute_tally(&proposal_id).unwrap();
+        assert_eq!(
+            tally.total_votes(),
+            1,
+            "one cryptographic voter must contribute at most one effective vote"
+        );
+    }
+
+    #[test]
+    fn sled_alias_spelled_second_vote_does_not_add_voting_weight() {
+        let (db, _tmp) = open_test_sled_db();
+        let store = SledGovernanceStore::new(db);
+        let proposal_id = ProposalId::generate();
+        let kp = KeyPair::generate().unwrap();
+        let canonical = kp.did().clone();
+        let alias = alias_spelling(&canonical);
+
+        store
+            .store_vote(&Vote::new(proposal_id.clone(), canonical, VoteChoice::For))
+            .unwrap();
+        store
+            .store_vote(&Vote::new(proposal_id.clone(), alias, VoteChoice::For))
+            .unwrap();
+
+        let tally = store.compute_tally(&proposal_id).unwrap();
+        assert_eq!(
+            tally.total_votes(),
+            1,
+            "one cryptographic voter must contribute at most one effective vote"
+        );
+    }
+
+    #[test]
+    fn in_memory_agreeing_historical_alias_rows_do_not_double_count() {
+        let store = InMemoryGovernanceStore::new();
+        let proposal_id = ProposalId::generate();
+        let kp = KeyPair::generate().unwrap();
+        let canonical = kp.did().clone();
+        let alias = alias_spelling(&canonical);
+
+        insert_legacy_row_mem(
+            &store,
+            &Vote::new(proposal_id.clone(), canonical, VoteChoice::For),
+        );
+        insert_legacy_row_mem(
+            &store,
+            &Vote::new(proposal_id.clone(), alias, VoteChoice::For),
+        );
+
+        let tally = store.compute_tally(&proposal_id).unwrap();
+        assert_eq!(
+            tally.for_votes, 1,
+            "agreeing historical alias rows collapse to one effective vote"
+        );
+    }
+
+    #[test]
+    fn in_memory_conflicting_historical_alias_rows_fail_closed() {
+        let store = InMemoryGovernanceStore::new();
+        let proposal_id = ProposalId::generate();
+        let kp = KeyPair::generate().unwrap();
+        let canonical = kp.did().clone();
+        let alias = alias_spelling(&canonical);
+
+        insert_legacy_row_mem(
+            &store,
+            &Vote::new(proposal_id.clone(), canonical, VoteChoice::For),
+        );
+        insert_legacy_row_mem(
+            &store,
+            &Vote::new(proposal_id.clone(), alias, VoteChoice::Against),
+        );
+
+        let err = store
+            .compute_tally(&proposal_id)
+            .expect_err("conflicting historical acts must not be silently resolved");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("conflicting"),
+            "fail-closed error must name the conflict, got: {msg}"
+        );
+    }
+
+    #[test]
+    fn sled_agreeing_historical_alias_rows_do_not_double_count() {
+        let (db, _tmp) = open_test_sled_db();
+        let store = SledGovernanceStore::new(db);
+        let proposal_id = ProposalId::generate();
+        let kp = KeyPair::generate().unwrap();
+        let canonical = kp.did().clone();
+        let alias = alias_spelling(&canonical);
+
+        insert_legacy_row_sled(
+            &store,
+            &Vote::new(proposal_id.clone(), canonical, VoteChoice::For),
+        );
+        insert_legacy_row_sled(
+            &store,
+            &Vote::new(proposal_id.clone(), alias, VoteChoice::For),
+        );
+
+        let tally = store.compute_tally(&proposal_id).unwrap();
+        assert_eq!(
+            tally.for_votes, 1,
+            "agreeing historical alias rows collapse to one effective vote"
+        );
+    }
+
+    #[test]
+    fn sled_conflicting_historical_alias_rows_fail_closed() {
+        let (db, _tmp) = open_test_sled_db();
+        let store = SledGovernanceStore::new(db);
+        let proposal_id = ProposalId::generate();
+        let kp = KeyPair::generate().unwrap();
+        let canonical = kp.did().clone();
+        let alias = alias_spelling(&canonical);
+
+        insert_legacy_row_sled(
+            &store,
+            &Vote::new(proposal_id.clone(), canonical, VoteChoice::For),
+        );
+        insert_legacy_row_sled(
+            &store,
+            &Vote::new(proposal_id.clone(), alias, VoteChoice::Against),
+        );
+
+        let err = store
+            .compute_tally(&proposal_id)
+            .expect_err("conflicting historical acts must not be silently resolved");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("conflicting"),
+            "fail-closed error must name the conflict, got: {msg}"
+        );
+    }
+
+    /// Counter-control: the fix must not be "refuse everything".
+    #[test]
+    fn distinct_principals_still_each_contribute_one_vote() {
+        let store = InMemoryGovernanceStore::new();
+        let (db, _tmp) = open_test_sled_db();
+        let sled_store = SledGovernanceStore::new(db);
+        let proposal_id = ProposalId::generate();
+        let kp1 = KeyPair::generate().unwrap();
+        let kp2 = KeyPair::generate().unwrap();
+
+        for target in [
+            &store as &dyn GovernanceStore,
+            &sled_store as &dyn GovernanceStore,
+        ] {
+            target
+                .store_vote(&Vote::new(
+                    proposal_id.clone(),
+                    kp1.did().clone(),
+                    VoteChoice::For,
+                ))
+                .unwrap();
+            target
+                .store_vote(&Vote::new(
+                    proposal_id.clone(),
+                    kp2.did().clone(),
+                    VoteChoice::Against,
+                ))
+                .unwrap();
+
+            let tally = target.compute_tally(&proposal_id).unwrap();
+            assert_eq!(tally.for_votes, 1, "distinct principals must still count");
+            assert_eq!(
+                tally.against_votes, 1,
+                "distinct principals must still count"
+            );
+        }
+    }
+
+    /// Counter-control: the existing store-layer "allow vote changes" contract
+    /// (`test_vote_replacement`) must survive, including across spellings.
+    #[test]
+    fn alias_spelled_revote_replaces_rather_than_accumulating() {
+        let store = InMemoryGovernanceStore::new();
+        let proposal_id = ProposalId::generate();
+        let kp = KeyPair::generate().unwrap();
+        let canonical = kp.did().clone();
+        let alias = alias_spelling(&canonical);
+
+        store
+            .store_vote(&Vote::new(proposal_id.clone(), canonical, VoteChoice::For))
+            .unwrap();
+        store
+            .store_vote(&Vote::new(proposal_id.clone(), alias, VoteChoice::Against))
+            .unwrap();
+
+        let votes = store.list_votes(&proposal_id).unwrap();
+        assert_eq!(votes.len(), 1, "one principal keeps exactly one stored row");
+        assert_eq!(votes[0].choice, VoteChoice::Against, "later act supersedes");
+    }
+}

--- a/icn/crates/icn-governance/src/tally.rs
+++ b/icn/crates/icn-governance/src/tally.rs
@@ -2,8 +2,10 @@
 
 use crate::delegation::DelegationManager;
 use crate::domain::GovernanceDomainId;
+use crate::error::GovernanceError;
 use crate::proposal::ProposalId;
 use crate::vote::{Vote, VoteChoice};
+use crate::vote_principal::{effective_votes, VotingPrincipal};
 use icn_identity::Did;
 use serde::{Deserialize, Serialize};
 use std::collections::{HashMap, HashSet};
@@ -70,6 +72,13 @@ impl VoteTally {
     }
 }
 
+/// Raw summation of vote rows, one row at a time.
+///
+/// This counts **every** row it is given and therefore carries no protection
+/// against one cryptographic voter appearing under several DID spellings.
+/// Production tallies must use [`VoteTally::try_from_votes`], which reduces
+/// rows to one effective vote per principal and fails closed on conflicting
+/// stored acts (#2641).
 impl From<Vec<Vote>> for VoteTally {
     fn from(votes: Vec<Vote>) -> Self {
         let mut tally = VoteTally::empty();
@@ -77,6 +86,21 @@ impl From<Vec<Vote>> for VoteTally {
             tally.add_vote(&vote);
         }
         tally
+    }
+}
+
+impl VoteTally {
+    /// Tally `votes` giving each cryptographic voting principal at most one
+    /// effective vote, whatever multibase spelling of its DID named it.
+    ///
+    /// Fails closed if one principal has conflicting stored acts, rather than
+    /// choosing which historical act wins (see [`effective_votes`]).
+    pub fn try_from_votes(votes: &[Vote]) -> Result<Self, GovernanceError> {
+        let mut tally = VoteTally::empty();
+        for vote in effective_votes(votes)? {
+            tally.add_vote(vote);
+        }
+        Ok(tally)
     }
 }
 
@@ -103,44 +127,55 @@ pub fn compute_tally_with_delegations(
     delegation_manager: &DelegationManager,
     domain_id: &GovernanceDomainId,
     proposal_id: &ProposalId,
-) -> VoteTally {
-    // Build a map of voter -> vote for quick lookup
-    let vote_map: HashMap<&Did, &Vote> = votes.iter().map(|v| (&v.voter, v)).collect();
+) -> Result<VoteTally, GovernanceError> {
+    // Reduce stored rows to one effective act per cryptographic principal, so a
+    // re-spelled DID cannot vote twice or be delegated to twice (#2641).
+    let direct = effective_votes(votes)?;
 
-    // Track who has already been counted to avoid double-counting
-    let mut counted: HashSet<&Did> = HashSet::new();
+    // Build a map of principal -> vote for quick lookup
+    let mut vote_map: HashMap<VotingPrincipal, &Vote> = HashMap::new();
+    for &vote in &direct {
+        vote_map.insert(VotingPrincipal::of(&vote.voter)?, vote);
+    }
+
+    // Track which principals have already been counted to avoid double-counting
+    let mut counted: HashSet<VotingPrincipal> = HashSet::new();
     let mut tally = VoteTally::empty();
 
     // First pass: count direct votes
-    for vote in votes {
+    for &vote in &direct {
         tally.add_vote(vote);
-        counted.insert(&vote.voter);
+        counted.insert(VotingPrincipal::of(&vote.voter)?);
     }
 
     // Second pass: resolve delegated votes for non-voters
     for voter in eligible_voters {
-        if counted.contains(voter) {
+        let voter_principal = VotingPrincipal::of(voter)?;
+        if counted.contains(&voter_principal) {
             continue; // Already voted directly
         }
 
         // Resolve the delegation chain
         let delegate = delegation_manager.resolve_delegate(voter, domain_id, proposal_id);
+        let delegate_principal = VotingPrincipal::of(&delegate)?;
 
-        // If the delegate is not the same as the voter (i.e., delegation exists)
-        // and the delegate voted, count the vote for the delegator
-        if delegate != *voter {
-            if let Some(delegate_vote) = vote_map.get(&delegate) {
+        // If the delegate is not the same principal as the voter (i.e., a
+        // delegation exists) and the delegate voted, count the vote for the
+        // delegator. Comparing principals stops a self-delegation from being
+        // laundered into a second vote by re-spelling the delegate DID.
+        if delegate_principal != voter_principal {
+            if let Some(delegate_vote) = vote_map.get(&delegate_principal) {
                 // Create a vote for the delegator based on the delegate's choice and weight
                 let delegated_vote =
                     Vote::new(proposal_id.clone(), voter.clone(), delegate_vote.choice)
                         .with_weight(delegate_vote.weight);
                 tally.add_vote(&delegated_vote);
-                counted.insert(voter);
+                counted.insert(voter_principal);
             }
         }
     }
 
-    tally
+    Ok(tally)
 }
 
 /// Result of computing a tally with delegation details
@@ -161,45 +196,53 @@ pub fn compute_detailed_tally_with_delegations(
     delegation_manager: &DelegationManager,
     domain_id: &GovernanceDomainId,
     proposal_id: &ProposalId,
-) -> DelegatedTallyResult {
-    let vote_map: HashMap<&Did, &Vote> = votes.iter().map(|v| (&v.voter, v)).collect();
-    let mut counted: HashSet<&Did> = HashSet::new();
+) -> Result<DelegatedTallyResult, GovernanceError> {
+    // One effective act per cryptographic principal (#2641).
+    let direct = effective_votes(votes)?;
+
+    let mut vote_map: HashMap<VotingPrincipal, &Vote> = HashMap::new();
+    for &vote in &direct {
+        vote_map.insert(VotingPrincipal::of(&vote.voter)?, vote);
+    }
+    let mut counted: HashSet<VotingPrincipal> = HashSet::new();
     let mut tally = VoteTally::empty();
     let mut delegated_count = 0;
-    let direct_count = votes.len();
+    let direct_count = direct.len();
 
     // Count direct votes
-    for vote in votes {
+    for &vote in &direct {
         tally.add_vote(vote);
-        counted.insert(&vote.voter);
+        counted.insert(VotingPrincipal::of(&vote.voter)?);
     }
 
     // Resolve delegated votes
     for voter in eligible_voters {
-        if counted.contains(voter) {
+        let voter_principal = VotingPrincipal::of(voter)?;
+        if counted.contains(&voter_principal) {
             continue;
         }
 
         let delegate = delegation_manager.resolve_delegate(voter, domain_id, proposal_id);
+        let delegate_principal = VotingPrincipal::of(&delegate)?;
 
-        if delegate != *voter {
-            if let Some(delegate_vote) = vote_map.get(&delegate) {
+        if delegate_principal != voter_principal {
+            if let Some(delegate_vote) = vote_map.get(&delegate_principal) {
                 // Preserve the delegate's vote weight
                 let delegated_vote =
                     Vote::new(proposal_id.clone(), voter.clone(), delegate_vote.choice)
                         .with_weight(delegate_vote.weight);
                 tally.add_vote(&delegated_vote);
-                counted.insert(voter);
+                counted.insert(voter_principal);
                 delegated_count += 1;
             }
         }
     }
 
-    DelegatedTallyResult {
+    Ok(DelegatedTallyResult {
         tally,
         delegated_vote_count: delegated_count,
         direct_vote_count: direct_count,
-    }
+    })
 }
 
 #[cfg(test)]
@@ -322,7 +365,8 @@ mod tests {
         let eligible = vec![alice.clone(), bob.clone()];
 
         let tally =
-            compute_tally_with_delegations(&votes, &eligible, &manager, &domain_id, &proposal_id);
+            compute_tally_with_delegations(&votes, &eligible, &manager, &domain_id, &proposal_id)
+                .expect("distinct principals must tally without conflict");
 
         // Should count 2 votes: Bob's direct + Alice's delegated
         assert_eq!(tally.for_votes, 2);
@@ -356,7 +400,8 @@ mod tests {
         let eligible = vec![alice.clone(), bob.clone()];
 
         let tally =
-            compute_tally_with_delegations(&votes, &eligible, &manager, &domain_id, &proposal_id);
+            compute_tally_with_delegations(&votes, &eligible, &manager, &domain_id, &proposal_id)
+                .expect("distinct principals must tally without conflict");
 
         // Alice's direct vote should win (Against), Bob votes For
         assert_eq!(tally.for_votes, 1);
@@ -400,7 +445,8 @@ mod tests {
         let eligible = vec![alice.clone(), bob.clone(), charlie.clone()];
 
         let tally =
-            compute_tally_with_delegations(&votes, &eligible, &manager, &domain_id, &proposal_id);
+            compute_tally_with_delegations(&votes, &eligible, &manager, &domain_id, &proposal_id)
+                .expect("distinct principals must tally without conflict");
 
         // Should count 3 votes: Charlie direct, Bob delegated, Alice delegated
         assert_eq!(tally.for_votes, 3);
@@ -436,7 +482,8 @@ mod tests {
         let eligible = vec![alice.clone(), bob.clone(), charlie.clone()];
 
         let tally =
-            compute_tally_with_delegations(&votes, &eligible, &manager, &domain_id, &proposal_id);
+            compute_tally_with_delegations(&votes, &eligible, &manager, &domain_id, &proposal_id)
+                .expect("distinct principals must tally without conflict");
 
         // Only Charlie's vote counts; Alice's delegation goes to Bob who didn't vote
         assert_eq!(tally.for_votes, 1);
@@ -480,7 +527,8 @@ mod tests {
             &manager,
             &domain_id,
             &proposal_id,
-        );
+        )
+        .expect("distinct principals must tally without conflict");
 
         assert_eq!(result.direct_vote_count, 1);
         assert_eq!(result.delegated_vote_count, 2);

--- a/icn/crates/icn-governance/src/tally.rs
+++ b/icn/crates/icn-governance/src/tally.rs
@@ -5,7 +5,9 @@ use crate::domain::GovernanceDomainId;
 use crate::error::GovernanceError;
 use crate::proposal::ProposalId;
 use crate::vote::{Vote, VoteChoice};
-use crate::vote_principal::{effective_votes, VotingPrincipal};
+use crate::vote_principal::{
+    effective_votes, DelegationResolution, DelegationStep, VotingPrincipal,
+};
 use icn_identity::Did;
 use serde::{Deserialize, Serialize};
 use std::collections::{HashMap, HashSet};
@@ -138,8 +140,12 @@ pub fn compute_tally_with_delegations(
         vote_map.insert(VotingPrincipal::of(&vote.voter)?, vote);
     }
 
-    // Track which principals have already been counted to avoid double-counting
+    // Principals that voted *directly*. Delegation de-duplication belongs to
+    // `resolution`, not here: marking a delegator counted would short-circuit
+    // the next spelling of that principal before its delegate could be
+    // compared, and a disagreement would pass unnoticed (#2641).
     let mut counted: HashSet<VotingPrincipal> = HashSet::new();
+    let mut resolution = DelegationResolution::new();
     let mut tally = VoteTally::empty();
 
     // First pass: count direct votes
@@ -164,13 +170,19 @@ pub fn compute_tally_with_delegations(
         // delegator. Comparing principals stops a self-delegation from being
         // laundered into a second vote by re-spelling the delegate DID.
         if delegate_principal != voter_principal {
+            // Several spellings of one delegator must agree on the delegate, or
+            // `eligible_voters` order would choose the delegated act (#2641).
+            if resolution.record(voter, voter_principal, delegate_principal)?
+                == DelegationStep::AlreadyExpanded
+            {
+                continue;
+            }
             if let Some(delegate_vote) = vote_map.get(&delegate_principal) {
                 // Create a vote for the delegator based on the delegate's choice and weight
                 let delegated_vote =
                     Vote::new(proposal_id.clone(), voter.clone(), delegate_vote.choice)
                         .with_weight(delegate_vote.weight);
                 tally.add_vote(&delegated_vote);
-                counted.insert(voter_principal);
             }
         }
     }
@@ -204,7 +216,12 @@ pub fn compute_detailed_tally_with_delegations(
     for &vote in &direct {
         vote_map.insert(VotingPrincipal::of(&vote.voter)?, vote);
     }
+    // Principals that voted *directly*. Delegation de-duplication belongs to
+    // `resolution`, not here: marking a delegator counted would short-circuit
+    // the next spelling of that principal before its delegate could be
+    // compared, and a disagreement would pass unnoticed (#2641).
     let mut counted: HashSet<VotingPrincipal> = HashSet::new();
+    let mut resolution = DelegationResolution::new();
     let mut tally = VoteTally::empty();
     let mut delegated_count = 0;
     let direct_count = direct.len();
@@ -226,13 +243,20 @@ pub fn compute_detailed_tally_with_delegations(
         let delegate_principal = VotingPrincipal::of(&delegate)?;
 
         if delegate_principal != voter_principal {
+            // Same rule as the ordinary tally: one principal delegates once, and
+            // disagreeing spellings fail closed rather than letting list order
+            // pick the act (#2641).
+            if resolution.record(voter, voter_principal, delegate_principal)?
+                == DelegationStep::AlreadyExpanded
+            {
+                continue;
+            }
             if let Some(delegate_vote) = vote_map.get(&delegate_principal) {
                 // Preserve the delegate's vote weight
                 let delegated_vote =
                     Vote::new(proposal_id.clone(), voter.clone(), delegate_vote.choice)
                         .with_weight(delegate_vote.weight);
                 tally.add_vote(&delegated_vote);
-                counted.insert(voter_principal);
                 delegated_count += 1;
             }
         }
@@ -339,6 +363,76 @@ mod tests {
     // Helper to create deterministic test DIDs
     fn test_did(seed: u8) -> Did {
         Did::from_anchor_id(&[seed; 32])
+    }
+
+    /// Re-spell a DID as multibase base16 over the same identifier bytes.
+    fn alias_spelling(did: &Did) -> Did {
+        let bytes = did.identifier_bytes().expect("test DID must decode");
+        Did::from_str(&format!("did:icn:f{}", hex::encode(bytes)))
+            .expect("base16 multibase spelling must parse")
+    }
+
+    /// #2641: where `eligible_voters` names one principal under several
+    /// spellings and those spellings delegate to voters who disagree, counting
+    /// the first one encountered would make list order the authority over a
+    /// vote. Fail closed instead.
+    #[test]
+    fn competing_alias_delegations_fail_closed() {
+        use crate::delegation::{Delegation, DelegationManager, DelegationScope};
+
+        let kp = icn_identity::KeyPair::generate().unwrap();
+        let delegator = kp.did().clone();
+        let alias = alias_spelling(&delegator);
+        assert_ne!(delegator, alias, "control: the spellings must differ");
+
+        let delegate_a = icn_identity::KeyPair::generate().unwrap().did().clone();
+        let delegate_b = icn_identity::KeyPair::generate().unwrap().did().clone();
+        let domain_id = GovernanceDomainId::new("test-coop");
+        let proposal_id = ProposalId::generate();
+
+        // One key, two spellings, two different delegates.
+        let mut manager = DelegationManager::new();
+        manager
+            .add_delegation(Delegation::new(
+                delegator.clone(),
+                delegate_a.clone(),
+                DelegationScope::Blanket,
+            ))
+            .unwrap();
+        manager
+            .add_delegation(Delegation::new(
+                alias.clone(),
+                delegate_b.clone(),
+                DelegationScope::Blanket,
+            ))
+            .unwrap();
+
+        // Both delegates vote, and they disagree.
+        let votes = vec![
+            Vote::new(proposal_id.clone(), delegate_a, VoteChoice::For),
+            Vote::new(proposal_id.clone(), delegate_b, VoteChoice::Against),
+        ];
+        let eligible = vec![delegator, alias];
+
+        let err =
+            compute_tally_with_delegations(&votes, &eligible, &manager, &domain_id, &proposal_id)
+                .expect_err("eligible-list order must not choose which delegated act counts");
+        assert!(
+            err.to_string().contains("competing delegations"),
+            "must name the competing delegations, got: {err}"
+        );
+
+        let detailed = compute_detailed_tally_with_delegations(
+            &votes,
+            &eligible,
+            &manager,
+            &domain_id,
+            &proposal_id,
+        );
+        assert!(
+            detailed.is_err(),
+            "the detailed twin must fail closed on the same evidence"
+        );
     }
 
     #[test]

--- a/icn/crates/icn-governance/src/vote_principal.rs
+++ b/icn/crates/icn-governance/src/vote_principal.rs
@@ -1,0 +1,168 @@
+//! Cryptographic voting-principal identity for governance acts.
+//!
+//! A [`Did`] retains whatever multibase spelling it was parsed from, and its
+//! `Eq`/`Hash` are string equality (#2627 / N2-A is the tranche that changes
+//! that). One Ed25519 key therefore has many accepted textual names.
+//!
+//! Governance must not let representation buy voting weight (#2641), so vote
+//! admission and vote counting resolve each voter to the 32-byte public key its
+//! DID decodes to, rather than to the spelling that named it.
+//!
+//! This is deliberately local to governance. It does not canonicalize DIDs, does
+//! not change `Did` equality, and does not re-key any persisted store — the
+//! membership/vote re-key stays behind the `IDENTITY_SEMANTICS.md` §7.5 gate.
+
+use crate::error::GovernanceError;
+use crate::vote::Vote;
+use icn_identity::Did;
+use std::collections::HashMap;
+
+/// The decoded cryptographic principal that a voter DID names.
+///
+/// Two `Did`s whose multibase identifiers decode to the same 32 bytes are the
+/// same `VotingPrincipal`, whatever spelling they carry.
+///
+/// Identity is the decoded bytes rather than a parsed `VerifyingKey`. For a DID
+/// that passed `Did::from_str` validation the two are equivalent — those bytes
+/// *are* the Ed25519 public key — but keying on bytes also resolves
+/// anchor-derived DIDs (`Did::from_anchor_id`), which are legitimate principals
+/// in this codebase yet need not decompress to an Edwards point. Demanding a
+/// verifying key here would refuse to tally those rather than protect them.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub struct VotingPrincipal([u8; 32]);
+
+impl VotingPrincipal {
+    /// Resolve the principal a voter DID names.
+    ///
+    /// Fails closed: a DID whose identifier does not decode to 32 bytes names
+    /// no principal, and must be neither admitted nor counted.
+    pub fn of(did: &Did) -> Result<Self, GovernanceError> {
+        let bytes = did.identifier_bytes().map_err(|e| {
+            GovernanceError::InvalidVoter(format!("voter DID does not decode: {e}"))
+        })?;
+        Ok(Self(bytes))
+    }
+
+    /// The decoded identifier bytes this principal is.
+    pub fn as_bytes(&self) -> &[u8; 32] {
+        &self.0
+    }
+}
+
+/// Whether two stored acts by one principal express the same effective vote.
+///
+/// Only the fields that carry voting power are compared. Two rows that differ
+/// solely in comment or timestamp express the same act and are not a conflict.
+fn same_effective_act(a: &Vote, b: &Vote) -> bool {
+    a.choice == b.choice && a.weight == b.weight
+}
+
+/// Reduce stored vote rows to at most one effective vote per cryptographic
+/// principal.
+///
+/// Returned in first-encountered order, so the caller's ordering is preserved
+/// and no ordering of the underlying storage becomes an authority rule.
+///
+/// # Rules
+///
+/// * Rows whose voter DIDs decode to different keys are different voters.
+/// * Several rows for one principal that express the *same* effective act
+///   collapse to one contribution. No survivor is being chosen: every candidate
+///   contributes identically, so the result does not depend on which is kept.
+/// * Several rows for one principal that express *conflicting* acts fail closed.
+///   Deciding which of two conflicting historical acts is authoritative is a
+///   migration/conflict policy owned by `IDENTITY_SEMANTICS.md` §7.5, not by
+///   this function, and guessing would silently rewrite governance history.
+pub fn effective_votes(votes: &[Vote]) -> Result<Vec<&Vote>, GovernanceError> {
+    let mut order: Vec<&Vote> = Vec::new();
+    let mut seen: HashMap<VotingPrincipal, usize> = HashMap::new();
+
+    for vote in votes {
+        let principal = VotingPrincipal::of(&vote.voter)?;
+        match seen.get(&principal) {
+            None => {
+                seen.insert(principal, order.len());
+                order.push(vote);
+            }
+            Some(&idx) => {
+                let kept = order[idx];
+                if !same_effective_act(kept, vote) {
+                    return Err(GovernanceError::ConflictingVoteRecords(format!(
+                        "proposal {}: one voting principal has conflicting stored acts \
+                         ({:?} weight {} as '{}' vs {:?} weight {} as '{}'); \
+                         resolving this requires the §7.5-gated vote migration, \
+                         so the tally fails closed rather than choosing a winner",
+                        vote.proposal_id.0,
+                        kept.choice,
+                        kept.weight,
+                        kept.voter,
+                        vote.choice,
+                        vote.weight,
+                        vote.voter,
+                    )));
+                }
+            }
+        }
+    }
+
+    Ok(order)
+}
+
+/// The single effective act already recorded for the principal `voter` names.
+///
+/// Returns `Ok(None)` when that principal has not voted. Fails closed when the
+/// stored rows for that principal conflict with one another, so neither
+/// admission nor lookup silently picks one of two conflicting historical acts.
+///
+/// Only rows for this principal are inspected: a conflicting pair belonging to
+/// some *other* voter must not block this voter from acting.
+pub fn prior_act_for<'a>(
+    votes: &'a [Vote],
+    voter: &Did,
+) -> Result<Option<&'a Vote>, GovernanceError> {
+    let principal = VotingPrincipal::of(voter)?;
+    let mut found: Option<&'a Vote> = None;
+
+    for vote in votes {
+        if VotingPrincipal::of(&vote.voter)? != principal {
+            continue;
+        }
+        match found {
+            None => found = Some(vote),
+            Some(kept) => {
+                if !same_effective_act(kept, vote) {
+                    return Err(GovernanceError::ConflictingVoteRecords(format!(
+                        "proposal {}: one voting principal has conflicting stored acts \
+                         ({:?} weight {} as '{}' vs {:?} weight {} as '{}'); \
+                         resolving this requires the §7.5-gated vote migration, \
+                         so governance fails closed rather than choosing a winner",
+                        vote.proposal_id.0,
+                        kept.choice,
+                        kept.weight,
+                        kept.voter,
+                        vote.choice,
+                        vote.weight,
+                        vote.voter,
+                    )));
+                }
+            }
+        }
+    }
+
+    Ok(found)
+}
+
+/// Reject a second vote from a principal that has already acted.
+///
+/// Constructs [`GovernanceError::AlreadyVoted`], enforcing INV-6 ("duplicate
+/// vote must be rejected") by cryptographic principal rather than by spelling,
+/// so re-spelling a voter DID no longer buys a second counted vote (#2641).
+pub fn ensure_has_not_voted(votes: &[Vote], voter: &Did) -> Result<(), GovernanceError> {
+    if let Some(existing) = prior_act_for(votes, voter)? {
+        return Err(GovernanceError::AlreadyVoted(format!(
+            "{} has already voted on proposal {} (recorded under DID spelling '{}')",
+            voter, existing.proposal_id.0, existing.voter
+        )));
+    }
+    Ok(())
+}

--- a/icn/crates/icn-governance/src/vote_principal.rs
+++ b/icn/crates/icn-governance/src/vote_principal.rs
@@ -114,8 +114,13 @@ pub fn effective_votes(votes: &[Vote]) -> Result<Vec<&Vote>, GovernanceError> {
 /// stored rows for that principal conflict with one another, so neither
 /// admission nor lookup silently picks one of two conflicting historical acts.
 ///
-/// Only rows for this principal are inspected: a conflicting pair belonging to
-/// some *other* voter must not block this voter from acting.
+/// A conflicting pair belonging to some *other* voter does not block this voter
+/// from acting: conflicts are only ever reported within one principal.
+///
+/// Every row is still decoded, because a row's principal cannot be compared
+/// without decoding it. A row whose voter DID does not decode therefore fails
+/// this lookup closed whoever it belongs to — an unidentifiable voter cannot be
+/// ruled out as being this principal, so it cannot be safely skipped.
 pub fn prior_act_for<'a>(
     votes: &'a [Vote],
     voter: &Did,

--- a/icn/crates/icn-governance/src/vote_principal.rs
+++ b/icn/crates/icn-governance/src/vote_principal.rs
@@ -125,15 +125,25 @@ pub fn prior_act_for<'a>(
     votes: &'a [Vote],
     voter: &Did,
 ) -> Result<Option<&'a Vote>, GovernanceError> {
+    Ok(acts_for(votes, voter)?.first().copied())
+}
+
+/// Every stored row naming the principal `voter` names, in encounter order.
+///
+/// Fails closed on the same terms as [`prior_act_for`]. More than one row means
+/// the rows were written before duplicate-act prevention existed: they agree, or
+/// this would have returned an error, but they are still several rows for one
+/// voter and callers that must write must take that into account.
+pub fn acts_for<'a>(votes: &'a [Vote], voter: &Did) -> Result<Vec<&'a Vote>, GovernanceError> {
     let principal = VotingPrincipal::of(voter)?;
-    let mut found: Option<&'a Vote> = None;
+    let mut found: Vec<&'a Vote> = Vec::new();
 
     for vote in votes {
         if VotingPrincipal::of(&vote.voter)? != principal {
             continue;
         }
-        match found {
-            None => found = Some(vote),
+        match found.first() {
+            None => found.push(vote),
             Some(kept) => {
                 if !same_effective_act(kept, vote) {
                     return Err(GovernanceError::ConflictingVoteRecords(format!(
@@ -150,6 +160,7 @@ pub fn prior_act_for<'a>(
                         vote.voter,
                     )));
                 }
+                found.push(vote);
             }
         }
     }

--- a/icn/crates/icn-governance/src/vote_principal.rs
+++ b/icn/crates/icn-governance/src/vote_principal.rs
@@ -108,6 +108,72 @@ pub fn effective_votes(votes: &[Vote]) -> Result<Vec<&Vote>, GovernanceError> {
     Ok(order)
 }
 
+/// How many distinct voting principals a member list names.
+///
+/// Quorum denominators must count voters rather than DID spellings. The tally
+/// numerator gives one principal one vote (#2641), so a list naming one key
+/// under several spellings would otherwise claim several electorate slots for a
+/// single voter and read their vote as partial turnout.
+pub fn distinct_principals(members: &[Did]) -> Result<usize, GovernanceError> {
+    let mut seen = std::collections::HashSet::new();
+    for member in members {
+        seen.insert(VotingPrincipal::of(member)?);
+    }
+    Ok(seen.len())
+}
+
+/// Tracks which delegate each principal resolved to while a delegated tally is
+/// being expanded.
+///
+/// One principal delegates once. Where an eligible-voter list names it under
+/// several spellings, those spellings must resolve to the same delegate — else
+/// the order of that list would decide which delegated act counts, which is a
+/// hidden selector over a vote rather than a democratic outcome.
+#[derive(Debug, Default)]
+pub struct DelegationResolution {
+    seen: HashMap<VotingPrincipal, VotingPrincipal>,
+}
+
+/// What [`DelegationResolution::record`] found for a principal.
+#[derive(Debug, PartialEq, Eq)]
+pub enum DelegationStep {
+    /// First spelling of this principal: expand its delegation.
+    Expand,
+    /// A previous spelling already resolved to the same delegate: skip.
+    AlreadyExpanded,
+}
+
+impl DelegationResolution {
+    /// Create an empty resolution tracker.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Record the delegate this principal resolved to, failing closed if an
+    /// earlier spelling of the same principal resolved to a different one.
+    pub fn record(
+        &mut self,
+        delegator: &Did,
+        delegator_principal: VotingPrincipal,
+        delegate_principal: VotingPrincipal,
+    ) -> Result<DelegationStep, GovernanceError> {
+        match self.seen.get(&delegator_principal) {
+            Some(&already) if already != delegate_principal => {
+                Err(GovernanceError::CompetingDelegations(format!(
+                    "one voting principal holds competing delegations under different DID \
+                     spellings ('{delegator}' resolves elsewhere than a previous spelling of \
+                     the same key); refusing to let list order choose which delegated act counts"
+                )))
+            }
+            Some(_) => Ok(DelegationStep::AlreadyExpanded),
+            None => {
+                self.seen.insert(delegator_principal, delegate_principal);
+                Ok(DelegationStep::Expand)
+            }
+        }
+    }
+}
+
 /// The single effective act already recorded for the principal `voter` names.
 ///
 /// Returns `Ok(None)` when that principal has not voted. Fails closed when the

--- a/icn/crates/icn-identity/src/lib.rs
+++ b/icn/crates/icn-identity/src/lib.rs
@@ -619,6 +619,60 @@ mod tests {
     }
 
     #[test]
+    fn identifier_bytes_are_equal_across_multibase_spellings() {
+        let kp = KeyPair::generate().unwrap();
+        let canonical = kp.did().clone();
+        let bytes = canonical.identifier_bytes().unwrap();
+
+        // Same key, spelled base16 instead of base58btc.
+        let alias = Did::from_str(&format!("did:icn:f{}", hex::encode(bytes))).unwrap();
+
+        assert_ne!(
+            canonical.as_str(),
+            alias.as_str(),
+            "the two spellings must differ, or this proves nothing"
+        );
+        assert_eq!(
+            canonical.identifier_bytes().unwrap(),
+            alias.identifier_bytes().unwrap(),
+            "one key must have one identifier whatever spelling names it"
+        );
+        assert_eq!(
+            bytes,
+            kp.verifying_key().to_bytes(),
+            "for a validated DID the identifier bytes are the public key"
+        );
+    }
+
+    #[test]
+    fn identifier_bytes_resolve_anchor_derived_dids_that_are_not_ed25519_points() {
+        // `from_anchor_id` bypasses validation, so its 32 bytes need not
+        // decompress to an Edwards point. Callers keying on identity must still
+        // be able to resolve it.
+        // Roughly half of arbitrary 32-byte values decompress; [2u8; 32] does not.
+        let anchor = Did::from_anchor_id(&[2u8; 32]);
+
+        assert!(
+            anchor.to_verifying_key().is_err(),
+            "control: this anchor id is not a valid Ed25519 point"
+        );
+        assert_eq!(
+            anchor.identifier_bytes().unwrap(),
+            [2u8; 32],
+            "identifier bytes must still resolve"
+        );
+    }
+
+    #[test]
+    fn identifier_bytes_reject_a_non_32_byte_identifier() {
+        let short = Did::new_unchecked(format!(
+            "did:icn:{}",
+            multibase::encode(multibase::Base::Base58Btc, [7u8; 16])
+        ));
+        assert!(short.identifier_bytes().is_err());
+    }
+
+    #[test]
     fn test_did_from_str_invalid_prefix() {
         let result = Did::from_str("invalid:prefix:abc123");
         assert!(result.is_err());

--- a/icn/crates/icn-identity/src/lib.rs
+++ b/icn/crates/icn-identity/src/lib.rs
@@ -250,6 +250,39 @@ impl Did {
         &self.0
     }
 
+    /// Decode the 32 identifier bytes this DID names.
+    ///
+    /// A `did:icn:` identifier is a multibase encoding of 32 bytes, and the
+    /// same bytes have many accepted spellings (base58btc, base16, base32,
+    /// ...). This returns the bytes themselves, so callers that must treat one
+    /// principal as one principal can compare identity rather than spelling
+    /// (see #2641).
+    ///
+    /// Unlike [`Did::to_verifying_key`] this does not require the bytes to be a
+    /// valid Ed25519 point, so it also resolves anchor-derived DIDs built by
+    /// [`Did::from_anchor_id`].
+    ///
+    /// This is an accessor only: it does not canonicalize the DID and does not
+    /// change how `Did` compares or hashes.
+    pub fn identifier_bytes(&self) -> Result<[u8; 32]> {
+        let encoded_part = self
+            .0
+            .get(8..)
+            .ok_or_else(|| anyhow::anyhow!("Invalid DID format: too short"))?;
+
+        if encoded_part.is_empty() {
+            anyhow::bail!("Invalid DID format: empty identifier after prefix");
+        }
+
+        let (_base, decoded_bytes) = multibase::decode(encoded_part)
+            .map_err(|e| anyhow::anyhow!("Invalid DID multibase encoding: {e}"))?;
+
+        decoded_bytes
+            .as_slice()
+            .try_into()
+            .map_err(|_| anyhow::anyhow!("Invalid DID: identifier is not 32 bytes"))
+    }
+
     /// Extract the Ed25519 verifying key from this DID
     ///
     /// This decodes the DID's multibase-encoded public key and returns

--- a/icn/crates/icn-identity/src/lib.rs
+++ b/icn/crates/icn-identity/src/lib.rs
@@ -265,10 +265,15 @@ impl Did {
     /// This is an accessor only: it does not canonicalize the DID and does not
     /// change how `Did` compares or hashes.
     pub fn identifier_bytes(&self) -> Result<[u8; 32]> {
+        // Validate the prefix rather than assuming it. Every `Did` reaching here
+        // through `from_str` or `Deserialize` has been checked, but
+        // `new_unchecked` bypasses that, and decoding whatever follows the first
+        // eight characters of some other scheme would hand back bytes that name
+        // no ICN principal.
         let encoded_part = self
             .0
-            .get(8..)
-            .ok_or_else(|| anyhow::anyhow!("Invalid DID format: too short"))?;
+            .strip_prefix("did:icn:")
+            .ok_or_else(|| anyhow::anyhow!("Invalid DID format: must start with 'did:icn:'"))?;
 
         if encoded_part.is_empty() {
             anyhow::bail!("Invalid DID format: empty identifier after prefix");
@@ -660,6 +665,21 @@ mod tests {
             anchor.identifier_bytes().unwrap(),
             [2u8; 32],
             "identifier bytes must still resolve"
+        );
+    }
+
+    #[test]
+    fn identifier_bytes_reject_a_did_of_another_method() {
+        // `new_unchecked` bypasses prefix validation. Slicing a fixed eight
+        // characters off some other scheme would decode bytes that name no ICN
+        // principal, so the accessor must refuse rather than invent one.
+        let kp = KeyPair::generate().unwrap();
+        let suffix = kp.did().as_str().strip_prefix("did:icn:").unwrap();
+        let foreign = Did::new_unchecked(format!("did:key:{suffix}"));
+
+        assert!(
+            foreign.identifier_bytes().is_err(),
+            "a non-icn DID method must not resolve to an ICN principal"
         );
     }
 


### PR DESCRIPTION
Closes #2641.

`Did::from_str` accepts any multibase encoding of a 32-byte identifier and keeps the spelling it was handed; `Did` equality is string equality. Governance keyed "same voter" off that spelling, so one cryptographic voter could buy one counted vote per spelling of their own DID.

This makes governance resolve a voter to the bytes its `did:icn:` identifier decodes to. It does not change `Did` equality, canonicalize DIDs at parse, or re-key any persisted store.

## Reproduced first, on unmodified `main`

Commit `9c80c796` is the reproduction, added before any fix. On `5ea10498` it failed 7/9:

```
in_memory_alias_spelled_second_vote_does_not_add_voting_weight   left: 2
sled_alias_spelled_second_vote_does_not_add_voting_weight        left: 2
in_memory_conflicting_historical_alias_rows_fail_closed
  → VoteTally { for_votes: 1, against_votes: 1, abstain_votes: 0 }
sled_conflicting_historical_alias_rows_fail_closed
  → VoteTally { for_votes: 1, against_votes: 1, abstain_votes: 0 }
```

That last line is one person recorded as voting **For and Against the same proposal, both counted**.

The two controls passed, so the reproduction is not vacuous: the spellings really are distinct `Did` values over one key today, and two genuinely distinct principals still each count.

### Live mechanism, where it differs from the issue

The issue's claims all held, but reachability is sharper than recorded, and one detail is wrong in the issue's favour:

* **`GovernanceManager::cast_vote` delegates to `governance_handle` as its first statement**, before the membership gate and before the recast guard. In actor-backed deployments — the production configuration — neither of the manager's checks ran at all.
* **`GovernanceActor`'s `CastVote` handler had no duplicate-vote guard whatsoever.** It called `save_vote` directly. This, not the manager's string comparison, was the load-bearing hole.
* In the in-process manager, `MembershipSource::StaticList` compares by spelling and so refuses an alias at the *membership* gate (fail-closed, wrong message). The manager-level bypass is reachable under `MembershipSource::TrustThreshold`, which admits any DID.
* The REST voter comes from `claims.sub` (`http/handlers.rs:1822`), and the gateway's challenge flow keys challenges by `Did` while verifying with `to_verifying_key`, so a caller can complete auth under any spelling of their own key and carry it into `sub`.

## Invariant

> For one proposal, one cryptographic voting principal contributes at most one effective vote, regardless of which accepted textual encoding names that principal.

This is INV-6 ("duplicate vote must be rejected") enforced by principal instead of by spelling.

## Rules, stated separately

**Identity.** `VotingPrincipal` is the 32 decoded multibase identifier bytes, via the new read-only accessor `Did::identifier_bytes`. Not a parsed `VerifyingKey`: for a validated DID the two are equivalent, but `Did::from_anchor_id` (a `new_unchecked` path, used for treasury principals in `apps/membership` and as `test_did()` across governance tests) produces valid DIDs whose bytes need not decompress to an Edwards point. Keying on a verifying key would have refused to tally those rather than protecting them.

**Admission.** `ensure_has_not_voted` compares principals and constructs `GovernanceError::AlreadyVoted` — its first constructor in the workspace. The manager keeps its INV-6 refusal. The actor keeps its pre-existing vote-changing behaviour, but writes the update onto the row the principal already owns, so a re-spelling updates rather than stacking. Both store implementations supersede a principal's prior row across spellings; sled also removes the aliased row and its index entry.

**Tally.** `VoteTally::try_from_votes` reduces rows to one effective act per principal and is used by every tally path in the workspace: both `GovernanceStore` impls, the manager's two sites, the actor's read-only `get_vote_tally`, and — the two the review caught — the decision-producing tally inside `CloseProposal` and its close-time delegation expansion `apply_delegation_to_tally`. Delegated tallies key by principal; the `tally.rs` pair became fallible (they had no production callers). `From<Vec<Vote>>` is left intact and documented as raw summation.

On liveness, so the coverage claim is not overstated: the live vote storage is `apps/governance/src/state_store.rs`, driven by the actor. `icn-governance::GovernanceStore` is a library surface whose only in-workspace consumer is `ProposalCleanupTask::archive_proposal`, and that task is exported but not instantiated in-workspace.

**Historical rows.** Rows for one principal that agree on `(choice, weight)` collapse to one contribution — no survivor is chosen, because every candidate contributes identically. Rows that **conflict fail closed**, at admission and at tally. Choosing between two conflicting historical acts is the §7.5 migration's business; guessing would silently rewrite governance history. No lexical, iteration, timestamp, hash or arrival order is used as an authority rule.

## N2-A boundary

Nothing here presupposes or preempts #2627. `Did`'s `Eq`/`Hash` are untouched, parsing is untouched, and **no persisted key changed**: vote rows stay `Display`-keyed and membership lists stay spelling-compared, so `IDENTITY_SEMANTICS.md` §7.5's re-key gate is intact and the N2-A0 rows stay `NEEDS MIGRATION`.

§7.5 names four prerequisites. This delivers **duplicate-act prevention** only; migration ordering, alias/transition recognition and final cutover remain undesigned.

After N2-A makes `Did` key-equal, the app guards and the tally reduction remain necessary — rows are keyed by `Display`, which I7 does not touch. Three anti-vacuity controls assert the spellings are distinct under today's equality and will fail loudly when that changes, forcing the proofs to be re-derived rather than silently passing.

## Verification

* `cargo test -p icn-governance -p icn-governance-actor -p icn-identity` — pass.
* `cargo fmt --all -- --check` — clean. `cargo clippy --workspace --all-targets -- -D warnings` — clean.
* `docs/scripts/doc_control_check.py` — pass, no new warnings.

**Mutation controls**, with production sources checksummed before and restored/verified after:

| Mutation | Killed by |
|---|---|
| A — principal identity reverted to DID spelling | 7 store/tally proofs + the manager admission proof |
| B — tally reverted to counting every row | the 4 historical-row proofs (both stores, agreeing + conflicting) |
| C — actor row identity reverted to spelling | the actor-path proof |
| D — close tally reverted to raw summation | the close fail-closed proof |
| E — delegation expansion reverted to spelling keying | the self-delegation laundering proof |
| F — `identifier_bytes` reverted to slicing without a prefix check | the foreign-DID-method proof |
| G — actor duplicate-row refusal removed | the legacy-duplicate refusal proof |
| H — pre-filter conflict detection removed | the filtered-close fail-closed proof |
| I — quorum denominator reverted to counting spellings | the principal-denominator proof |
| J — competing-delegation disagreement check disabled | the competing-delegations proof |
| K — manager denominator reverted to `members.len()` | the standalone-denominator proof |
| L — manager pre-filter validation removed | the standalone filtered-close proof |
| M — library delegation guard removed | the library competing-delegations proof |

A and B kill disjoint sets, which is the point: admission and counting are independently proven, so neither defence is load-bearing alone. Counter-controls survived every mutation.

## Review outcome

One FULL generation, STANDARD lane. **2 BLOCKER · 5 FOLLOW_UP · 1 QUESTION · 3 NOT_A_FINDING.** Both blockers were confirmed at source and fixed as one batch:

* **`CloseProposal` built the deciding tally by raw summation** (`VoteTally::empty()` + `add_vote` in a loop), so the read-only `get_vote_tally` refused a conflicting pair while the path that commits the decision to a receipt counted both. My own audit grepped for `VoteTally::from` and missed the loop form.
* **`apply_delegation_to_tally`, the production close-time delegation expansion, was still spelling-keyed.** I had fixed its non-production twin in `tally.rs` and left this one. A member could delegate from one spelling of their key to another, vote as the delegate, and have that single vote resolved back to them as a second — on a fresh deployment, no legacy rows needed. This was the more serious of the two.

Both have regression coverage, and mutations D and E prove that coverage discriminating.

While fixing blocker 2 I found a third defect in the same function and folded it into the batch: unlike its `tally.rs` equivalent, `apply_delegation_to_tally` never marked a delegator as counted, so a member list naming one principal under two spellings would have expanded its delegation twice. An independent sweep for the pattern that hid both blockers — raw `add_vote` loops and `.voter ==` comparisons — found nothing else in production code.

The five follow-ups are recorded in the ledger issue rather than fixed here, along with the answer to the QUESTION about `GovernanceStore` liveness and three further spelling-keyed eligibility comparisons in the same fail-closed family.

### Second round

Three further automated findings after that batch, all confirmed at source and fixed in `d9ac5ccc`:

* **Actor admission could manufacture the conflict it then fails on.** With two agreeing pre-fix rows for one principal, the update landed on one spelling-keyed row and left the others, turning a reducible duplicate into a conflicting pair that breaks every later tally. `GovernanceStateStore` overwrites by key and cannot supersede them all, so the actor now refuses without mutating and names the required migration. The rows agree, so the proposal still tallies and still closes meanwhile. I deliberately did not add a vote delete to that trait: putting deletion of persisted vote rows on the admission path is what §7.5 gates.
* **Filtered close could hide a conflict.** Standing revalidation is spelling-keyed, so a standing set naming one spelling of a conflicting pair dropped the other and left the reduction nothing to notice. I had recorded this shape myself as a follow-up; that was the wrong call, since the contract states conflicting rows fail closed and on this path they did not. Conflicts are now detected across every stored row before eligibility narrows the set.
* **The sled alias supersede was not atomic.** Correctly a FOLLOW_UP under the predicate — that store has no live caller — but fixed anyway, because it is a durability regression introduced on the exact lines this PR changes. Removals, replacement and index now apply as one `sled::Batch`.

New helper `acts_for` exposes every row for a principal on the same fail-closed terms as `prior_act_for`.

### Third round

Two further findings, both rooted in a membership list naming one key under several DID spellings, and both inconsistencies this PR introduced by reducing one half of a computation. Fixed in `9ab8aec1`:

* **The quorum denominator counted spellings, not principals.** The numerator became principal-reduced while `eligible_count` stayed `eligible_members.len()`, so a list naming one key twice claimed two electorate slots for one voter: under a 100% quorum a sole member who *had* voted closed `NoQuorum` at 1/2 turnout. Both halves of the ratio now count distinct principals.
* **Competing delegations were resolved by membership-list order.** The `direct_voters` marker added in the previous round to stop double-expansion meant that where two spellings of one member delegated to different voters, whichever the resolver listed first silently won — list order acting as authority over a vote, which is worse than the visible double-count it replaced. A principal's spellings must now resolve to the same delegate or the close fails closed, and a principal expands at most once. That marker also replaces `direct_voters`, which conflated "voted directly" with "delegation already applied".

Only the counting half of the first was taken: rejecting duplicate-principal membership lists, and principal-aware eligibility generally, is a membership-admission change and stays in #2678.

### Fourth round

Three findings, each the manager or library **twin** of something already fixed in the actor — the reviewer cited that asymmetry as the evidence, which is fair. Fixed in `865fc6b5`:

* standalone quorum denominator counted `members.len()` while its numerator was principal-reduced;
* `close_proposal_inner` reduced only the filtered rows, so a spelling-keyed standing set could hide a conflicting pair;
* `compute_tally_with_delegations` and its detailed twin let eligible-list order pick between competing alias delegations.

To stop this recurring, the logic now lives in `icn-governance` and is shared rather than reimplemented per path: `distinct_principals` for electorate counting, `DelegationResolution`/`DelegationStep` for delegation expansion. The actor was switched onto both.

Writing the library test exposed a hole in the actor fix as originally shipped: `counted` marked a delegator after expanding its delegation, which short-circuited the next spelling of that principal *before* its delegate could be compared — the guard sat downstream of the skip that hid what it was meant to catch. `counted` now means "voted directly" only.

A sweep for the remaining shapes — electorate `.len()` over DID collections, tally-after-filter sites, delegation expansion loops — finds no further twins. `resolve_delegate`'s spelling-keyed `visited` set stays: bounded by `max_depth`, and an alias self-cycle is already caught at expansion by the principal comparison.

All 13 review threads are dispositioned and resolved.

Coverage includes both production `GovernanceStore` implementations, the manager under both membership sources, and the actor path.

## Non-goals

Not done here: global `Did` equality/hash change (N2-A/#2627), parse-time canonicalization, re-keying any persisted store, the §7.5 membership/vote re-key, N2-B/N2-D/N2-H, and #2676's `MisbehaviorDetector` — which is the same representation-keying class of defect and is evidence for N2-A's systemic surface, not something to fix quietly here.

## Correction recorded in history

`c3a1ecaa` first enforced INV-6 refusal in the actor. That changed the actor's policy rather than fixing #2641 — re-casting has always been allowed there — and broke `a_second_operation_in_one_domain_advances_its_sequence`. `e7dadbc3` corrects it to supersede-by-principal. The failure was initially missed because a test run's output was truncated; the final runs are captured in full.

<!-- ICN-DELIVERY-LIFECYCLE:BEGIN -->
```
ICN DELIVERY LIFECYCLE
State:                FROZEN
Lane:                 STANDARD
Acceptance contract:  One cryptographic voting principal contributes at most one
                      effective vote per proposal, regardless of which accepted
                      multibase spelling of its DID names it -- enforced at
                      governance admission and at every tally path, with
                      conflicting historical rows failing closed and the
                      electorate counted by principal.
                      Non-goals: Did Eq/Hash change, parse canonicalization,
                      any persisted re-key, the §7.5 membership/vote re-key,
                      principal-aware membership/eligibility comparison,
                      N2-B/N2-D/N2-H, #2676.
Review generation:    CLOSED
Freeze head:          865fc6b5b95110c04004b759eb40f811918ab949
Known blockers:       0
Follow-up ledger:     #2678
Unrelated CI flake:   #2679 (icn-commons sled flock retry test; not #1955)
```
<!-- ICN-DELIVERY-LIFECYCLE:END -->
