### PR TITLE
test(net): make PeerId::Ord's dependency on the I7 Did equality change mechanical

### DIFF
--- a/icn/crates/icn-net/tests/peerid_i7_ordering_tripwire.rs
+++ b/icn/crates/icn-net/tests/peerid_i7_ordering_tripwire.rs
@@ -39,9 +39,22 @@
 //! [`peerid_eq_and_ord_must_agree_in_whatever_regime_production_is_in`] asserts the
 //! biconditional itself rather than either side's current value. It therefore passes on today's
 //! `main`, passes again after a *correct* I7 patch that moves `Did::Eq` and `PeerId::Ord`
-//! together, and fails **only** in the half-completed state. A test that instead asserted
+//! together, and fails **only** in a half-completed state. A test that instead asserted
 //! "these are unequal today" would go red on a correct future patch, which would train the next
 //! implementer to delete it.
+//!
+//! That property is easy to lose by accident, so it is measured rather than assumed. Every
+//! test here except [`pre_i7_regime_record_every_spelling_is_its_own_peer`] — which is
+//! deliberately regime-dependent and says so — was run against a simulated correct I7 patch
+//! (`Did` equality and hash over `identifier_bytes`, `PeerId::Ord` over the same, both with a
+//! defined order for identifiers that do not decode) and stayed green. Anything added here
+//! should be checked the same way: a guard that fires on the *correct* patch is worse than no
+//! guard, because it argues for its own deletion at exactly the wrong moment.
+//!
+//! One trap worth naming for whoever re-runs that check: restoring a mutated file with a tool
+//! that preserves mtime (`cp -p`, `shutil.copy2`) sets the timestamp backwards, so cargo
+//! considers the crate fresh and silently keeps the mutated rlib. Confirm `Compiling
+//! icn-identity` and `Compiling icn-net` actually appear before believing a result.
 //!
 //! # The identity source
 //!
@@ -286,19 +299,24 @@ fn peerid_eq_and_ord_must_agree_in_whatever_regime_production_is_in() {
                  silently drops peers from ordered collections today. Revert it."
             );
 
-            if !eq_says_same && same_principal_after_i7(a, b) {
+            // Counted on properties that do not move with the regime: two *different
+            // spellings* of *one principal*. Counting "currently unequal but one principal
+            // after I7" instead would reach zero once `Did::Eq` adopts I7 — the non-vacuity
+            // guard would then fire on the correct patch and tell its implementer, wrongly,
+            // that the coherence assertion above proved nothing.
+            if a.0.as_str() != b.0.as_str() && same_principal_after_i7(a, b) {
                 transition_relevant_pairs += 1;
             }
         }
     }
 
-    // Non-vacuity: the assertion above is only load-bearing if the population contains pairs
-    // that I7 will actually move. If a future edit removes the alias generation, this fails
-    // rather than letting the suite pass on trivial pairs.
+    // Non-vacuity: the assertion above is only load-bearing if the population contains more
+    // than one spelling of some principal. If a future edit removes the alias generation, this
+    // fails rather than letting the suite pass on trivially-distinct pairs.
     assert!(
         transition_relevant_pairs > 0,
-        "no pair in the population is unequal today but one principal after I7, so the \
-         coherence assertion above proved nothing about the transition"
+        "no two members of the population are different spellings of one principal, so the \
+         coherence assertion above was only exercised on pairs no regime change can move"
     );
 }
 
@@ -398,17 +416,16 @@ fn neighbour_sets_ordered_and_hashed_views_report_the_same_peers() {
          `BTreeSet<PeerId>` fields key on `PeerId::Ord` and `metadata: HashMap<PeerId, _>` \
          keys on the derived `Hash`/`Eq`. After I7 (#2627) the map follows `Did` into \
          principal identity and the sets do not, unless `PeerId::Ord` changes in the same \
-         patch — at which point `total_count()`, the neighbour-class limits enforced from \
-         `handlers/hello.rs` and `handlers/handshake.rs`, and `remove_neighbor` all disagree \
-         with each other.",
+         patch — at which point `enforce_limit`, which counts a class with `set_ref.len()` \
+         (`topology.rs`), and `remove_neighbor` disagree with the metadata map.",
         ordered.len(),
         metadata.len()
     );
     assert_eq!(
         sets.total_count(),
         metadata.len(),
-        "`total_count()` is summed from the ordered sets and is what neighbour limits are \
-         checked against; it must agree with the metadata map for the same reason"
+        "`total_count()` sums the four ordered sets, so it must agree with the metadata map \
+         for the same reason"
     );
 }
 
