### PR TITLE
fix(ccl): key a CCL value by the principal a DID names, not its spelling

### DIFF
--- a/icn/crates/icn-ccl/src/types.rs
+++ b/icn/crates/icn-ccl/src/types.rs
@@ -197,6 +197,22 @@ impl Value {
 }
 
 // Implement Hash for Value to use in Sets
+//
+// One rule governs the DID-bearing arms below: a `Value` hashes by the
+// *principal* a DID names, never by the spelling that named it.
+//
+// `did:icn:` identifiers are multibase, so one 32-byte identifier has more than
+// one accepted textual encoding. `Did` equality is still spelling-sensitive
+// today; N2-A (#2627) intends to make it principal-sensitive (I7,
+// `docs/architecture/IDENTITY_SEMANTICS.md` §11). Rust requires only
+// `a == b => hash(a) == hash(b)`, never the converse, so a hash may be coarser
+// than equality. Hashing by principal therefore satisfies both regimes: today
+// two spellings merely collide, which `HashSet` resolves by comparing; after I7
+// they are equal and must hash equally, which they already will.
+//
+// This is a keying rule only. It does not canonicalize a `Value`, change how
+// one displays or serializes, or touch `Did` equality — `Value`'s derived
+// `PartialEq` still follows `Did`, unchanged.
 impl std::hash::Hash for Value {
     fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
         match self {
@@ -214,8 +230,26 @@ impl std::hash::Hash for Value {
             }
             Value::Did(did) => {
                 3u8.hash(state);
-                // Hash the DID's string representation
-                format!("{did:?}").hash(state);
+                match did.identifier_bytes() {
+                    // The identifier the spelling decodes to, read by exactly
+                    // the rule `icn-identity` owns. CCL does not parse DIDs.
+                    Ok(identifier) => {
+                        0u8.hash(state);
+                        identifier.hash(state);
+                    }
+                    // A DID that names no ICN principal cannot be keyed by one.
+                    // Every public constructor yields a decodable 32-byte
+                    // identifier — `from_anchor_id` skips parsing but still
+                    // encodes 32 bytes — so this is defensive. Falling back to
+                    // the spelling keeps the contract either way: equality
+                    // between two DIDs that decode to nothing can only ever be
+                    // spelling equality. The discriminant keeps that population
+                    // from colliding with decoded identifiers.
+                    Err(_) => {
+                        1u8.hash(state);
+                        did.as_str().hash(state);
+                    }
+                }
             }
             Value::List(list) => {
                 4u8.hash(state);
@@ -225,11 +259,27 @@ impl std::hash::Hash for Value {
             }
             Value::Set(set) => {
                 5u8.hash(state);
-                let mut items: Vec<_> = set.iter().collect();
-                items.sort_by(|a, b| format!("{a:?}").cmp(&format!("{b:?}")));
-                for item in items {
-                    item.hash(state);
+                // A set has no order, so one has to be imposed to hash its
+                // members in sequence — and the previous key, `format!("{a:?}")`,
+                // put DID spelling back into the aggregate that the arm above
+                // just took it out of. Two sets naming the same principals could
+                // sort differently and hash differently while being equal.
+                //
+                // Combine per-member hashes commutatively instead, so no order
+                // is imposed at all. Addition over a set of distinct members is
+                // the standard multiset digest; `len` separates sets that happen
+                // to share a sum. `DefaultHasher` is fixed-seed, which is what
+                // makes members comparable to each other — `Hash` output is
+                // already process-local (std collections seed `RandomState`),
+                // so nothing here is persisted, transmitted or consensus-visible.
+                let mut combined = 0u64;
+                for item in set {
+                    let mut item_hasher = std::collections::hash_map::DefaultHasher::new();
+                    item.hash(&mut item_hasher);
+                    combined = combined.wrapping_add(std::hash::Hasher::finish(&item_hasher));
                 }
+                set.len().hash(state);
+                combined.hash(state);
             }
             Value::Map(map) => {
                 6u8.hash(state);

--- a/icn/crates/icn-ccl/src/types.rs
+++ b/icn/crates/icn-ccl/src/types.rs
@@ -269,9 +269,21 @@ impl std::hash::Hash for Value {
                 // is imposed at all. Addition over a set of distinct members is
                 // the standard multiset digest; `len` separates sets that happen
                 // to share a sum. `DefaultHasher` is fixed-seed, which is what
-                // makes members comparable to each other — `Hash` output is
-                // already process-local (std collections seed `RandomState`),
-                // so nothing here is persisted, transmitted or consensus-visible.
+                // makes members comparable to each other.
+                //
+                // What this does NOT mean is that the hash is invisible. No
+                // `Hash` output is persisted or transmitted, but `HashSet`
+                // *iteration order* is a function of it, `interpreter.rs` reads
+                // that order, `icn-compute`'s executor serializes the resulting
+                // value, and `result_quorum.rs` blake3-hashes those bytes for
+                // multi-executor agreement. So set iteration order does reach a
+                // consensus-compared payload. That order was already
+                // `RandomState`-seeded and already varied per process before
+                // this rule existed: changing the hash changes *which*
+                // nondeterministic order results, not whether one is
+                // deterministic. The underlying determinism hazard is
+                // pre-existing and tracked separately (#2682); do not read this
+                // arm as having made set iteration canonical.
                 let mut combined = 0u64;
                 for item in set {
                     let mut item_hasher = std::collections::hash_map::DefaultHasher::new();

--- a/icn/crates/icn-ccl/tests/value_did_hash.rs
+++ b/icn/crates/icn-ccl/tests/value_did_hash.rs
@@ -67,10 +67,12 @@ fn a_principal() -> Did {
 fn project_to_one_spelling(value: &Value) -> Value {
     match value {
         Value::Did(did) => match did.identifier_bytes() {
-            Ok(bytes) => Value::Did(
-                Did::from_str(&format!("did:icn:f{}", hex::encode(bytes)))
-                    .expect("32 bytes always spell a valid did:icn:"),
-            ),
+            // `from_anchor_id` re-encodes any 32 bytes without parsing them, so
+            // the projection is total. Routing through `from_str` instead would
+            // reject an identifier that is not an Ed25519 point — an
+            // anchor-derived DID, for one — and this helper has no business
+            // panicking on a principal the type accepts.
+            Ok(bytes) => Value::Did(Did::from_anchor_id(&bytes)),
             Err(_) => Value::Did(did.clone()),
         },
         Value::List(items) => Value::List(items.iter().map(project_to_one_spelling).collect()),

--- a/icn/crates/icn-ccl/tests/value_did_hash.rs
+++ b/icn/crates/icn-ccl/tests/value_did_hash.rs
@@ -309,8 +309,12 @@ fn the_hash_eq_contract_holds_under_simulated_principal_equality() {
     // equality is untouched. Every value in the corpus is well-formed after
     // I7 — no set holds two spellings of one principal, because such a set
     // cannot be built once insertion collapses them.
-    let p = a_principal();
-    let q = a_principal();
+    // Pinned, not drawn freely: the corpus's aggregate members only expose a
+    // spelling-derived member order when re-spelling flips it, and with two
+    // unpinned principals that happens on about half the draws. Taking the
+    // canonically-lesser one as `p` makes `{p, q}` order `[p, q]` against
+    // `{p, q_alias}`'s `[q_alias, p]` on every run.
+    let (q, p) = two_principals_in_pinned_canonical_order();
     let p_alias = alternate_spelling(&p);
     let q_alias = alternate_spelling(&q);
 

--- a/icn/crates/icn-ccl/tests/value_did_hash.rs
+++ b/icn/crates/icn-ccl/tests/value_did_hash.rs
@@ -1,0 +1,369 @@
+//! `Value::Did` / `Value::Set` hash compatibility across DID spellings.
+//!
+//! ICN accepts more than one textual encoding for the same 32-byte principal
+//! identifier. `Did` equality is still spelling-sensitive today; N2-A (#2627)
+//! intends to make it principal-sensitive (`IDENTITY_SEMANTICS.md` §11, I7).
+//!
+//! Rust's contract is one-way:
+//!
+//! ```text
+//! a == b  =>  hash(a) == hash(b)
+//! ```
+//!
+//! The converse is not required, so a hash may be *coarser* than equality. That
+//! is what lets this land before the equality flip: two spellings of one
+//! principal share a hash today while `Did` still calls them distinct — a
+//! deliberate collision, which `HashSet` resolves by comparing — and the same
+//! rule is already correct once they become equal.
+//!
+//! These tests do not change or simulate `Did` equality in production. Where a
+//! test needs the post-I7 relation it builds it locally, from
+//! `Did::identifier_bytes`.
+
+#![allow(unknown_lints, clippy::unwrap_used, clippy::expect_used)]
+
+use std::collections::hash_map::DefaultHasher;
+use std::collections::{HashMap, HashSet};
+use std::hash::{Hash, Hasher};
+
+use icn_ccl::Value;
+use icn_identity::{Did, KeyPair};
+
+/// Hash one value with a fixed-seed hasher so two values can be compared.
+fn hash_of(value: &Value) -> u64 {
+    let mut hasher = DefaultHasher::new();
+    value.hash(&mut hasher);
+    hasher.finish()
+}
+
+/// A second, equally valid textual encoding of the principal `did` names.
+///
+/// `did:icn:` identifiers are multibase, so the same 32 bytes have a base58btc
+/// spelling and a base16 spelling. Both parse; both decode to one identifier.
+fn alternate_spelling(did: &Did) -> Did {
+    let bytes = did
+        .identifier_bytes()
+        .expect("a validated DID decodes to 32 identifier bytes");
+    let alias = Did::from_str(&format!("did:icn:f{}", hex::encode(bytes)))
+        .expect("a base16 multibase spelling of 32 bytes is a valid did:icn:");
+    assert_ne!(
+        did.as_str(),
+        alias.as_str(),
+        "the two spellings must differ, or the test proves nothing"
+    );
+    alias
+}
+
+fn a_principal() -> Did {
+    KeyPair::generate().expect("keypair").did().clone()
+}
+
+/// Rewrite every `Did` in `value` to one chosen spelling, recursively.
+///
+/// This models the post-I7 world without touching production equality: after
+/// I7 two values are equal exactly when their projections are equal under
+/// today's derived `PartialEq`. A `Value::Set` is rebuilt, so aliases of one
+/// principal collapse here exactly as they would collapse on insertion then.
+fn project_to_one_spelling(value: &Value) -> Value {
+    match value {
+        Value::Did(did) => match did.identifier_bytes() {
+            Ok(bytes) => Value::Did(
+                Did::from_str(&format!("did:icn:f{}", hex::encode(bytes)))
+                    .expect("32 bytes always spell a valid did:icn:"),
+            ),
+            Err(_) => Value::Did(did.clone()),
+        },
+        Value::List(items) => Value::List(items.iter().map(project_to_one_spelling).collect()),
+        Value::Set(items) => Value::Set(items.iter().map(project_to_one_spelling).collect()),
+        Value::Map(entries) => Value::Map(
+            entries
+                .iter()
+                .map(|(k, v)| (k.clone(), project_to_one_spelling(v)))
+                .collect(),
+        ),
+        other => other.clone(),
+    }
+}
+
+#[test]
+fn one_did_value_hashes_the_same_as_an_identical_copy() {
+    let value = Value::Did(a_principal());
+    assert_eq!(value, value.clone());
+    assert_eq!(hash_of(&value), hash_of(&value.clone()));
+}
+
+#[test]
+fn two_spellings_of_one_principal_hash_equally() {
+    let canonical = a_principal();
+    let alias = alternate_spelling(&canonical);
+
+    assert_eq!(
+        hash_of(&Value::Did(canonical)),
+        hash_of(&Value::Did(alias)),
+        "one principal must have one hash, whatever spelling names it"
+    );
+}
+
+#[test]
+fn two_distinct_principals_stay_distinct_in_a_hash_set() {
+    let p = a_principal();
+    let q = a_principal();
+
+    let mut set = HashSet::new();
+    set.insert(Value::Did(p.clone()));
+    set.insert(Value::Did(q.clone()));
+
+    assert_eq!(set.len(), 2, "two principals are two members");
+    assert!(set.contains(&Value::Did(p)));
+    assert!(set.contains(&Value::Did(q)));
+}
+
+#[test]
+fn a_hash_map_still_resolves_each_spelling_under_the_deliberate_collision() {
+    // Both spellings hash alike now but are still unequal under today's `Did`
+    // equality, so the map holds two entries in one bucket. Lookup must not
+    // confuse them: a colliding hash is resolved by `Eq`, not by the hash.
+    let canonical = a_principal();
+    let alias = alternate_spelling(&canonical);
+
+    let mut map = HashMap::new();
+    map.insert(Value::Did(canonical.clone()), "canonical");
+    map.insert(Value::Did(alias.clone()), "alias");
+
+    assert_eq!(map.get(&Value::Did(canonical)), Some(&"canonical"));
+    assert_eq!(map.get(&Value::Did(alias)), Some(&"alias"));
+}
+
+/// Two principals whose canonical spellings sort in a known order.
+///
+/// The order matters. A base16 alias always begins `f` and a base58btc
+/// canonical spelling always begins `z`, so an alias sorts before every
+/// canonical spelling. Pinning `greater > lesser` canonically guarantees that
+/// re-spelling the greater one *flips* the order a spelling-derived sort would
+/// impose — which is what makes the set tests below fail deterministically
+/// against a spelling-sorted aggregate rather than half the time.
+fn two_principals_in_pinned_canonical_order() -> (Did, Did) {
+    loop {
+        let a = a_principal();
+        let b = a_principal();
+        if a.as_str() > b.as_str() {
+            return (a, b);
+        }
+        if b.as_str() > a.as_str() {
+            return (b, a);
+        }
+    }
+}
+
+#[test]
+fn a_set_value_hashes_independently_of_how_its_members_are_spelled() {
+    // The aggregate is the half that is easy to miss: principalising the
+    // element hash is not enough while the order members are fed to the hasher
+    // is still derived from their spelling.
+    let (greater, lesser) = two_principals_in_pinned_canonical_order();
+    let greater_alias = alternate_spelling(&greater);
+
+    let spelled_one_way = Value::Set(HashSet::from([
+        Value::Did(greater),
+        Value::Did(lesser.clone()),
+    ]));
+    let spelled_the_other_way = Value::Set(HashSet::from([
+        Value::Did(greater_alias),
+        Value::Did(lesser),
+    ]));
+
+    assert_eq!(
+        hash_of(&spelled_one_way),
+        hash_of(&spelled_the_other_way),
+        "a set of principals must hash by its principals, not by their spelling"
+    );
+}
+
+#[test]
+fn nested_aggregates_hash_independently_of_member_spelling() {
+    let (greater, lesser) = two_principals_in_pinned_canonical_order();
+
+    let nest = |did: Did| {
+        Value::Map(HashMap::from([(
+            "members".to_string(),
+            Value::List(vec![Value::Set(HashSet::from([
+                Value::Did(did),
+                Value::Did(lesser.clone()),
+            ]))]),
+        )]))
+    };
+
+    assert_eq!(
+        hash_of(&nest(greater.clone())),
+        hash_of(&nest(alternate_spelling(&greater))),
+        "spelling must not survive nesting inside a map, list or set"
+    );
+}
+
+#[test]
+fn a_principal_hashes_the_same_however_the_did_was_constructed() {
+    // `from_anchor_id` builds a base58btc spelling without parsing; `from_str`
+    // parses a base16 one. Same 32 identifier bytes, two construction paths,
+    // two spellings — one principal, so one hash.
+    let bytes = a_principal()
+        .identifier_bytes()
+        .expect("a validated DID decodes to 32 identifier bytes");
+    let anchored = Did::from_anchor_id(&bytes);
+    let parsed = Did::from_str(&format!("did:icn:f{}", hex::encode(bytes)))
+        .expect("a base16 spelling of a valid key parses");
+
+    assert_ne!(
+        anchored.as_str(),
+        parsed.as_str(),
+        "the two spellings must differ, or the test proves nothing"
+    );
+    assert_eq!(
+        hash_of(&Value::Did(anchored)),
+        hash_of(&Value::Did(parsed)),
+        "construction path must not change which principal a value keys under"
+    );
+}
+
+#[test]
+fn an_anchor_derived_did_that_is_not_a_key_still_keys_by_its_identifier() {
+    // `from_anchor_id` bypasses parsing, so its 32 bytes need not decompress to
+    // an Ed25519 point — and such a DID has no second *parseable* spelling,
+    // because `from_str` rejects a non-point. It must still key by its
+    // identifier rather than dropping to the spelling fallback.
+    let anchor = Did::from_anchor_id(&[2u8; 32]);
+
+    assert!(
+        anchor.to_verifying_key().is_err(),
+        "control: this anchor id is deliberately not a valid Ed25519 point"
+    );
+    assert_eq!(
+        anchor
+            .identifier_bytes()
+            .expect("the identifier still resolves"),
+        [2u8; 32],
+        "control: the decoded branch is the one this DID takes"
+    );
+    assert_ne!(
+        hash_of(&Value::Did(anchor)),
+        hash_of(&Value::Did(Did::from_anchor_id(&[3u8; 32]))),
+        "two anchors are two principals"
+    );
+}
+
+#[test]
+fn a_did_value_does_not_hash_as_the_string_that_spells_it() {
+    // Guard against over-collapsing: the fix must narrow spelling out of the
+    // DID hash without merging `Value::Did` into `Value::String`.
+    let did = a_principal();
+    assert_ne!(
+        hash_of(&Value::Did(did.clone())),
+        hash_of(&Value::String(did.as_str().to_string())),
+        "a DID and the string that spells it are different values"
+    );
+}
+
+#[test]
+fn non_did_values_keep_hashing_by_their_own_content() {
+    // Determinism for the variants this change is not about.
+    for (a, b) in [
+        (Value::Int(7), Value::Int(7)),
+        (Value::String("x".into()), Value::String("x".into())),
+        (Value::Bool(true), Value::Bool(true)),
+        (Value::None, Value::None),
+        (
+            Value::List(vec![Value::Int(1), Value::Int(2)]),
+            Value::List(vec![Value::Int(1), Value::Int(2)]),
+        ),
+        (
+            Value::Set(HashSet::from([Value::Int(1), Value::Int(2)])),
+            Value::Set(HashSet::from([Value::Int(2), Value::Int(1)])),
+        ),
+        (
+            Value::Map(HashMap::from([("k".to_string(), Value::Int(1))])),
+            Value::Map(HashMap::from([("k".to_string(), Value::Int(1))])),
+        ),
+    ] {
+        assert_eq!(a, b, "control: these values are equal");
+        assert_eq!(hash_of(&a), hash_of(&b), "equal values must hash equally");
+    }
+
+    assert_ne!(
+        hash_of(&Value::Int(1)),
+        hash_of(&Value::String("1".into())),
+        "distinct variants must not be conflated"
+    );
+    assert_ne!(
+        hash_of(&Value::List(vec![Value::Int(1)])),
+        hash_of(&Value::Set(HashSet::from([Value::Int(1)]))),
+        "a list is not a set"
+    );
+}
+
+#[test]
+fn the_hash_eq_contract_holds_under_simulated_principal_equality() {
+    // The whole point of the tranche, stated as the law it enforces:
+    //
+    //     post_i7_equal(a, b)  =>  hash(a) == hash(b)
+    //
+    // `post_i7_equal` is built here from `identifier_bytes`; production `Did`
+    // equality is untouched. Every value in the corpus is well-formed after
+    // I7 — no set holds two spellings of one principal, because such a set
+    // cannot be built once insertion collapses them.
+    let p = a_principal();
+    let q = a_principal();
+    let p_alias = alternate_spelling(&p);
+    let q_alias = alternate_spelling(&q);
+
+    let corpus = vec![
+        Value::Did(p.clone()),
+        Value::Did(p_alias.clone()),
+        Value::Did(q.clone()),
+        Value::Did(q_alias.clone()),
+        Value::List(vec![Value::Did(p.clone()), Value::Did(q.clone())]),
+        Value::List(vec![
+            Value::Did(p_alias.clone()),
+            Value::Did(q_alias.clone()),
+        ]),
+        Value::Set(HashSet::from([
+            Value::Did(p.clone()),
+            Value::Did(q.clone()),
+        ])),
+        Value::Set(HashSet::from([
+            Value::Did(p_alias.clone()),
+            Value::Did(q_alias.clone()),
+        ])),
+        Value::Set(HashSet::from([
+            Value::Did(p.clone()),
+            Value::Did(q_alias.clone()),
+        ])),
+        Value::Map(HashMap::from([("owner".to_string(), Value::Did(p))])),
+        Value::Map(HashMap::from([("owner".to_string(), Value::Did(p_alias))])),
+        Value::Int(1),
+        Value::String("did:icn:not-a-did".into()),
+        Value::None,
+    ];
+
+    let mut proved_a_cross_spelling_pair = false;
+    for a in &corpus {
+        for b in &corpus {
+            let post_i7_equal = project_to_one_spelling(a) == project_to_one_spelling(b);
+            if !post_i7_equal {
+                continue;
+            }
+            assert_eq!(
+                hash_of(a),
+                hash_of(b),
+                "values equal after I7 must already hash equally:\n  {a:?}\n  {b:?}"
+            );
+            if a != b {
+                proved_a_cross_spelling_pair = true;
+            }
+        }
+    }
+
+    assert!(
+        proved_a_cross_spelling_pair,
+        "the corpus must contain a pair that is unequal today but equal after I7, \
+         or this test passes vacuously"
+    );
+}


### PR DESCRIPTION
## What this changes

`icn-ccl`'s `Value` derives `PartialEq`/`Eq`, so `Value::Did` equality follows `Did`. Its hand-written `Hash` did **not** follow `Did`:

| Site | Before |
|---|---|
| `types.rs:218` | `Value::Did(did) => format!("{did:?}").hash(state)` — the `Debug` of the spelling |
| `types.rs:229` | `Value::Set` sorted members by `format!("{a:?}")` before feeding them to the hasher |

Both now key on the principal: DIDs hash by the identifier `Did::identifier_bytes()` decodes, and `Value::Set` combines member hashes commutatively so **no** ordering key is imposed at all.

## 1. The current invariant

`did:icn:` identifiers are multibase, so one 32-byte identifier has more than one accepted textual encoding. Today `Did` equality is spelling-sensitive, so equality and this hash agree — by accident, not by construction.

## 2. The future N2-A invariant

N2-A (#2627) intends to make `Did` equality principal-sensitive (I7, `docs/architecture/IDENTITY_SEMANTICS.md` §11). At that point two equal `Value::Did`s would hash differently, and two equal `Value::Set`s would order their members differently.

That is a **violated `Hash`/`Eq` contract**, and it is silent. `HashSet<Value>` backs `Value::Set`, the `participants` special variable (`interpreter.rs:404`) and the `in` operator (`interpreter.rs:485`), so membership tests would begin returning wrong answers with no error anywhere.

This is `n2-a-migration-gate.md` §6.2 / blocker #6, implemented as that document designs it.

## 3. Why principal-oriented hashing can safely land before the equality change

Rust requires `a == b ⟹ hash(a) == hash(b)`. It does **not** require the converse, so a hash may be *coarser* than equality.

- **Today** — two spellings are unequal but now share a hash. That is a deliberate collision, which `HashSet` resolves by comparing. Behaviour is unchanged.
- **After I7** — they are equal and must hash equally. They already will.

The rule is also correct under *either* mechanism §11 permits: equality over decoded bytes, or encoding pinned at parse. If N2-A pins the encoding instead, alternate spellings never coexist and identical bytes still hash identically.

## 4. Why unequal values sharing a hash is valid

`HashSet`/`HashMap` use the hash to choose a bucket and `Eq` to decide identity within it. Colliding entries remain distinct. `a_hash_map_still_resolves_each_spelling_under_the_deliberate_collision` asserts exactly this.

## 5. Fixing only the obvious arm is not enough

Principalising the element hash while `Value::Set` still orders members by spelling leaves two *equal* sets hashing differently — the numerator fixed and the denominator still representation-sensitive. Mutation B below keeps the `Value::Did` fix, reverts only the ordering, and the aggregate tests still fail.

## 6. Tests — 11, in `icn/crates/icn-ccl/tests/value_did_hash.rs`

Identical representation; two spellings of one principal; two construction paths (`from_anchor_id` vs `from_str`); distinct principals in a `HashSet`; a `HashMap` under the deliberate collision; `Value::Set`; nesting through map → list → set; a non-Ed25519-point anchor DID; `Value::Did` vs the `Value::String` that spells it; non-DID variants unchanged.

The centrepiece is a contract harness that builds the post-I7 equality relation **locally** from `identifier_bytes` and asserts `post_i7_equal(a, b) ⟹ hash(a) == hash(b)` over a mixed corpus, with a guard that the corpus contains a pair unequal today but equal after I7 — so it cannot pass vacuously. Production `Did` equality is neither changed nor monkey-patched.

`two_principals_in_pinned_canonical_order` pins the canonical order deliberately: a base16 alias (`f…`) only re-orders against a base58btc canonical (`z…`) half the time, so without it the aggregate tests would discriminate on a coin toss.

### Mutation-discrimination proof

| Mutation | Failures |
|---|---|
| **A** — revert the `Value::Did` arm, keep the `Set` fix | 5, in 8 of 8 runs |
| **B** — revert the `Value::Set` ordering, keep the `Did` fix | 3, in 24 of 24 runs |

Both fail on hash-mismatch assertions, not on compilation.

The mutation-B row was weaker when this PR opened: the contract harness drew its two principals freely, so it caught mutation B only 13 times in 24 runs while the two dedicated set tests caught it 24/24. `6ca96729` pins the harness's principals, and all three now fail deterministically. The row above is the corrected measurement.

## 7. `Did` equality is unchanged

`Did`'s `PartialEq`, `Eq` and `Hash` are untouched. `Value`'s derived `PartialEq` still follows `Did` exactly as before. Nothing here canonicalizes a `Value`, alters CCL syntax, set semantics, DID display, serialization, contract execution or governance semantics.

## 8. N2-A migration remains blocked and owned elsewhere

The equality flip, persisted-store dispositions, the collision scan and the §7.5 membership/vote re-key are **not** in this PR and remain owned by #2627. This only shrinks the surface that must change in one atomic patch.

## Deterministic-semantics impact — stated, not hidden

The **hash values** of `Value::Did` and `Value::Set` change for every value, including non-DID sets. Two consequences follow, and the second is not "unobservable" — it is *unchanged in kind*, which is a weaker and more accurate claim than this section originally made.

Verified rather than assumed:

- `Hash for Value` has no consumer outside `HashSet<Value>` within `icn-ccl`;
- no crate keys a `HashMap`/`HashSet`/`BTreeMap`/`BTreeSet` by `icn_ccl::Value`;
- no content hasher, signing path, canonical encoder or persisted key encoding consumes `Value`'s std `Hash` output;
- std collection hashing is `RandomState`-seeded, so it is process-local by construction.

**Disclosed, not claimed away.** `HashSet<Value>` iteration order is a function of member hashes, it is read at `interpreter.rs:344`, and the resulting `Value` is serialized at `icn-compute/src/executor.rs:161` into the replicated compute result that `actor/lifecycle.rs` hashes and majority-votes. So CCL set iteration order does reach a consensus-compared payload. That order was **already** `RandomState`-seeded and already varied per process before this diff; this change alters *which* nondeterministic order results, not whether one is deterministic. The underlying determinism hazard is pre-existing, is owned by neither this PR nor #2627, and is recorded in the follow-up ledger.

**One correction to an earlier claim in this body.** It previously asserted that no fixed-seed hasher is ever applied to a `Value`. That is untrue of this PR's own code: the `Value::Set` arm uses a fixed-seed `DefaultHasher` per member (`types.rs:277`) to make member digests comparable to one another. The consequence is that two sets with equal `(len, combined)` now collide in every process rather than unpredictably per process. That is recorded in the follow-up ledger with its reachability analysis; the sound alternatives are worse, since sorting members by digest is unsound on digest ties and would reintroduce the exact `Hash`/`Eq` violation this PR fixes.

No public API, serialization, canonical encoding or wire format moves. `Value::Set` hashing also gets cheaper: `O(n)` with no allocation, replacing an `O(n log n)` sort that allocated a `format!` string per comparison.

## Out of scope — reported, not changed

`ContractActor::compute_code_hash` (`icn-ccl/src/actor.rs:311`) derives a `ContentHash` via SHA-256 over `format!("{participant:?}")`, across an order-sensitive `Vec<Did>`. That is a **persisted, deployment-visible identifier derived from DID spelling** — the same family as the `icn-commons` weak-holder id that #2627 §5 classifies as *"A — and a blocking prerequisite"* — but it is **absent from that issue's namespace table**. Changing it would move every deployed contract's `ContentHash`, so it belongs to the N2-A lane, not here. Five `messages.rs` sites and `actor.rs:356` are `#[cfg(test)]` twins of the same rule.

## Verification

- `cargo fmt --all --check` — clean
- `cargo clippy --workspace --all-targets --all-features -- -D warnings` — exit 0
- `cargo test -p icn-ccl` — 247 passed, 0 failed
- `ops/scripts/drift-check.sh` — PASS

## Coordination

Branched from `main` at `83682563`. Verified disjoint from the active N2-A branch `claude/icn-identity-n2-a-811d17` (`9299b8ba`), which touches `docs/`, `icn-identity` and `icn-store` only. This PR uses `Did::identifier_bytes()` as a caller; that lane's in-flight refactor changes its body, not its signature.

Refs #2627

## Transitional exposure — the one thing that argues against pre-landing

Principal-oriented hashing plus still-spelling-sensitive equality means alternate spellings of one principal are Eq-**distinct** but hash **identically**. `Did::from_str` accepts 17 spellings of one principal, so a length-`k` `Value::List` yields 17^k Eq-distinct values sharing one hash, with no search required. Untrusted `HashMap<String, icn_ccl::Value>` deserialization at `icn-rpc/src/handler/contract.rs:192` and `icn-compute/src/executor.rs:147` has no body or cardinality bound.

Measured end-to-end at comparable payload size (attack = lists over one principal's spellings; control = same shape over distinct principals):

| n | attack payload | attack | control payload | control | ratio |
|---|---|---|---|---|---|
| 2000 | 572 KB | 217 ms | 534 KB | 176 ms | 1.2x |
| 4000 | 1.14 MB | 673 ms | 1.07 MB | 369 ms | 1.8x |
| 8000 | 2.28 MB | 2.50 s | 2.13 MB | 702 ms | 3.6x |

Insertion alone is cleanly quadratic. This family exists **only** in the transitional window: before this PR the spellings hash apart, and after I7 they are equal, so a `HashSet` holds one member rather than colliding. Within this lane the window is unavoidable — the alternative mechanism §11 I7 permits, pinning the encoding at parse, changes DID acceptance rules and belongs to #2627.

It fails `materially_breaks_it` on these numbers, because the control is already 702 ms for 2.1 MB unattacked: the dominant defect on this path is the absent input bound, which is pre-existing. The trade — pre-land with a quantified transitional amplification, or hold this atomic with the I7 flip and accept a larger single patch — was put to the maintainer, who decided to pre-land. Removing the CCL hash correction from N2-A's atomic patch is the purpose of this lane and is judged worth that delta. The fix direction for the underlying bound is recorded in #2682.

## Review outcome

One FULL review generation, STANDARD lane, against `861ad047`: **0 BLOCKER · 3 FOLLOW_UP · 0 QUESTION · 3 NOT_A_FINDING**. Nothing satisfied every condition in `blocker_predicate.all_must_hold`.

Two further automated review threads landed afterwards. One — a latent panic in the test helper's post-I7 projection — is fixed in `d07d8ba9` and resolved. The other raises a transitional hash-collision exposure that is **`introduced_here` = true** and is measured in the follow-up ledger, #2682; the maintainer decision was to pre-land as-is, so it is ledgered and resolved. It is summarised in "Transitional exposure" below.

All three of the FULL generation's follow-ups concerned the accuracy of this body rather than the deliverable. One was closed in code (`6ca96729`, the harness pinning); the other two are recorded in the follow-up ledger, #2682, and this body is corrected above. The reviewer independently re-derived the both-regimes correctness argument variant by variant and found no counterexample in either direction, and independently verified the consumer/scope claims rather than accepting them.

<!-- ICN-DELIVERY-LIFECYCLE:BEGIN -->
```
ICN DELIVERY LIFECYCLE
State:                FROZEN
Lane:                 STANDARD
Acceptance contract:  See "What this changes" and the non-goals stated throughout this body.
Review generation:    CLOSED
Freeze head:          b675eae1a27260f54c49291e3439783d4e293df4
Known blockers:       0
Follow-up ledger:     #2682
```

**Freeze provenance.** The reviewed artifact was `1bf1853624e958bb3ecd9c03cee71a4aea5e0351`.
`main` then advanced to `81297c429ac817dbb25350cd4d0ed0d48c05e48e` (#2680), and this
repository requires branches to be up to date before merging (`strict: true`), so the branch
was brought up to date with the maintainer's explicit authorization. The new freeze head
`b675eae1a27260f54c49291e3439783d4e293df4` is a merge commit whose **first parent is the
reviewed head** and whose second parent is that `main` — nothing was rewritten, rebased, or
hand-edited.

Equivalence of the PR-owned change was verified rather than assumed: the git blob hashes of
both changed files are byte-identical across the update
(`icn-ccl/src/types.rs` `3f552cd40492972d5077dc91f4ae141d3f83c3c0`,
`icn-ccl/tests/value_did_hash.rs` `7da3ce7859ba0ed93c20f0f9b7a6ba1b83dd9662`), and the
effective diff against current `main` is still exactly those two files.

Integration surface with #2680: `types.rs` imports only `icn_identity::Did` and calls
`did.identifier_bytes()`. #2680 extracted that method's body into a new free
`identifier_bytes_of_spelling()` and made the method delegate; the method's signature and
behaviour are unchanged, and #2681 does not use the new free function. The reviewed reasoning
is therefore intact, and no re-review of the unchanged CCL logic was performed or needed.
<!-- ICN-DELIVERY-LIFECYCLE:END -->