@@ -421,6 +438,12 @@ fn no_neighbour_is_left_without_metadata_and_no_metadata_is_orphaned() {
     for (_, peer) in &spellings {
         sets.add_neighbor(peer.clone(), topology("eu", "c1"), None, 0.1, &limits);
     }
+
+    // A second, unrelated principal that survives the removal below. Without it, a correct I7
+    // patch would collapse the 23 spellings to one peer, the removal would empty the struct,
+    // and the final assertion would compare two empty sets — green, and proving nothing.
+    let bystander = a_peer();
+    sets.add_neighbor(bystander.clone(), topology("eu", "c1"), None, 0.1, &limits);
 
     // Remove under one spelling. `remove_neighbor` deletes from the ordered sets by `Ord` and
     // from `metadata` by `Hash`/`Eq`; if those stop agreeing, one of the two deletions misses.
@@ -440,7 +463,7 @@ fn no_neighbour_is_left_without_metadata_and_no_metadata_is_orphaned() {
 }
 
 #[test]
-fn a_peer_lands_in_at_most_one_neighbour_class() {
+fn the_promotion_path_leaves_ordered_and_hashed_views_agreeing() {
     // `add_neighbor` starts by calling `remove_neighbor`, precisely so re-adding a peer under
     // new topology moves it rather than duplicating it. That step removes from the ordered
     // sets by `Ord` and from `metadata` by `Hash`/`Eq`. When those disagree, the ordered
@@ -465,32 +488,35 @@ fn a_peer_lands_in_at_most_one_neighbour_class() {
         &limits,
     );
 
-    let classes: [(&str, &BTreeSet<PeerId>); 4] = [
-        ("local_cluster", &sets.local_cluster),
-        ("regional", &sets.regional),
-        ("backbone", &sets.backbone),
-        ("trusted", &sets.trusted),
-    ];
+    // Regime-agnostic control: the second `add_neighbor` used a different region, so it must
+    // have placed its peer in `backbone` whether or not that peer was recognised as the same
+    // one already in `local_cluster`. Asserting the *number* of occupied classes instead would
+    // be regime-dependent — two today, one after a correct I7 patch.
+    assert!(
+        !sets.backbone.is_empty(),
+        "CONTROL: the re-add under a different region must have exercised the promotion path, \
+         or the assertion below proves nothing about it"
+    );
 
-    for (_, peer) in spellings.iter().take(2) {
-        let occupied: Vec<&str> = classes
-            .iter()
-            .filter(|(_, set)| set.contains(peer))
-            .map(|(name, _)| *name)
-            .collect();
-        assert!(
-            occupied.len() <= 1,
-            "one peer occupies {occupied:?} simultaneously. `add_neighbor` removes from every \
-             class before inserting, so this can only happen when the ordered removal fails to \
-             match a peer the hashed side considers the same — the I7 half-completion this \
-             file guards (#2627)."
-        );
-    }
-
+    // What is *not* asserted here, because getting it wrong is easy in both directions:
+    //
+    // "one principal occupies at most one class" is a **post-I7** invariant, not a current one.
+    // Today two spellings are two peers, so one principal legitimately sits in `local_cluster`
+    // and `backbone` at once; asserting otherwise is red on `main`. The mirror-image phrasing,
+    // "one `PeerId` occupies at most one class", is regime-agnostic but can never fail:
+    // `remove_neighbor` and the insert both dispatch on `Ord`, so `BTreeSet::contains` answers
+    // "one" in every regime, including the broken one.
+    //
+    // What is regime-agnostic *and* can fail is the disagreement the duplication comes from.
+    // Under a half-completed I7 patch the ordered removal misses a peer the hashed side has
+    // already merged, so the ordered rows outnumber the metadata rows — the observable form of
+    // "this principal now sits in two classes with one metadata row between them".
     assert_eq!(
         ordered_rows(&sets).len(),
         metadata_rows(&sets).len(),
-        "the promotion path must leave the ordered and hashed views agreeing too"
+        "the promotion path left {} ordered entries against {} metadata rows",
+        ordered_rows(&sets).len(),
+        metadata_rows(&sets).len()
     );
 }
 

--- a/icn/crates/icn-net/tests/peerid_i7_ordering_tripwire.rs
+++ b/icn/crates/icn-net/tests/peerid_i7_ordering_tripwire.rs
@@ -1,0 +1,585 @@
+//! #2627 / I7 — `PeerId::Ord` is atomic with the `Did` equality change.
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+//!
+//! # What this file is for
+//!
+//! `IDENTITY_SEMANTICS.md` §11 I7 intends `Did` equality to become *key* equality — two
+//! textual spellings that decode to one 32-byte identifier become one principal. `PeerId`
+//! derives `PartialEq`/`Eq`/`Hash` from `Did`, so those follow automatically. Its `Ord` does
+//! not: `topology.rs` compares `self.0.to_string()`, the spelling.
+//!
+//! Rust's ordered collections rely on the two agreeing:
+//!
+//! ```text
+//! a == b   <=>   a.cmp(b) == Ordering::Equal
+//! ```
+//!
+//! Today both sides are *false* for a re-spelled pair, so they agree. After I7 the left side
+//! becomes true; unless `PeerId::Ord` changes in the same patch, the right side stays false and
+//! a `BTreeSet<PeerId>` will hold two entries that compare equal while a `HashMap<PeerId, _>`
+//! holds one. `NeighborSets` uses **both** for the same peers, so the two halves of one struct
+//! would then disagree about how many peers exist, whether a removal succeeded, and whether a
+//! neighbour-class limit is reached.
+//!
+//! # Why `PeerId::Ord` cannot simply be fixed ahead of time
+//!
+//! Consistency has to hold in whichever regime production is in:
+//!
+//! * **today** `a == b` is false for a re-spelled pair, so `cmp` must **not** return `Equal`;
+//! * **after I7** `a == b` is true for that same pair, so `cmp` **must** return `Equal`.
+//!
+//! No single comparator satisfies both while `Did::Eq` is unchanged. Ordering by identifier
+//! bytes today would make `cmp` return `Equal` for values that are still `!=`, and a
+//! `BTreeSet` would silently drop one of two currently-distinct peers — the inverse violation,
+//! and a live regression rather than a latent one. So the comparator moves *with* I7, and this
+//! file exists to make that dependency mechanical instead of remembered.
+//!
+//! # How the tripwire is built so it is never wrong
+//!
+//! [`peerid_eq_and_ord_must_agree_in_whatever_regime_production_is_in`] asserts the
+//! biconditional itself rather than either side's current value. It therefore passes on today's
+//! `main`, passes again after a *correct* I7 patch that moves `Did::Eq` and `PeerId::Ord`
+//! together, and fails **only** in the half-completed state. A test that instead asserted
+//! "these are unequal today" would go red on a correct future patch, which would train the next
+//! implementer to delete it.
+//!
+//! # The identity source
+//!
+//! The projection helpers key on [`Did::identifier_bytes`] — the accessor N2-A itself intends
+//! to use, and the only one defined across the whole accepted `Did` domain.
+//! `SenderPrincipal::from_did` is deliberately **not** used: it is narrower, failing for any
+//! DID that does not decode to an Ed25519 point, and
+//! [`an_anchor_derived_principal_is_a_first_class_peer`] proves that difference is real rather
+//! than theoretical.
+
+use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
+
+use icn_identity::{Did, KeyPair};
+use icn_net::{NeighborLimitsConfig, NeighborSets, NodeRole, PeerId, TopologyInfo};
+
+/// Every base that can spell an Ed25519 key *other than* the canonical base58btc.
+///
+/// Kept identical to the list in `tests/respelled_envelope_replay.rs` and
+/// `handlers/signed.rs`, which is the repository's measured acceptance class for
+/// `Did::from_str` (`docs/architecture/n2-a0-stored-key-inventory.md`). `Identity` is absent
+/// because `multibase::encode` panics on non-UTF-8 bytes; `Base58Btc` is absent because it is
+/// what `Did::from_public_key` emits.
+const ALTERNATE_SPELLINGS: [(&str, multibase::Base); 22] = [
+    ("base2", multibase::Base::Base2),
+    ("base8", multibase::Base::Base8),
+    ("base10", multibase::Base::Base10),
+    ("base16-lower", multibase::Base::Base16Lower),
+    ("base16-upper", multibase::Base::Base16Upper),
+    ("base32-lower", multibase::Base::Base32Lower),
+    ("base32-upper", multibase::Base::Base32Upper),
+    ("base32-pad-lower", multibase::Base::Base32PadLower),
+    ("base32-pad-upper", multibase::Base::Base32PadUpper),
+    ("base32-hex-lower", multibase::Base::Base32HexLower),
+    ("base32-hex-upper", multibase::Base::Base32HexUpper),
+    ("base32-hex-pad-lower", multibase::Base::Base32HexPadLower),
+    ("base32-hex-pad-upper", multibase::Base::Base32HexPadUpper),
+    ("base32-z", multibase::Base::Base32Z),
+    ("base36-lower", multibase::Base::Base36Lower),
+    ("base36-upper", multibase::Base::Base36Upper),
+    ("base58-flickr", multibase::Base::Base58Flickr),
+    ("base64", multibase::Base::Base64),
+    ("base64-pad", multibase::Base::Base64Pad),
+    ("base64-url", multibase::Base::Base64Url),
+    ("base64-url-pad", multibase::Base::Base64UrlPad),
+    ("base256-emoji", multibase::Base::Base256Emoji),
+];
+
+/// The identifier a DID names, by the rule `icn-identity` owns and N2-A intends to key on.
+fn principal_of(did: &Did) -> [u8; 32] {
+    did.identifier_bytes()
+        .expect("every DID reachable through a public constructor decodes to 32 bytes")
+}
+
+/// The equality relation I7 intends to install, computed locally.
+///
+/// Production `Did::PartialEq` is **not** touched, monkey-patched or shadowed anywhere in this
+/// file. This is only how the tests know which pairs the transition will move.
+fn same_principal_after_i7(a: &PeerId, b: &PeerId) -> bool {
+    principal_of(&a.0) == principal_of(&b.0)
+}
+
+/// Re-spell one principal under one base.
+///
+/// A spelling that stops parsing is a failure, not a skip: under current policy every base
+/// here is accepted, and letting a rejection quietly reduce coverage is how this kind of suite
+/// rots. If N2-A pins encodings at parse instead, that is a real behaviour change and belongs
+/// here explicitly.
+fn alias_in(base: multibase::Base, label: &str, canonical: &Did) -> Did {
+    let bytes = principal_of(canonical);
+    let alias = Did::from_str(&format!("did:icn:{}", multibase::encode(base, bytes)))
+        .unwrap_or_else(|e| {
+            panic!(
+                "the {label} spelling is accepted by `Did::from_str` under current policy and \
+                 this suite's coverage depends on it; it was rejected: {e}. If that is an \
+                 intentional tightening (N2-A / #2627), move {label} out of \
+                 ALTERNATE_SPELLINGS and assert its rejection explicitly."
+            )
+        });
+    assert_ne!(
+        alias.as_str(),
+        canonical.as_str(),
+        "CONTROL: the {label} alias must be a different *string*, or it proves nothing"
+    );
+    assert_eq!(
+        principal_of(&alias),
+        bytes,
+        "CONTROL: the {label} alias must name the *same principal*, or it is a different peer"
+    );
+    alias
+}
+
+/// One principal, spelled every accepted way: canonical first, then all 22 aliases.
+fn one_principal_every_spelling() -> Vec<(&'static str, PeerId)> {
+    let canonical = KeyPair::generate().unwrap().did().clone();
+    let mut out = vec![("base58btc-canonical", PeerId(canonical.clone()))];
+    out.extend(
+        ALTERNATE_SPELLINGS
+            .iter()
+            .map(|(label, base)| (*label, PeerId(alias_in(*base, label, &canonical)))),
+    );
+    out
+}
+
+fn a_peer() -> PeerId {
+    PeerId(KeyPair::generate().unwrap().did().clone())
+}
+
+fn topology(region: &str, cluster: &str) -> TopologyInfo {
+    TopologyInfo {
+        region: region.to_string(),
+        cluster_id: cluster.to_string(),
+        role: NodeRole::Edge,
+    }
+}
+
+// ---------------------------------------------------------------------------
+// 1. Container agreement, and a record of the current regime.
+// ---------------------------------------------------------------------------
+
+/// Regime-independent: whatever a re-spelled principal counts as, both containers must agree.
+///
+/// This never needs editing. One principal spelled 23 ways is 23 peers today and 1 peer after
+/// I7; either answer is coherent, and the two containers disagreeing is not.
+#[test]
+fn ordered_and_hashed_agree_on_one_respelled_principal() {
+    let spellings = one_principal_every_spelling();
+
+    for (_, peer) in &spellings {
+        assert_eq!(
+            principal_of(&peer.0),
+            principal_of(&spellings[0].1 .0),
+            "CONTROL: every spelling names one principal, so the counts below are about \
+             spelling alone"
+        );
+    }
+
+    // Built the way production builds them: `NeighborSets::add_neighbor` calls
+    // `BTreeSet::insert`, one peer at a time.
+    let mut ordered = BTreeSet::new();
+    let mut hashed = HashSet::new();
+    for (_, peer) in &spellings {
+        ordered.insert(peer.clone());
+        hashed.insert(peer.clone());
+    }
+
+    assert_eq!(
+        ordered.len(),
+        hashed.len(),
+        "a BTreeSet sees {} spellings of one principal and a HashSet sees {}. See \
+         `peerid_eq_and_ord_must_agree_in_whatever_regime_production_is_in` for the cause: \
+         `PeerId::Ord` and the derived `Hash`/`Eq` have stopped agreeing.",
+        ordered.len(),
+        hashed.len()
+    );
+
+    // A second, independent consequence of the same incoherence, worth asserting because it is
+    // so easy to miss: `BTreeSet` has two construction paths, and they only agree while `Ord`
+    // is a correct total order consistent with `Eq`. `FromIterator` sorts and bulk-builds;
+    // `insert` descends the tree. Measured under a simulated I7 half-completion, the same 23
+    // values gave 1 by `collect` and 23 by `insert` — the same container, built two ways,
+    // disagreeing about its own contents.
+    let collected: BTreeSet<PeerId> = spellings.iter().map(|(_, p)| p.clone()).collect();
+    assert_eq!(
+        collected.len(),
+        ordered.len(),
+        "`BTreeSet` built by `collect` holds {} peers and the same values inserted one at a \
+         time hold {}. A container cannot disagree with itself unless `PeerId::Ord` is no \
+         longer a total order consistent with `PeerId::Eq` — see the tripwire test in this \
+         file, and #2627.",
+        collected.len(),
+        ordered.len()
+    );
+}
+
+/// A record of which regime production is in. **Expected to be edited by the I7 patch.**
+///
+/// Unlike every other test here this one is deliberately regime-*dependent*, so that the count
+/// change is visible in the I7 diff rather than implicit. It is not a requirement that the
+/// count stay 23.
+#[test]
+fn pre_i7_regime_record_every_spelling_is_its_own_peer() {
+    let spellings = one_principal_every_spelling();
+    assert_eq!(spellings.len(), 23, "canonical plus 22 aliases");
+
+    let mut ordered = BTreeSet::new();
+    for (_, peer) in &spellings {
+        ordered.insert(peer.clone());
+    }
+
+    assert_eq!(
+        ordered.len(),
+        23,
+        "one principal spelled 23 ways currently counts as {} peers, not 23.\n\
+         \n\
+         If it is 1, `Did` equality has adopted I7 (#2627) — that is the intended destination, \
+         not a bug. Confirm that \
+         `peerid_eq_and_ord_must_agree_in_whatever_regime_production_is_in` and the \
+         `NeighborSets` tests in this file are green, then change this expectation to 1. Do \
+         not change it while any of those is red: that would be recording the half-completed \
+         state as if it were the goal.",
+        ordered.len()
+    );
+}
+
+// ---------------------------------------------------------------------------
+// 2. The tripwire.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn peerid_eq_and_ord_must_agree_in_whatever_regime_production_is_in() {
+    // Rust's law for ordered collections, asserted as a biconditional so it holds before and
+    // after I7 and fails only in between.
+    let spellings = one_principal_every_spelling();
+    let unrelated = a_peer();
+
+    let mut population: Vec<(&str, PeerId)> = spellings.clone();
+    population.push(("unrelated-principal", unrelated));
+
+    let mut transition_relevant_pairs = 0usize;
+
+    for (label_a, a) in &population {
+        for (label_b, b) in &population {
+            let eq_says_same = a == b;
+            let ord_says_same = a.cmp(b) == std::cmp::Ordering::Equal;
+
+            assert_eq!(
+                eq_says_same, ord_says_same,
+                "`PeerId` `Eq` and `Ord` disagree about {label_a} vs {label_b}.\n\
+                 \n\
+                 If `Eq` says equal and `Ord` does not, `Did` equality has adopted I7 \
+                 (#2627, IDENTITY_SEMANTICS.md §11) while `PeerId::Ord` in \
+                 `icn-net/src/topology.rs` still compares `self.0.to_string()`. Those two \
+                 changes are ATOMIC: a `BTreeSet<PeerId>` would hold two entries that compare \
+                 equal, and `NeighborSets` would disagree with its own metadata map.\n\
+                 \n\
+                 Fix: order `PeerId` by `Did::identifier_bytes()` in the same patch that \
+                 changes `Did` equality, with a total tie-break for any identifier that does \
+                 not decode. Do NOT relax this assertion.\n\
+                 \n\
+                 If `Ord` says equal and `Eq` does not, someone made `PeerId::Ord` \
+                 principal-aware BEFORE `Did::Eq` — that is the inverse violation and it \
+                 silently drops peers from ordered collections today. Revert it."
+            );
+
+            if !eq_says_same && same_principal_after_i7(a, b) {
+                transition_relevant_pairs += 1;
+            }
+        }
+    }
+
+    // Non-vacuity: the assertion above is only load-bearing if the population contains pairs
+    // that I7 will actually move. If a future edit removes the alias generation, this fails
+    // rather than letting the suite pass on trivial pairs.
+    assert!(
+        transition_relevant_pairs > 0,
+        "no pair in the population is unequal today but one principal after I7, so the \
+         coherence assertion above proved nothing about the transition"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// 3. The paired-container law, on bare collections.
+// ---------------------------------------------------------------------------
+
+/// Ordered and hashed containers must partition the same peers the same way.
+///
+/// This is the invariant `NeighborSets` depends on, isolated from it. It is stated without
+/// reference to which regime is current, so it holds before and after I7.
+fn assert_containers_partition_identically(population: &[(&str, PeerId)]) {
+    for (label_a, a) in population {
+        for (label_b, b) in population {
+            let mut ordered = BTreeSet::new();
+            ordered.insert(a.clone());
+            ordered.insert(b.clone());
+
+            let mut hashed = HashSet::new();
+            hashed.insert(a.clone());
+            hashed.insert(b.clone());
+
+            assert_eq!(
+                ordered.len(),
+                hashed.len(),
+                "a BTreeSet and a HashSet disagree about whether {label_a} and {label_b} are \
+                 one peer or two. Ordered containers key on `PeerId::Ord`, hashed ones on the \
+                 derived `Hash`/`Eq`; when `Did` equality moves to identifier bytes (I7, \
+                 #2627) the derived half follows and `Ord` does not unless it is changed in \
+                 the same patch."
+            );
+
+            let mut ordered_map = BTreeMap::new();
+            ordered_map.insert(a.clone(), "a");
+            ordered_map.insert(b.clone(), "b");
+
+            let mut hashed_map = HashMap::new();
+            hashed_map.insert(a.clone(), "a");
+            hashed_map.insert(b.clone(), "b");
+
+            assert_eq!(
+                ordered_map.len(),
+                hashed_map.len(),
+                "a BTreeMap and a HashMap disagree about {label_a} vs {label_b} — same cause \
+                 as the set case above"
+            );
+        }
+    }
+}
+
+#[test]
+fn ordered_and_hashed_containers_partition_peers_identically() {
+    let mut population = one_principal_every_spelling();
+    population.push(("second-principal", a_peer()));
+    population.push(("third-principal", a_peer()));
+    assert_containers_partition_identically(&population);
+}
+
+// ---------------------------------------------------------------------------
+// 4. The real structure: NeighborSets holds one identity under both regimes.
+// ---------------------------------------------------------------------------
+
+/// The metadata key set, observed through the public API.
+///
+/// `metadata` is private, but `peers_needing_rtt_refresh` enumerates it: `is_rtt_stale()`
+/// returns true when no RTT was ever recorded, so with none recorded this is every metadata
+/// row. No sleeping and no timing dependency.
+fn metadata_rows(sets: &NeighborSets) -> Vec<PeerId> {
+    sets.peers_needing_rtt_refresh()
+}
+
+fn ordered_rows(sets: &NeighborSets) -> Vec<PeerId> {
+    let mut all: Vec<PeerId> = Vec::new();
+    all.extend(sets.local_cluster.iter().cloned());
+    all.extend(sets.regional.iter().cloned());
+    all.extend(sets.backbone.iter().cloned());
+    all.extend(sets.trusted.iter().cloned());
+    all
+}
+
+#[test]
+fn neighbour_sets_ordered_and_hashed_views_report_the_same_peers() {
+    let mut sets = NeighborSets::new(topology("eu", "c1"));
+    let limits = NeighborLimitsConfig::default();
+
+    for (_, peer) in one_principal_every_spelling() {
+        sets.add_neighbor(peer, topology("eu", "c1"), None, 0.1, &limits);
+    }
+
+    let ordered = ordered_rows(&sets);
+    let metadata = metadata_rows(&sets);
+
+    assert_eq!(
+        ordered.len(),
+        metadata.len(),
+        "`NeighborSets` ordered sets hold {} peers while its metadata map holds {}. The four \
+         `BTreeSet<PeerId>` fields key on `PeerId::Ord` and `metadata: HashMap<PeerId, _>` \
+         keys on the derived `Hash`/`Eq`. After I7 (#2627) the map follows `Did` into \
+         principal identity and the sets do not, unless `PeerId::Ord` changes in the same \
+         patch — at which point `total_count()`, the neighbour-class limits enforced from \
+         `handlers/hello.rs` and `handlers/handshake.rs`, and `remove_neighbor` all disagree \
+         with each other.",
+        ordered.len(),
+        metadata.len()
+    );
+    assert_eq!(
+        sets.total_count(),
+        metadata.len(),
+        "`total_count()` is summed from the ordered sets and is what neighbour limits are \
+         checked against; it must agree with the metadata map for the same reason"
+    );
+}
+
+#[test]
+fn no_neighbour_is_left_without_metadata_and_no_metadata_is_orphaned() {
+    let mut sets = NeighborSets::new(topology("eu", "c1"));
+    let limits = NeighborLimitsConfig::default();
+    let spellings = one_principal_every_spelling();
+
+    for (_, peer) in &spellings {
+        sets.add_neighbor(peer.clone(), topology("eu", "c1"), None, 0.1, &limits);
+    }
+
+    // Remove under one spelling. `remove_neighbor` deletes from the ordered sets by `Ord` and
+    // from `metadata` by `Hash`/`Eq`; if those stop agreeing, one of the two deletions misses.
+    sets.remove_neighbor(&spellings[0].1);
+
+    let ordered: HashSet<PeerId> = ordered_rows(&sets).into_iter().collect();
+    let metadata: HashSet<PeerId> = metadata_rows(&sets).into_iter().collect();
+
+    assert_eq!(
+        ordered, metadata,
+        "after a removal the ordered sets and the metadata map name different peers. A peer in \
+         an ordered set with no metadata row is scored `unwrap_or(0.0)` by `enforce_limit` and \
+         becomes a permanent eviction candidate; a metadata row with no ordered entry is \
+         unreachable state that nothing prunes. Both appear at I7 (#2627) if `PeerId::Ord` is \
+         not moved to identifier bytes alongside `Did` equality."
+    );
+}
+
+#[test]
+fn a_peer_lands_in_at_most_one_neighbour_class() {
+    // `add_neighbor` starts by calling `remove_neighbor`, precisely so re-adding a peer under
+    // new topology moves it rather than duplicating it. That step removes from the ordered
+    // sets by `Ord` and from `metadata` by `Hash`/`Eq`. When those disagree, the ordered
+    // removal misses and the peer ends up in two classes at once.
+    let mut sets = NeighborSets::new(topology("eu", "c1"));
+    let limits = NeighborLimitsConfig::default();
+    let spellings = one_principal_every_spelling();
+
+    // Same principal, first as a local-cluster peer, then re-added as a backbone peer.
+    sets.add_neighbor(
+        spellings[0].1.clone(),
+        topology("eu", "c1"),
+        None,
+        0.1,
+        &limits,
+    );
+    sets.add_neighbor(
+        spellings[1].1.clone(),
+        topology("us", "c9"),
+        None,
+        0.1,
+        &limits,
+    );
+
+    let classes: [(&str, &BTreeSet<PeerId>); 4] = [
+        ("local_cluster", &sets.local_cluster),
+        ("regional", &sets.regional),
+        ("backbone", &sets.backbone),
+        ("trusted", &sets.trusted),
+    ];
+
+    for (_, peer) in spellings.iter().take(2) {
+        let occupied: Vec<&str> = classes
+            .iter()
+            .filter(|(_, set)| set.contains(peer))
+            .map(|(name, _)| *name)
+            .collect();
+        assert!(
+            occupied.len() <= 1,
+            "one peer occupies {occupied:?} simultaneously. `add_neighbor` removes from every \
+             class before inserting, so this can only happen when the ordered removal fails to \
+             match a peer the hashed side considers the same — the I7 half-completion this \
+             file guards (#2627)."
+        );
+    }
+
+    assert_eq!(
+        ordered_rows(&sets).len(),
+        metadata_rows(&sets).len(),
+        "the promotion path must leave the ordered and hashed views agreeing too"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// 5. Controls.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn distinct_principals_stay_distinct_under_both_notions() {
+    let a = a_peer();
+    let b = a_peer();
+
+    assert_ne!(
+        principal_of(&a.0),
+        principal_of(&b.0),
+        "CONTROL: two generated keys are two principals"
+    );
+    assert_ne!(a, b, "different identifier bytes must never be `Eq`");
+    assert_ne!(
+        a.cmp(&b),
+        std::cmp::Ordering::Equal,
+        "different identifier bytes must never compare `Equal`, in either regime"
+    );
+    assert!(
+        !same_principal_after_i7(&a, &b),
+        "and I7 must not merge them either"
+    );
+
+    let ordered: BTreeSet<PeerId> = [a.clone(), b.clone()].into_iter().collect();
+    let hashed: HashSet<PeerId> = [a, b].into_iter().collect();
+    assert_eq!(ordered.len(), 2);
+    assert_eq!(hashed.len(), 2);
+}
+
+#[test]
+fn an_anchor_derived_principal_is_a_first_class_peer() {
+    // `Did::from_anchor_id` names a principal whose 32 bytes need not decompress to an Ed25519
+    // point, and roughly half do not. Such a DID is accepted by the type and can key a peer
+    // container, so any I7 projection must be defined for it.
+    let anchor = PeerId(Did::from_anchor_id(&[2u8; 32]));
+
+    assert!(
+        anchor.0.to_verifying_key().is_err(),
+        "CONTROL: this anchor id is deliberately not a valid Ed25519 point"
+    );
+    assert_eq!(
+        principal_of(&anchor.0),
+        [2u8; 32],
+        "`identifier_bytes` resolves it, which is why the projection keys on that and not on a \
+         verifying key"
+    );
+
+    // This is why `SenderPrincipal` must not stand in for general principal identity: it is
+    // built from a `VerifyingKey` and fails closed here by design (`replay_guard.rs`). Using it
+    // as the peer-identity source would silently drop this population.
+    assert!(
+        icn_net::replay_guard::SenderPrincipal::from_did(&anchor.0).is_err(),
+        "CONTROL: `SenderPrincipal` is narrower than a `Did` principal — it must not be used as \
+         the identity source for peer containers"
+    );
+
+    let other = PeerId(Did::from_anchor_id(&[3u8; 32]));
+    assert_ne!(anchor, other);
+    assert_ne!(anchor.cmp(&other), std::cmp::Ordering::Equal);
+
+    let population = [
+        ("anchor-2", anchor),
+        ("anchor-3", other),
+        ("keypair", a_peer()),
+    ];
+    assert_containers_partition_identically(&population);
+}
+
+#[test]
+fn the_alternate_spellings_are_exactly_the_class_the_parser_accepts() {
+    // Non-vacuity for the list itself: if `Did::from_str` tightens, `alias_in` panics rather
+    // than letting this suite quietly cover fewer spellings.
+    let canonical = KeyPair::generate().unwrap().did().clone();
+    let mut seen = HashSet::new();
+    for (label, base) in ALTERNATE_SPELLINGS {
+        let alias = alias_in(base, label, &canonical);
+        assert!(
+            seen.insert(alias.as_str().to_string()),
+            "{label} produced a spelling already generated by another base"
+        );
+    }
+    assert_eq!(seen.len(), 22, "all 22 alternate spellings are distinct");
+    assert!(
+        !seen.contains(canonical.as_str()),
+        "CONTROL: none of them is the canonical base58btc spelling"
+    );
+}

--- a/icn/crates/icn-net/tests/peerid_i7_ordering_tripwire.rs
+++ b/icn/crates/icn-net/tests/peerid_i7_ordering_tripwire.rs
@@ -463,7 +463,7 @@ fn no_neighbour_is_left_without_metadata_and_no_metadata_is_orphaned() {
 }
 
 #[test]
-fn the_promotion_path_leaves_ordered_and_hashed_views_agreeing() {
+fn a_peer_lands_in_at_most_one_neighbour_class() {
     // `add_neighbor` starts by calling `remove_neighbor`, precisely so re-adding a peer under
     // new topology moves it rather than duplicating it. That step removes from the ordered
     // sets by `Ord` and from `metadata` by `Hash`/`Eq`. When those disagree, the ordered
@@ -498,19 +498,49 @@ fn the_promotion_path_leaves_ordered_and_hashed_views_agreeing() {
          or the assertion below proves nothing about it"
     );
 
-    // What is *not* asserted here, because getting it wrong is easy in both directions:
+    // The invariant, phrased so it is both regime-agnostic and able to fail.
     //
-    // "one principal occupies at most one class" is a **post-I7** invariant, not a current one.
-    // Today two spellings are two peers, so one principal legitimately sits in `local_cluster`
-    // and `backbone` at once; asserting otherwise is red on `main`. The mirror-image phrasing,
-    // "one `PeerId` occupies at most one class", is regime-agnostic but can never fail:
-    // `remove_neighbor` and the insert both dispatch on `Ord`, so `BTreeSet::contains` answers
-    // "one" in every regime, including the broken one.
+    // Two phrasings do not work. "One *principal* occupies at most one class" is a post-I7
+    // invariant: today two spellings are two peers, so one principal legitimately sits in
+    // `local_cluster` and `backbone` at once, and asserting otherwise is red on `main`. "One
+    // `PeerId` occupies at most one class", tested with `BTreeSet::contains`, can never fail —
+    // `contains` dispatches on `Ord`, and `remove_neighbor` and the insert use `Ord` too, so it
+    // answers "one" in every regime including the broken one.
     //
-    // What is regime-agnostic *and* can fail is the disagreement the duplication comes from.
-    // Under a half-completed I7 patch the ordered removal misses a peer the hashed side has
-    // already merged, so the ordered rows outnumber the metadata rows — the observable form of
-    // "this principal now sits in two classes with one metadata row between them".
+    // What works is comparing entries *across* classes with `Eq`. Today the two spellings are
+    // `!=`, so no cross-class pair is equal. After a correct I7 patch there is only one entry,
+    // so there is no cross-class pair at all. In the half-completed state the ordered removal
+    // misses — `Ord` still separates the spellings — while `Eq` has already merged them, so two
+    // entries in two classes compare equal. That is precisely "one peer in two classes".
+    let classes: [(&str, &BTreeSet<PeerId>); 4] = [
+        ("local_cluster", &sets.local_cluster),
+        ("regional", &sets.regional),
+        ("backbone", &sets.backbone),
+        ("trusted", &sets.trusted),
+    ];
+    for (name_a, set_a) in &classes {
+        for (name_b, set_b) in &classes {
+            if name_a == name_b {
+                continue;
+            }
+            for peer_a in set_a.iter() {
+                for peer_b in set_b.iter() {
+                    assert_ne!(
+                        peer_a, peer_b,
+                        "the same peer is in `{name_a}` and `{name_b}` at once. \
+                         `add_neighbor` removes from every class before inserting, so this can \
+                         only happen when the ordered removal fails to match a peer the hashed \
+                         side already considers the same — `Did` equality has adopted I7 \
+                         (#2627) while `PeerId::Ord` still compares `self.0.to_string()`. Move \
+                         `PeerId::Ord` to `Did::identifier_bytes()` in the same patch."
+                    );
+                }
+            }
+        }
+    }
+
+    // The same divergence seen from the other side: the ordered rows outnumber the metadata
+    // rows, because the missed ordered removal left an entry the hashed side had merged away.
     assert_eq!(
         ordered_rows(&sets).len(),
         metadata_rows(&sets).len(),


### PR DESCRIPTION
## What this changes

One new test file — `icn/crates/icn-net/tests/peerid_i7_ordering_tripwire.rs`. **No production code, no behaviour change.** `Did::Eq`/`Hash`, `PeerId::Ord`, peer data, wire formats and connection behaviour are all untouched.

It makes it mechanically difficult to land N2-A's `Did` equality change (#2627, I7) without simultaneously fixing `PeerId::Ord` and the peer containers that depend on it.

## The invariant

Rust's ordered collections require `a == b ⟺ a.cmp(b) == Ordering::Equal`.

`PeerId` (`icn-net/src/topology.rs:41-56`) derives `PartialEq`/`Eq`/`Hash` from `Did` — so those **follow `Did` automatically** and self-correct at I7. Its `Ord` is hand-written over `self.0.to_string()`, the spelling, and does **not**.

* **Today** — a re-spelled pair is `!=` and `cmp != Equal`. Both false, so they agree.
* **After I7** — the same pair becomes `==` while `cmp` stays unequal. Incoherent.

## Why `PeerId::Ord` cannot be fixed ahead of time

Consistency must hold in whichever regime production is in. Today that forces alias pairs to compare **unequal**; after I7 it forces the same pairs to compare **equal**. No single comparator satisfies both while `Did::Eq` is unchanged.

Making `Ord` principal-aware early produces the *inverse* violation — `cmp == Equal` with `a != b` — and a `BTreeSet` then silently drops one of two currently-distinct peers. That trades a latent regression for a live one. Mutation 2 below demonstrates it.

So the comparator moves **with** I7, and this PR encodes that dependency instead of relying on it being remembered.

## The paired-container surface

`NeighborSets` is the only place `PeerId` keys a collection, and it uses **both** regimes for the same peers:

| Field | Type | Keyed by | At I7 |
|---|---|---|---|
| `local_cluster`, `regional`, `backbone`, `trusted` | `BTreeSet<PeerId>` | **`Ord`** (spelling) | ✗ does not follow |
| `metadata` | `HashMap<PeerId, PeerMetadata>` | derived `Hash`/`Eq` | ✓ follows |

Traced lifecycle, and what breaks when the halves disagree:

* **insert** (`add_neighbor`) — the ordered set keeps both spellings while `metadata` keeps one, and the second `metadata.insert` overwrites the first row.
* **promotion/demotion** — `add_neighbor` begins with `remove_neighbor` precisely so a re-added peer *moves* rather than duplicating. The ordered removal misses, so the peer ends up in **two neighbour classes at once**.
* **removal** (`remove_neighbor`) — deletes from the sets by `Ord` and from `metadata` by `Hash`/`Eq`; one of the two misses, leaving either an ordered entry with no metadata or an unreachable metadata row that nothing prunes.
* **counts / limits** — `enforce_limit` (`topology.rs:427-441`) counts a class with `set_ref.len()` against `max`, so a doubled ordered set means one principal consumes two slots. (`total_count()` has no production caller; `handlers/hello.rs:377` and `handlers/handshake.rs:67` pass `local_cluster.len()` to observability metrics, not to enforcement. An earlier revision of this PR attributed enforcement to those call sites — that was wrong, and the assertion messages have been corrected too.)
* **eviction** — a set entry with no metadata scores `unwrap_or(0.0)` in `enforce_limit` and becomes a permanent eviction candidate.
* **lookup** — `get_rtt`/`record_rtt` go through `metadata`, so they would resolve a peer the ordered sets consider absent.

`sample()` feeds a random `choose_multiple`, so ordering does not determine its outcome. There is no snapshot/restore path for `NeighborSets`.

## Tests — 10, and what each is for

**Regime-agnostic** (pass before I7, pass after a *correct* I7 patch, fail only in between):

1. `peerid_eq_and_ord_must_agree_in_whatever_regime_production_is_in` — the biconditional itself, over 23 spellings plus an unrelated principal, with a non-vacuity counter proving the population contains pairs the transition will actually move. The failure message names the file, the fix, and both failure directions.
2. `ordered_and_hashed_agree_on_one_respelled_principal` — a `BTreeSet` and a `HashSet` must reach the same count; and a `BTreeSet` built by `collect` must match one built by `insert`.
3. `ordered_and_hashed_containers_partition_peers_identically` — pairwise over `BTreeSet`/`HashSet`/`BTreeMap`/`HashMap`.
4. `neighbour_sets_ordered_and_hashed_views_report_the_same_peers` — the real struct: ordered rows vs metadata rows vs `total_count()`.
5. `no_neighbour_is_left_without_metadata_and_no_metadata_is_orphaned` — set equality of the two views after a removal.
6. `a_peer_lands_in_at_most_one_neighbour_class` — drives `add_neighbor`'s remove-then-insert across a re-spelling, then asserts no two entries in *different* classes are `Eq`-equal. That phrasing is the one that works: "one principal per class" is post-I7 only and red on `main` today, and "one `PeerId` per class" tested with `BTreeSet::contains` can never fail, because `contains` dispatches on `Ord` just as the insert and removal do. Comparing across classes with `Eq` is green in both settled regimes and red in the half-completed one.

**Controls** (must *not* fire, and did not under either mutation):

7. `distinct_principals_stay_distinct_under_both_notions`
8. `an_anchor_derived_principal_is_a_first_class_peer` — a `Did::from_anchor_id` principal whose 32 bytes are deliberately not an Ed25519 point. Also asserts that `SenderPrincipal::from_did` **rejects** it, which is why the projection helpers key on `Did::identifier_bytes()` and not on a verifying key: `SenderPrincipal` is narrower than a `Did` principal and would silently drop that population.
9. `the_alternate_spellings_are_exactly_the_class_the_parser_accepts` — non-vacuity for the spelling list; a spelling that stops parsing is a failure, not a skip.

**Deliberately regime-dependent, and labelled as such:**

10. `pre_i7_regime_record_every_spelling_is_its_own_peer` — records that one principal currently counts as 23 peers. Its message tells the I7 implementer to change it to 1 **only once the other tests are green**, so the count change is visible in the I7 diff rather than implicit.

The 22 alternate spellings and the `alias_in` helper mirror `tests/respelled_envelope_replay.rs`, the repository's existing measured acceptance class for `Did::from_str`.

## Discrimination — measured across four regimes

Every regime below was run with `Compiling icn-identity` and `Compiling icn-net` confirmed in the output, so no result comes from a stale rlib.

| Regime | Simulated by | Result |
|---|---|---|
| **R0** — today's `main` | nothing | **10 / 10 pass** |
| **R1** — *correct* I7 | `Did::Eq`/`Hash` **and** `PeerId::Ord` both over `identifier_bytes()` | **9 pass, 1 fail** — only `pre_i7_regime_record_…`, which is the one test designed to change |
| **R2** — half-completed I7 | `Did::Eq`/`Hash` moved, `PeerId::Ord` untouched | **4 pass, 6 fail** |
| **R3** — inverse violation | `PeerId::Ord` moved, `Did::Eq` untouched | **3 pass, 7 fail** |

R2 is the failure this PR exists to catch. **R1 is the property that makes it safe**: a guard that fires on the *correct* patch argues for its own deletion at exactly the wrong moment, so it is measured rather than assumed. All mutations reverted; `git status` shows only the test file.

Two things worth recording for whoever re-runs this:

* Under R2 the same 23 values produced **1** entry via `BTreeSet::collect` and **23** via `BTreeSet::insert` — one container, built two ways, disagreeing about its own contents. An early draft used `collect` and therefore *missed* the failure. The tests now use `insert`, which is what `add_neighbor` does, and assert the two paths agree.
* Restoring a mutated file with a tool that preserves mtime (`cp -p`, `shutil.copy2`) sets the timestamp backwards, cargo considers the crate fresh, and the mutated rlib silently survives into the next regime. That produced a bogus R3 reading mid-review until the rebuild lines were checked. The file header names this trap.

## Additional ordered/hash twins found — reported, not changed

Bounded to the peer/topology domain, not a workspace sweep:

* **`discovery.rs:44`** — `HashMap<String, PeerInfo>`, a **third** peer-identity keying regime in `icn-net` alongside `session.connections` (String) and `peer_connections` (`Did`), and not in the §5 table. It inserts by `did.as_str()` (`:234`) and looks up by `did.as_str()` (`:244`) but **removes by the mDNS instance name** (`:191`) — insert and remove already use different key spaces. Not tested here: exercising it needs an mDNS daemon and timing.
* **`icn-gossip/src/vector_clock.rs:50`** — `HashMap<Did, ClockEntry>`, and `SerializedClock { clock: HashMap<Did, u64> }` goes **on the wire**. At I7 two spellings' entries merge, which is semantically right but is a wire-visible cardinality change, and `HashMap::insert` on deserialize keeps the *last* entry rather than applying a merge rule. Migration-bearing; belongs to #2627.

Both are reported to #2627 rather than addressed here.

## Review outcome

One FULL review generation, STANDARD lane, against `15931ec8`: **1 BLOCKER · 4 FOLLOW_UP · 0 QUESTION · 6 NOT_A_FINDING**.

The blocker was real and central: the tripwire's non-vacuity counter was itself regime-dependent (`!eq_says_same && same_principal_after_i7(...)`), so it reached zero once `Did::Eq` adopted I7 and fired on a **correct** patch — with a message telling that implementer the coherence assertion "proved nothing". Exactly the failure mode the file claims to avoid, and I had asserted R1 without running it. Fixed by counting *distinct spellings of one principal*, which no regime change moves.

Three in-file follow-ups were fixed in the same batch rather than deferred: the false `total_count()`/handlers enforcement attribution; `a_peer_lands_in_at_most_one_neighbour_class`, whose named assertion could never fire because `BTreeSet::contains` dispatches on `Ord`; and `no_neighbour_is_left_without_metadata_…`, which went vacuous under R1 until a surviving bystander principal was added. The fourth — a "4 controls" miscount in this body — is corrected above.

Two automated reviewers then independently found the same non-vacuity blocker, and one proposed a better fix for the `contains` problem than my first resolution: rather than documenting why both obvious phrasings fail and dropping the assertion, compare entries *across* classes with `Eq`. That is regime-agnostic **and** able to fail, so the named invariant is testable again — under a half-completed patch the test now fails on its own assertion with "the same peer is in `local_cluster` and `backbone` at once" instead of on a downstream count.

The reviewer independently reproduced all discrimination counts, ran 25 consecutive passes for flakiness, probed the leading-zero multibase hypothesis over 400 keypairs × 22 bases, and verified the factual claims in the doc comments.

## Verification

* `cargo fmt --all --check` — clean
* `cargo clippy -p icn-net --all-targets --all-features -- -D warnings` — exit 0
* `cargo test -p icn-net` — full crate suite
* No sleeps, no network, no timing dependency. `peers_needing_rtt_refresh` is used to enumerate the metadata key set because `is_rtt_stale()` is true when no RTT was recorded.

## Scope

Branched from `main` at `83682563`. Disjoint from #2680 (`icn-store` / identity migration scanner) and from #2681 (frozen, `icn-ccl`). Does not touch `Did::Eq`/`Hash`, `PeerId::Ord`, persistent peer data, wire formats, connection behaviour, or the N2-A collision scanner. The CCL determinism and input-bound follow-ups in #2682 are deliberately not mixed in.

Refs #2627

<!-- ICN-DELIVERY-LIFECYCLE:BEGIN -->
```
ICN DELIVERY LIFECYCLE
State:                FROZEN
Lane:                 STANDARD
Acceptance contract:  Add executable tests making PeerId::Ord's dependency on the I7 Did
                      equality change (#2627) mechanically obvious, and characterize the
                      NeighborSets ordered/hashed paired-container invariant, such that a
                      half-completed I7 patch is test-red. Non-goals: Did::Eq/Hash,
                      PeerId::Ord production behaviour, persistent peer data, wire format,
                      connection behaviour, the N2-A collision scanner, ContractActor::
                      compute_code_hash, and the #2682 CCL determinism/input-bound items.
Review generation:    CLOSED
Freeze head:          aaa547ff8ec8c6b65565f96d2898b28d1f1e72de
Known blockers:       0
Follow-up ledger:     none — all four findings closed in-PR
```

**Freeze provenance.** The reviewed artifact was `24c748eb7f1a565c7465ca7e4b4330f3f57f685b`.
`main` advanced twice underneath it — to `81297c42…` (#2680) and then `496d7594…` (#2681) — and
this repository requires branches to be up to date before merging (`strict: true`), so the
branch was brought up to date with the maintainer's explicit authorization. The new freeze head
`aaa547ff8ec8c6b65565f96d2898b28d1f1e72de` is a merge commit whose **first parent is the
reviewed head** and whose second parent is `496d7594…`. Nothing was rebased, rewritten or
hand-edited.

Equivalence was verified rather than assumed: the git blob hash of the single changed file,
`icn-net/tests/peerid_i7_ordering_tripwire.rs`, is byte-identical across the update
(`41319dcfd2312d2a54aad3383f730f68e090e9b4`), and the effective diff against current `main` is
still exactly that one file.

**Integration with what landed underneath.** The four-regime reasoning rests on three
production surfaces, and `git diff` reports all three unchanged between the reviewed base
`83682563` and current `main`: `icn-net/src/topology.rs` (`PeerId` still derives
`PartialEq`/`Eq`/`Hash` and hand-writes `Ord` over `self.0.to_string()`),
`icn-identity/src/anchor.rs` (`Did::from_anchor_id`), and `icn-net/src/replay_guard.rs`
(`SenderPrincipal`). #2680 added `identifier_bytes_of_spelling()` alongside
`Did::identifier_bytes()` without altering the method this suite calls. #2681 cannot interact
at all: it changed `icn-ccl` only, and `icn-net` does not depend on `icn-ccl` — the kernel
meaning firewall forbids it. No re-review of the tripwire logic was performed or needed.
<!-- ICN-DELIVERY-LIFECYCLE:END -->
