### PR TITLE
refactor(ccl): give the contract code hash one owner instead of ten

### DIFF
--- a/icn/bins/icnctl/src/main.rs
+++ b/icn/bins/icnctl/src/main.rs
@@ -5504,16 +5504,10 @@ async fn handle_contract_command(
 
             println!("Signing deployment as {deployer_did}");
 
-            // Compute code hash (must match ContractActor::compute_code_hash)
-            let code_hash = {
-                use sha2::{Digest, Sha256};
-                let mut hasher = Sha256::new();
-                hasher.update(contract.name.as_bytes());
-                for participant in &contract.participants {
-                    hasher.update(format!("{participant:?}").as_bytes());
-                }
-                icn_ledger::ContentHash::from_bytes(hasher.finalize().into())
-            };
+            // The one authoritative definition of the rule. These bytes are
+            // signed below, so a local re-implementation that drifts from
+            // icn-ccl produces a deployment no peer can verify.
+            let code_hash = icn_ccl::compute_contract_code_hash(&contract);
 
             // Create installation record
             let installed_at = std::time::SystemTime::now()
@@ -5702,16 +5696,10 @@ fn handle_contract_prepare(contract_file: &Path, output: &Path, data_dir: &Path)
         contract.participants.len()
     );
 
-    // Compute code hash
-    let code_hash = {
-        use sha2::{Digest, Sha256};
-        let mut hasher = Sha256::new();
-        hasher.update(contract.name.as_bytes());
-        for participant in &contract.participants {
-            hasher.update(format!("{participant:?}").as_bytes());
-        }
-        icn_ledger::ContentHash::from_bytes(hasher.finalize().into())
-    };
+    // The one authoritative definition of the rule. These bytes are signed
+    // below, so a local re-implementation that drifts from icn-ccl produces a
+    // co-signature no peer can verify.
+    let code_hash = icn_ccl::compute_contract_code_hash(&contract);
 
     // Create installation record
     let installed_at = std::time::SystemTime::now()

--- a/icn/crates/icn-ccl/src/actor.rs
+++ b/icn/crates/icn-ccl/src/actor.rs
@@ -302,17 +302,13 @@ impl ContractActor {
     }
 
     /// Compute deterministic hash for contract code
+    ///
+    /// Delegates to [`crate::code_hash::compute_contract_code_hash`], the one
+    /// authoritative definition of the rule. Do not re-implement it here: the
+    /// result is signed, gossiped and accepted verbatim from remote peers, so a
+    /// local copy that drifts produces deployments no peer can verify.
     fn compute_code_hash(&self, contract: &Contract) -> ContentHash {
-        // In a real implementation, this would hash the contract bytecode
-        // For now, use a simple hash based on contract name + participants
-        use sha2::{Digest, Sha256};
-        let mut hasher = Sha256::new();
-        hasher.update(contract.name.as_bytes());
-        for participant in &contract.participants {
-            hasher.update(format!("{participant:?}").as_bytes());
-        }
-        let hash_bytes = hasher.finalize();
-        ContentHash::from_bytes(hash_bytes.into())
+        crate::code_hash::compute_contract_code_hash(contract)
     }
 
     /// List all installed contracts
@@ -347,15 +343,13 @@ mod tests {
         (actor, runtime)
     }
 
-    /// Helper to compute code hash (same algorithm as ContractActor)
+    /// Helper to compute code hash.
+    ///
+    /// Calls the canonical rule rather than re-implementing it, so these tests
+    /// exercise the behaviour production uses instead of a private replica that
+    /// can agree with a bug.
     fn compute_code_hash(contract: &Contract) -> ContentHash {
-        use sha2::{Digest, Sha256};
-        let mut hasher = Sha256::new();
-        hasher.update(contract.name.as_bytes());
-        for participant in &contract.participants {
-            hasher.update(format!("{participant:?}").as_bytes());
-        }
-        ContentHash::from_bytes(hasher.finalize().into())
+        crate::code_hash::compute_contract_code_hash(contract)
     }
 
     /// Helper to create valid signatures for contract deployment

--- a/icn/crates/icn-ccl/src/code_hash.rs
+++ b/icn/crates/icn-ccl/src/code_hash.rs
@@ -1,0 +1,87 @@
+//! The contract code hash — one authoritative implementation.
+//!
+//! # What this is
+//!
+//! [`compute_contract_code_hash`] is the single definition of the rule that
+//! turns a [`Contract`] into the [`ContentHash`] that identifies a deployment.
+//! Before this module existed the same ten lines were written out ten times —
+//! three production sites and seven test/protocol twins — with no shared
+//! function, so changing one silently desynchronised the rest.
+//!
+//! # Where the result travels
+//!
+//! The hash this produces is not a local convenience value. It is:
+//!
+//! * **signed** — participants sign
+//!   [`ContractDeploymentMessage::compute_signing_bytes`], which is
+//!   `code_hash ‖ installed_at`;
+//! * **gossiped** — published on the `contracts:deploy` topic;
+//! * **accepted verbatim from remote peers** — the remote install path in
+//!   [`crate::actor`] takes `msg.code_hash` as given and does *not* recompute
+//!   it from `msg.contract`;
+//! * the **in-memory registry and invocation key** for
+//!   [`crate::runtime::ContractRuntime`].
+//!
+//! It is **not** the durable `ContractRegistry` storage key. That is a separate
+//! rule — [`crate::registry::compute_hash`], BLAKE3 over the JSON serialisation
+//! — which owns the persisted `contract:*` / `metadata:*` keyspace and is
+//! independently spelling- and order-sensitive. The two rules are distinct and
+//! must not be merged; see `docs/architecture/n2-a-migration-gate.md`.
+//!
+//! # What it hashes, and what it does not
+//!
+//! Carried forward from the original implementation: this is a placeholder for
+//! hashing the contract *bytecode*. It hashes the contract **name and
+//! participant list** and nothing else — currency, state variables, rules and
+//! triggers are all outside it, so two contracts with the same name and
+//! participants but different bodies share one identity. Replacing this with a
+//! real code hash is a protocol change that moves every deployed identifier,
+//! not a cleanup.
+//!
+//! # Why the encoding is left as it is
+//!
+//! Consolidating this rule deliberately changes **ownership and nothing else**.
+//! Every property below is load-bearing for values that are already signed,
+//! already gossiped, and already accepted from remote peers, so "improving" any
+//! of them would move live protocol identifiers:
+//!
+//! * **SHA-256**, not a newer digest.
+//! * The contract **name is fed raw** (`as_bytes()`), not `Debug`-quoted.
+//! * Participants are fed in **`Vec` order**. Permuting the participant list
+//!   changes the contract's identity. They are deliberately not sorted.
+//! * Each participant is fed as **`format!("{participant:?}")`** — the derived
+//!   `Debug` of `Did(String)`, so the bytes include the `Did(`, the quotes and
+//!   Rust's string escaping. This is *not* `Display` and *not* `as_str()`.
+//! * Consequently the hash is **sensitive to the textual spelling** of a DID.
+//!   `did:icn:` identifiers are multibase, so one principal has many accepted
+//!   spellings, and today each one yields a different contract identity.
+//! * There is **no domain-separation tag, no length prefix and no separator**
+//!   between fields. `compute_contract_code_hash` of an empty-named contract
+//!   with no participants is exactly `sha256("")`. The concatenation is
+//!   therefore ambiguous between the name and the participant list.
+//!
+//! That ambiguity and that spelling sensitivity are real defects. They are also
+//! **migration semantics**, owned by N2-A / I7 (#2627), not by this module.
+//! Fixing them here would change every deployed contract's identifier without a
+//! migration. Do not repair them opportunistically — change the rule only as
+//! part of a migration that also moves the identifiers that already exist.
+
+use crate::ast::Contract;
+use icn_ledger::ContentHash;
+use sha2::{Digest, Sha256};
+
+/// Compute the deterministic code hash identifying a contract deployment.
+///
+/// The historical rule, preserved byte for byte: `SHA-256(name ‖ Debug(p₀) ‖ …
+/// ‖ Debug(pₙ))` over the participants in their declared `Vec` order.
+///
+/// See the module documentation for what the result is used for and why the
+/// encoding must not be tidied up.
+pub fn compute_contract_code_hash(contract: &Contract) -> ContentHash {
+    let mut hasher = Sha256::new();
+    hasher.update(contract.name.as_bytes());
+    for participant in &contract.participants {
+        hasher.update(format!("{participant:?}").as_bytes());
+    }
+    ContentHash::from_bytes(hasher.finalize().into())
+}

--- a/icn/crates/icn-ccl/src/lib.rs
+++ b/icn/crates/icn-ccl/src/lib.rs
@@ -48,6 +48,7 @@ pub mod actor;
 pub mod ast;
 pub mod charter_rules;
 pub mod charter_validator;
+pub mod code_hash;
 pub mod disputes;
 pub mod error;
 pub mod fuel_estimator;
@@ -64,6 +65,7 @@ pub use actor::{ContractActor, GossipCallback, CONTRACTS_DEPLOY_TOPIC};
 pub use ast::{BinOp, Contract, Expr, Rule, Stmt, UnOp};
 pub use charter_rules::{CharterRule, CharterRuleSet, ValidationResult};
 pub use charter_validator::CharterValidator;
+pub use code_hash::compute_contract_code_hash;
 pub use disputes::{
     Dispute, DisputeActor, DisputeActorHandle, DisputeConfig, DisputeEvidence,
     DisputeGossipCallback, DisputeId, DisputeMessage, DisputeOutcome, DisputeReason,

--- a/icn/crates/icn-ccl/src/messages.rs
+++ b/icn/crates/icn-ccl/src/messages.rs
@@ -219,14 +219,7 @@ mod tests {
         let kp = KeyPair::generate().unwrap();
         let contract = create_test_contract(&kp);
 
-        // Compute code hash
-        use sha2::{Digest, Sha256};
-        let mut hasher = Sha256::new();
-        hasher.update(contract.name.as_bytes());
-        for participant in &contract.participants {
-            hasher.update(format!("{participant:?}").as_bytes());
-        }
-        let code_hash = ContentHash::from_bytes(hasher.finalize().into());
+        let code_hash = crate::code_hash::compute_contract_code_hash(&contract);
 
         let installed_at = SystemTime::now()
             .duration_since(SystemTime::UNIX_EPOCH)
@@ -287,13 +280,7 @@ mod tests {
 
         let contract = create_test_contract(&kp_alice);
 
-        use sha2::{Digest, Sha256};
-        let mut hasher = Sha256::new();
-        hasher.update(contract.name.as_bytes());
-        for participant in &contract.participants {
-            hasher.update(format!("{participant:?}").as_bytes());
-        }
-        let code_hash = ContentHash::from_bytes(hasher.finalize().into());
+        let code_hash = crate::code_hash::compute_contract_code_hash(&contract);
 
         let installed_at = SystemTime::now()
             .duration_since(SystemTime::UNIX_EPOCH)
@@ -371,13 +358,7 @@ mod tests {
 
         let contract = create_test_contract(&kp_alice);
 
-        use sha2::{Digest, Sha256};
-        let mut hasher = Sha256::new();
-        hasher.update(contract.name.as_bytes());
-        for participant in &contract.participants {
-            hasher.update(format!("{participant:?}").as_bytes());
-        }
-        let code_hash = ContentHash::from_bytes(hasher.finalize().into());
+        let code_hash = crate::code_hash::compute_contract_code_hash(&contract);
 
         let installed_at = SystemTime::now()
             .duration_since(SystemTime::UNIX_EPOCH)
@@ -427,13 +408,7 @@ mod tests {
             .add_participant(kp_alice.did().clone())
             .add_participant(kp_bob.did().clone());
 
-        use sha2::{Digest, Sha256};
-        let mut hasher = Sha256::new();
-        hasher.update(contract.name.as_bytes());
-        for participant in &contract.participants {
-            hasher.update(format!("{participant:?}").as_bytes());
-        }
-        let code_hash = ContentHash::from_bytes(hasher.finalize().into());
+        let code_hash = crate::code_hash::compute_contract_code_hash(&contract);
 
         let installed_at = SystemTime::now()
             .duration_since(SystemTime::UNIX_EPOCH)
@@ -500,13 +475,7 @@ mod tests {
         let kp = KeyPair::generate().unwrap();
         let contract = create_test_contract(&kp);
 
-        use sha2::{Digest, Sha256};
-        let mut hasher = Sha256::new();
-        hasher.update(contract.name.as_bytes());
-        for participant in &contract.participants {
-            hasher.update(format!("{participant:?}").as_bytes());
-        }
-        let code_hash = ContentHash::from_bytes(hasher.finalize().into());
+        let code_hash = crate::code_hash::compute_contract_code_hash(&contract);
 
         let installed_at = SystemTime::now()
             .duration_since(SystemTime::UNIX_EPOCH)

--- a/icn/crates/icn-ccl/tests/contract_code_hash_golden.rs
+++ b/icn/crates/icn-ccl/tests/contract_code_hash_golden.rs
@@ -1,0 +1,560 @@
+//! Golden and discrimination evidence for the contract code hash (Rule A).
+//!
+//! # What this file is for
+//!
+//! `icn_ccl::compute_contract_code_hash` replaced ten independently written
+//! copies of one rule — three production sites (`ContractActor`, and two
+//! `icnctl` signing paths) and seven test/protocol twins. That consolidation is
+//! only safe if it changed **ownership** and not **behaviour**, because the
+//! resulting hash is signed, gossiped, and accepted verbatim from remote peers.
+//!
+//! Every `GOLDEN_*` constant below was produced by running the **unmodified**
+//! `ContractActor::compute_code_hash` at `main`
+//! `b0c1130a102c5f15189358b01c9f9193932fc8ba`, before any duplicate was
+//! removed. None of them was derived by calling the canonical implementation.
+//! They are historical facts about the deployed rule, not a restatement of the
+//! current code.
+//!
+//! # What these tests are protecting
+//!
+//! Two of the pinned properties look like bugs, and are pinned *because* they
+//! look like bugs. Someone will eventually be tempted to fix them here:
+//!
+//! * **Spelling sensitivity.** One principal has many accepted multibase
+//!   spellings, and today each yields a different contract identity. That is
+//!   the split I7 (#2627) exists to close, together with a migration for the
+//!   identifiers that already exist. Closing it *here* would silently move
+//!   live protocol values.
+//! * **Concatenation ambiguity.** There is no domain tag, no length prefix and
+//!   no separator, so `sha256("")` is a reachable contract identity.
+//!
+//! Neither may be repaired outside a migration. These tests fail if either is.
+
+#![allow(unknown_lints, clippy::unwrap_used, clippy::expect_used)]
+
+use icn_ccl::ast::Contract;
+use icn_ccl::compute_contract_code_hash;
+use icn_ccl::ContractDeploymentMessage;
+use icn_identity::Did;
+use sha2::{Digest, Sha256};
+
+// ---------------------------------------------------------------------------
+// Corpus construction — deterministic, so the goldens are reproducible.
+// ---------------------------------------------------------------------------
+
+/// A DID built from a deterministic Ed25519 key, spelled base58btc.
+fn key_did(seed: u8) -> Did {
+    let vk = ed25519_dalek::SigningKey::from_bytes(&[seed; 32]).verifying_key();
+    Did::from_public_key(&vk)
+}
+
+/// The same 32 identifier bytes as [`key_did`], spelled base16-lower.
+///
+/// `did:icn:` identifiers are multibase, so `f` + lowercase hex is an accepted
+/// spelling of exactly the principal `key_did` names. `Did::from_str` accepts
+/// it and stores the spelling verbatim.
+fn key_did_base16(seed: u8) -> Did {
+    let raw = ed25519_dalek::SigningKey::from_bytes(&[seed; 32])
+        .verifying_key()
+        .to_bytes();
+    Did::from_str(&format!("did:icn:f{}", hex::encode(raw)))
+        .expect("base16 is an accepted multibase spelling")
+}
+
+fn anchor_did() -> Did {
+    Did::from_anchor_id(&[9u8; 32])
+}
+
+fn hex_of(c: &Contract) -> String {
+    hex::encode(compute_contract_code_hash(c).as_bytes())
+}
+
+// ---------------------------------------------------------------------------
+// Pinned spellings. If these move, the goldens below describe different inputs
+// and every assertion in this file becomes meaningless.
+// ---------------------------------------------------------------------------
+
+const P1_BASE58: &str = "did:icn:zGmaDrppBC7P5ARKV8g3djiwP89vz1jLK23V2GBjuAEGB";
+const P1_BASE16: &str = "did:icn:fea4a6c63e29c520abef5507b132ec5f9954776aebebe7b92421eea691446d22c";
+const P2_BASE58: &str = "did:icn:z7v54NWdBtkjuAFJrLGsS2SXnuk8nKam81mZJeeYxVFi9";
+const ANCHOR: &str = "did:icn:zcGfHiC6Kgg3FpFZvgwGcswsCRtp4aBP2fzuXRQPizuN";
+
+#[test]
+fn corpus_spellings_are_the_ones_the_goldens_were_taken_over() {
+    assert_eq!(key_did(7).as_str(), P1_BASE58);
+    assert_eq!(key_did_base16(7).as_str(), P1_BASE16);
+    assert_eq!(key_did(11).as_str(), P2_BASE58);
+    assert_eq!(anchor_did().as_str(), ANCHOR);
+}
+
+#[test]
+fn the_two_p1_spellings_name_one_principal_but_are_textually_distinct() {
+    let a = key_did(7);
+    let b = key_did_base16(7);
+    assert_ne!(
+        a.as_str(),
+        b.as_str(),
+        "corpus needs two distinct spellings"
+    );
+    assert_eq!(
+        a.identifier_bytes().unwrap(),
+        b.identifier_bytes().unwrap(),
+        "corpus needs those spellings to name the SAME principal"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Goldens — captured from the pre-consolidation production method.
+// ---------------------------------------------------------------------------
+
+const GOLDEN_EMPTY_MINIMAL: &str =
+    "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855";
+const GOLDEN_ORDINARY_NO_PARTICIPANTS: &str =
+    "948f4ce95b2f0769c9f2719563cb90fc2b3a91c4d4b27d681796cdc0ffb0b700";
+const GOLDEN_ONE_PARTICIPANT: &str =
+    "c9bcf62bf560dd613dc1dd875ef4d94e90e4da2f20b623b1db77412854d5b8aa";
+const GOLDEN_ORDER_AB: &str = "4c8d1641394f3a85affe293c6aeb8dd2cda3aa61f0e1a5ad4802b540274cedab";
+const GOLDEN_ORDER_BA: &str = "2bcf7b2cc394ed88004b516cf10803b2ebfab53bc322eb4a9163a0be387c2305";
+const GOLDEN_ALIAS_BASE16: &str =
+    "50a66980bbcecbd13757ce4554a5de26d3a89539d4988815184f3e62e0bdb429";
+const GOLDEN_ANCHOR_ONLY: &str = "272446633bb72aae88c8f04793b1ad7672bf48814ed75f9f4483acf32b391951";
+const GOLDEN_ANCHOR_PLUS_KEY: &str =
+    "eb31a36862983f1c8c4204a40c743ec4eeb99d23269b96ccfa04277e2bca3031";
+const GOLDEN_EMPTY_NAME_ONE_PARTICIPANT: &str =
+    "0bc0d4d4b82ec59d70572a2fd686fd4f81205c500d1a112b55d4b94ebd81c9f1";
+const GOLDEN_DEBUG_SENSITIVE_NAME: &str =
+    "5365c9217f59f08dca267786a3cf24ecb3cd51f0f818442101f78fa14beb0aeb";
+const GOLDEN_ICNCTL_DEPLOY_SHAPE: &str =
+    "261ec68d37e40bf8def9d380a3dc71fd960120bbdc40d9444b368f5b5394efeb";
+const GOLDEN_ICNCTL_COSIGN_SHAPE: &str =
+    "f82c2283bc41f24017358aa029b7c1d42d37e3baaa35b0925f4f809e2bff3a45";
+const GOLDEN_INTEGRATION_THREE_NODES: &str =
+    "503ad89cbd35f586dcfa19c31a062cd92f2b48d3a52241e60ca549253cb6a97e";
+
+/// A name whose `Debug` form differs from its `Display` form: it contains a
+/// quote, a backslash and a newline, all of which `Debug` would escape.
+fn debug_sensitive_name() -> String {
+    "Te\"st\\Contract\n".to_string()
+}
+
+fn ordinary() -> Contract {
+    Contract::new("TestContract".to_string())
+}
+
+#[test]
+fn canonical_rule_reproduces_every_pre_consolidation_golden() {
+    let p1 = key_did(7);
+    let p2 = key_did(11);
+    let anchor = anchor_did();
+
+    let cases: Vec<(&str, Contract, &str)> = vec![
+        (
+            "empty_minimal",
+            Contract::new(String::new()),
+            GOLDEN_EMPTY_MINIMAL,
+        ),
+        (
+            "ordinary_no_participants",
+            ordinary(),
+            GOLDEN_ORDINARY_NO_PARTICIPANTS,
+        ),
+        (
+            "one_participant",
+            ordinary().add_participant(p1.clone()),
+            GOLDEN_ONE_PARTICIPANT,
+        ),
+        (
+            "two_distinct_order_AB",
+            ordinary()
+                .add_participant(p1.clone())
+                .add_participant(p2.clone()),
+            GOLDEN_ORDER_AB,
+        ),
+        (
+            "two_distinct_order_BA",
+            ordinary()
+                .add_participant(p2.clone())
+                .add_participant(p1.clone()),
+            GOLDEN_ORDER_BA,
+        ),
+        (
+            "alias_base16_same_principal",
+            ordinary().add_participant(key_did_base16(7)),
+            GOLDEN_ALIAS_BASE16,
+        ),
+        (
+            "anchor_did_only",
+            ordinary().add_participant(anchor.clone()),
+            GOLDEN_ANCHOR_ONLY,
+        ),
+        (
+            "anchor_plus_key",
+            ordinary()
+                .add_participant(anchor.clone())
+                .add_participant(p1.clone()),
+            GOLDEN_ANCHOR_PLUS_KEY,
+        ),
+        (
+            "empty_name_one_participant",
+            Contract::new(String::new()).add_participant(p1.clone()),
+            GOLDEN_EMPTY_NAME_ONE_PARTICIPANT,
+        ),
+        (
+            "debug_sensitive_name",
+            Contract::new(debug_sensitive_name()).add_participant(p1.clone()),
+            GOLDEN_DEBUG_SENSITIVE_NAME,
+        ),
+        (
+            "icnctl_deploy_shape",
+            Contract::new("DeployedContract".to_string())
+                .add_participant(p1.clone())
+                .add_participant(p2.clone()),
+            GOLDEN_ICNCTL_DEPLOY_SHAPE,
+        ),
+        (
+            "icnctl_cosign_shape",
+            Contract::new("CoSigned".to_string())
+                .add_participant(p1.clone())
+                .add_participant(p2.clone())
+                .add_participant(anchor.clone()),
+            GOLDEN_ICNCTL_COSIGN_SHAPE,
+        ),
+        (
+            "integration_three_nodes",
+            ordinary()
+                .add_participant(key_did(21))
+                .add_participant(key_did(22))
+                .add_participant(key_did(23)),
+            GOLDEN_INTEGRATION_THREE_NODES,
+        ),
+    ];
+
+    for (name, contract, golden) in &cases {
+        assert_eq!(
+            &hex_of(contract),
+            golden,
+            "case `{name}`: consolidation changed the contract code hash. \
+             These bytes are signed, gossiped and accepted from remote peers — \
+             a change here moves live protocol identifiers."
+        );
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Independent encoding oracle.
+//
+// The goldens prove the output did not move. This proves *why*: the feed is a
+// bare concatenation of the raw name bytes and the `Debug` form of each
+// participant, in `Vec` order, with nothing between them. Built here from
+// first principles rather than by calling the canonical implementation.
+// ---------------------------------------------------------------------------
+
+fn oracle(name: &str, participants: &[&Did]) -> String {
+    let mut feed: Vec<u8> = Vec::new();
+    feed.extend_from_slice(name.as_bytes());
+    for p in participants {
+        feed.extend_from_slice(format!("{p:?}").as_bytes());
+    }
+    hex::encode(Sha256::digest(&feed))
+}
+
+#[test]
+fn encoding_is_a_bare_concatenation_with_no_separator_or_prefix() {
+    let p1 = key_did(7);
+    let p2 = key_did(11);
+
+    assert_eq!(
+        oracle("TestContract", &[&p1, &p2]),
+        GOLDEN_ORDER_AB,
+        "the historical feed is name-bytes then Debug-of-each-participant, unseparated"
+    );
+    assert_eq!(
+        oracle("", &[]),
+        GOLDEN_EMPTY_MINIMAL,
+        "an empty contract hashes to sha256 of the empty string"
+    );
+}
+
+#[test]
+fn empty_contract_identity_is_literally_sha256_of_nothing() {
+    // Pinning the ambiguity, not endorsing it: with no domain tag and no length
+    // prefix, this value is reachable. Adding either would move every deployed
+    // contract identifier, so it belongs to the I7 migration (#2627), not here.
+    assert_eq!(
+        hex_of(&Contract::new(String::new())),
+        hex::encode(Sha256::digest(b"")),
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Discrimination — each test builds the mutant a careless change would produce
+// and proves the pinned value rejects it.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn discriminates_a_change_of_hash_algorithm() {
+    let p1 = key_did(7);
+    let mutant = hex::encode(blake3::hash(b"TestContract").as_bytes());
+    assert_ne!(mutant, GOLDEN_ORDINARY_NO_PARTICIPANTS);
+
+    let mut feed = Vec::new();
+    feed.extend_from_slice(b"TestContract");
+    feed.extend_from_slice(format!("{p1:?}").as_bytes());
+    let sha512_truncated = hex::encode(&sha2::Sha512::digest(&feed)[..32]);
+    assert_ne!(
+        sha512_truncated, GOLDEN_ONE_PARTICIPANT,
+        "swapping the digest must not go unnoticed"
+    );
+}
+
+#[test]
+fn discriminates_debug_replaced_by_display() {
+    let p1 = key_did(7);
+    let mut feed = Vec::new();
+    feed.extend_from_slice(b"TestContract");
+    feed.extend_from_slice(format!("{p1}").as_bytes()); // Display, not Debug
+    assert_ne!(
+        hex::encode(Sha256::digest(&feed)),
+        GOLDEN_ONE_PARTICIPANT,
+        "Display drops the `Did(` wrapper and the quotes that Debug contributes"
+    );
+}
+
+#[test]
+fn discriminates_debug_replaced_by_as_str() {
+    let p1 = key_did(7);
+    let mut feed = Vec::new();
+    feed.extend_from_slice(b"TestContract");
+    feed.extend_from_slice(p1.as_str().as_bytes());
+    assert_ne!(
+        hex::encode(Sha256::digest(&feed)),
+        GOLDEN_ONE_PARTICIPANT,
+        "as_str() is the bare spelling; Debug adds `Did(\"` and `\")`"
+    );
+}
+
+#[test]
+fn discriminates_the_name_feed_being_debug_quoted_instead_of_raw() {
+    // The name is fed raw. A name containing a quote, a backslash and a newline
+    // is where raw and Debug diverge most visibly.
+    let name = debug_sensitive_name();
+    let p1 = key_did(7);
+
+    let mut mutant = Vec::new();
+    mutant.extend_from_slice(format!("{name:?}").as_bytes()); // Debug-quoted name
+    mutant.extend_from_slice(format!("{p1:?}").as_bytes());
+    assert_ne!(
+        hex::encode(Sha256::digest(&mutant)),
+        GOLDEN_DEBUG_SENSITIVE_NAME
+    );
+
+    // and the pinned value really is the raw-name feed
+    assert_eq!(oracle(&name, &[&p1]), GOLDEN_DEBUG_SENSITIVE_NAME);
+}
+
+#[test]
+fn discriminates_the_name_component_being_dropped() {
+    let p1 = key_did(7);
+    assert_ne!(
+        oracle("", &[&p1]),
+        GOLDEN_ONE_PARTICIPANT,
+        "dropping the name must change the identity"
+    );
+    assert_eq!(oracle("", &[&p1]), GOLDEN_EMPTY_NAME_ONE_PARTICIPANT);
+}
+
+#[test]
+fn discriminates_an_inserted_separator_or_length_prefix() {
+    let p1 = key_did(7);
+    let p2 = key_did(11);
+
+    let mut with_separator = Vec::new();
+    with_separator.extend_from_slice(b"TestContract");
+    for p in [&p1, &p2] {
+        with_separator.push(0x1f);
+        with_separator.extend_from_slice(format!("{p:?}").as_bytes());
+    }
+    assert_ne!(
+        hex::encode(Sha256::digest(&with_separator)),
+        GOLDEN_ORDER_AB
+    );
+
+    let mut with_length_prefix = Vec::new();
+    with_length_prefix.extend_from_slice(&(12u32).to_le_bytes());
+    with_length_prefix.extend_from_slice(b"TestContract");
+    for p in [&p1, &p2] {
+        let d = format!("{p:?}");
+        with_length_prefix.extend_from_slice(&(d.len() as u32).to_le_bytes());
+        with_length_prefix.extend_from_slice(d.as_bytes());
+    }
+    assert_ne!(
+        hex::encode(Sha256::digest(&with_length_prefix)),
+        GOLDEN_ORDER_AB
+    );
+}
+
+#[test]
+fn discriminates_participants_being_sorted() {
+    // Sorting is the most natural "determinism improvement" someone could make.
+    // It would collapse ORDER_AB and ORDER_BA into one identity.
+    assert_ne!(
+        GOLDEN_ORDER_AB, GOLDEN_ORDER_BA,
+        "participant order is part of contract identity today"
+    );
+
+    let p1 = key_did(7);
+    let p2 = key_did(11);
+
+    // A sorting mutant maps BOTH declaration orders onto one feed...
+    let mut from_ab = [&p1, &p2];
+    from_ab.sort_by_key(|d| d.as_str().to_string());
+    let mut from_ba = [&p2, &p1];
+    from_ba.sort_by_key(|d| d.as_str().to_string());
+    let sorted_hex = oracle("TestContract", &from_ab);
+    assert_eq!(
+        sorted_hex,
+        oracle("TestContract", &from_ba),
+        "a sorting mutant collapses the two declaration orders"
+    );
+
+    // ...so it cannot reproduce both goldens. Here `z7v5…` sorts before
+    // `zGma…`, so sorting yields the BA feed and it is the AB golden that
+    // catches the mutation.
+    assert_ne!(
+        sorted_hex, GOLDEN_ORDER_AB,
+        "sorting would give the AB contract the BA identity"
+    );
+}
+
+#[test]
+fn discriminates_aliases_being_principalized_early() {
+    // THIS TEST MUST KEEP FAILING TO BE EQUAL until I7 lands with a migration.
+    // Two accepted spellings of one principal produce two contract identities
+    // today. Making them agree here — without moving the identifiers that
+    // already exist — would silently re-key live deployments.
+    assert_ne!(
+        GOLDEN_ONE_PARTICIPANT, GOLDEN_ALIAS_BASE16,
+        "contract identity is still DID-spelling-sensitive in this tranche"
+    );
+
+    let canonical_spelling = key_did(7);
+    let alias_spelling = key_did_base16(7);
+    assert_ne!(
+        hex_of(&ordinary().add_participant(canonical_spelling)),
+        hex_of(&ordinary().add_participant(alias_spelling)),
+    );
+
+    // What a premature principalization would look like: feeding decoded bytes.
+    let bytes = key_did(7).identifier_bytes().unwrap();
+    let mut principalized = Vec::new();
+    principalized.extend_from_slice(b"TestContract");
+    principalized.extend_from_slice(&bytes);
+    let principalized = hex::encode(Sha256::digest(&principalized));
+    assert_ne!(principalized, GOLDEN_ONE_PARTICIPANT);
+    assert_ne!(principalized, GOLDEN_ALIAS_BASE16);
+}
+
+#[test]
+fn discriminates_a_change_to_the_bytes_that_get_signed() {
+    // The code hash reaches the wire through compute_signing_bytes. Pin that
+    // binding too, so a change to either half is caught.
+    let contract = ordinary()
+        .add_participant(key_did(7))
+        .add_participant(key_did(11));
+    let code_hash = compute_contract_code_hash(&contract);
+    let installed_at: u64 = 1_700_000_000;
+
+    let signing = ContractDeploymentMessage::compute_signing_bytes(&code_hash, installed_at);
+
+    let mut expected = Vec::new();
+    expected.extend_from_slice(&hex::decode(GOLDEN_ORDER_AB).unwrap());
+    expected.extend_from_slice(&installed_at.to_le_bytes());
+    assert_eq!(
+        hex::encode(&signing),
+        hex::encode(Sha256::digest(&expected)),
+        "signing bytes are sha256(code_hash || installed_at_le)"
+    );
+
+    // A one-second difference must produce different signing bytes.
+    let other = ContractDeploymentMessage::compute_signing_bytes(&code_hash, installed_at + 1);
+    assert_ne!(signing, other);
+}
+
+#[test]
+fn fields_outside_name_and_participants_do_not_affect_identity() {
+    // Currency, state vars, rules and triggers are NOT part of the hash today.
+    // Pinned because folding them in would move every deployed identifier.
+    let base = ordinary()
+        .add_participant(key_did(7))
+        .add_participant(key_did(11));
+    let embellished = ordinary()
+        .add_participant(key_did(7))
+        .add_participant(key_did(11))
+        .with_currency("USD".to_string());
+
+    assert_eq!(hex_of(&base), GOLDEN_ORDER_AB);
+    assert_eq!(
+        hex_of(&embellished),
+        GOLDEN_ORDER_AB,
+        "currency is outside the code hash today; changing that is a migration"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Anti-drift: the rule must exist exactly once in the workspace.
+//
+// The consolidation's whole purpose is that a future I7 migration edits one
+// place. The second `icnctl` signing site had no coupling comment at all and
+// was missed by every search that looked for the function name rather than the
+// algorithm — so this guard searches for the algorithm.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn the_rule_is_implemented_exactly_once_in_the_workspace() {
+    let rust_root = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+        .ancestors()
+        .nth(2)
+        .expect("crates/icn-ccl sits two levels below the cargo root")
+        .to_path_buf();
+
+    let canonical = rust_root.join("crates/icn-ccl/src/code_hash.rs");
+    assert!(
+        canonical.is_file(),
+        "canonical module not found at {canonical:?}"
+    );
+
+    let mut offenders: Vec<String> = Vec::new();
+    let mut stack = vec![rust_root.join("crates"), rust_root.join("bins")];
+    while let Some(dir) = stack.pop() {
+        let Ok(entries) = std::fs::read_dir(&dir) else {
+            continue;
+        };
+        for entry in entries.flatten() {
+            let path = entry.path();
+            if path.is_dir() {
+                if path.file_name().is_some_and(|n| n == "target") {
+                    continue;
+                }
+                stack.push(path);
+            } else if path.extension().is_some_and(|e| e == "rs") && path != canonical {
+                let Ok(text) = std::fs::read_to_string(&path) else {
+                    continue;
+                };
+                // The algorithm's fingerprint: a participant fed through Debug
+                // into a hasher. Matching on behaviour, not on a name.
+                if text.contains("hasher.update(format!(\"{participant:?}\")") {
+                    offenders.push(path.display().to_string());
+                }
+            }
+        }
+    }
+
+    assert!(
+        offenders.is_empty(),
+        "the contract code-hash rule was re-implemented outside \
+         icn-ccl/src/code_hash.rs. Call `icn_ccl::compute_contract_code_hash` \
+         instead — this rule is signed, gossiped and accepted from remote \
+         peers, and a copy that drifts breaks verification for every peer. \
+         Offending files: {offenders:?}"
+    );
+}

--- a/icn/crates/icn-ccl/tests/contract_code_hash_golden.rs
+++ b/icn/crates/icn-ccl/tests/contract_code_hash_golden.rs
@@ -509,6 +509,75 @@ fn fields_outside_name_and_participants_do_not_affect_identity() {
 // algorithm — so this guard searches for the algorithm.
 // ---------------------------------------------------------------------------
 
+/// Files allowed to contain the rule, relative to the cargo root.
+///
+/// `code_hash.rs` is the rule. This test file holds deliberate mutant replicas
+/// of it — that is how the discrimination tests above work — so it exempts
+/// itself. Nothing else may.
+const EXEMPT: &[&str] = &[
+    "crates/icn-ccl/src/code_hash.rs",
+    "crates/icn-ccl/tests/contract_code_hash_golden.rs",
+];
+
+/// Does this source file re-implement the contract code-hash rule?
+///
+/// Matching one source spelling is not enough: `uninlined_format_args` is
+/// `allow`ed workspace-wide (`icn/Cargo.toml`), so `format!("{:?}", participant)`
+/// is idiomatic here and a guard keyed to `format!("{participant:?}")` alone
+/// would wave it through. Whitespace is stripped first so formatting cannot
+/// evade the match, and two independent signals are used.
+/// Signals must be *adjacent*, not merely co-present in the same file. A
+/// file-scoped conjunction flags any large file that happens to contain all the
+/// tokens somewhere — `icnctl`'s 12k-line `main.rs` and `icn-steward`'s ceremony
+/// hashes both tripped an earlier version of this check while implementing
+/// nothing of the kind.
+fn re_implements_the_rule(source: &str) -> bool {
+    /// Byte-length-bounded prefix that never splits a UTF-8 character.
+    ///
+    /// Slicing `&s[..n]` directly panics when `n` lands inside a multi-byte
+    /// character, and this scans every `.rs` file in the workspace — several of
+    /// which contain non-ASCII in comments and string literals.
+    fn prefix(s: &str, max: usize) -> &str {
+        let mut end = max.min(s.len());
+        while end > 0 && !s.is_char_boundary(end) {
+            end -= 1;
+        }
+        &s[..end]
+    }
+
+    let norm: String = source.chars().filter(|c| !c.is_whitespace()).collect();
+
+    // Signal A — the rule's distinctive first step, matched contiguously. Every
+    // re-implementation feeds the contract name, whatever it then does with the
+    // participants.
+    if norm.contains("update(contract.name.as_bytes())") {
+        return true;
+    }
+
+    // Signal B — a Debug format handed straight to a hasher. Contiguous, so it
+    // catches `{participant:?}`, `{p:?}` and the non-inlined `{:?}, participant`
+    // alike, and is not satisfied by a `{:?}` elsewhere in the file.
+    if norm.contains(".participants") {
+        for (i, _) in norm.match_indices(".update(format!(\"{") {
+            let window = prefix(&norm[i..], 60);
+            if window.contains(":?}") {
+                return true;
+            }
+        }
+    }
+
+    // Signal C — the same feed written through a local binding, caught by
+    // proximity to the participant iteration rather than by adjacency.
+    for (i, _) in norm.match_indices("contract.participants") {
+        let window = prefix(&norm[i..], 320);
+        if window.contains(":?}") && window.contains("format!(") && window.contains(".update(") {
+            return true;
+        }
+    }
+
+    false
+}
+
 #[test]
 fn the_rule_is_implemented_exactly_once_in_the_workspace() {
     let rust_root = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
@@ -517,44 +586,111 @@ fn the_rule_is_implemented_exactly_once_in_the_workspace() {
         .expect("crates/icn-ccl sits two levels below the cargo root")
         .to_path_buf();
 
-    let canonical = rust_root.join("crates/icn-ccl/src/code_hash.rs");
-    assert!(
-        canonical.is_file(),
-        "canonical module not found at {canonical:?}"
-    );
+    let exempt: Vec<std::path::PathBuf> = EXEMPT.iter().map(|p| rust_root.join(p)).collect();
+    for path in &exempt {
+        assert!(
+            path.is_file(),
+            "exempt path not found at {path:?} — the scan root is wrong, which \
+             would make this guard pass vacuously"
+        );
+    }
+
+    // Every workspace member directory, not just the two that happened to hold
+    // copies. `apps/` contains seven members, three of which already depend on
+    // `icn-ccl` and are therefore the likeliest place for a copy to reappear.
+    let mut stack = Vec::new();
+    for root in ["crates", "bins", "apps"] {
+        let dir = rust_root.join(root);
+        assert!(
+            dir.is_dir(),
+            "expected workspace member root {dir:?} to exist; a renamed or \
+             missing root must fail loudly rather than silently shrink the scan"
+        );
+        stack.push(dir);
+    }
+    // Optional roots — absent in some checkouts, scanned when present.
+    for root in ["examples", "benches"] {
+        let dir = rust_root.join(root);
+        if dir.is_dir() {
+            stack.push(dir);
+        }
+    }
 
     let mut offenders: Vec<String> = Vec::new();
-    let mut stack = vec![rust_root.join("crates"), rust_root.join("bins")];
+    let mut scanned = 0usize;
     while let Some(dir) = stack.pop() {
-        let Ok(entries) = std::fs::read_dir(&dir) else {
-            continue;
-        };
-        for entry in entries.flatten() {
-            let path = entry.path();
+        // A directory we cannot read must not be silently skipped: that is a
+        // green pass over exactly the code this guard exists to police.
+        let entries =
+            std::fs::read_dir(&dir).unwrap_or_else(|e| panic!("cannot scan {dir:?}: {e}"));
+        for entry in entries {
+            let path = entry
+                .unwrap_or_else(|e| panic!("cannot read entry in {dir:?}: {e}"))
+                .path();
             if path.is_dir() {
                 if path.file_name().is_some_and(|n| n == "target") {
                     continue;
                 }
                 stack.push(path);
-            } else if path.extension().is_some_and(|e| e == "rs") && path != canonical {
-                let Ok(text) = std::fs::read_to_string(&path) else {
-                    continue;
-                };
-                // The algorithm's fingerprint: a participant fed through Debug
-                // into a hasher. Matching on behaviour, not on a name.
-                if text.contains("hasher.update(format!(\"{participant:?}\")") {
-                    offenders.push(path.display().to_string());
+            } else if path.extension().is_some_and(|e| e == "rs") && !exempt.contains(&path) {
+                let text = std::fs::read_to_string(&path)
+                    .unwrap_or_else(|e| panic!("cannot read {path:?}: {e}"));
+                scanned += 1;
+                if re_implements_the_rule(&text) {
+                    offenders.push(
+                        path.strip_prefix(&rust_root)
+                            .unwrap_or(&path)
+                            .display()
+                            .to_string(),
+                    );
                 }
             }
         }
     }
 
     assert!(
+        scanned > 500,
+        "only {scanned} files scanned — the walk is not reaching the workspace"
+    );
+    assert!(
         offenders.is_empty(),
         "the contract code-hash rule was re-implemented outside \
          icn-ccl/src/code_hash.rs. Call `icn_ccl::compute_contract_code_hash` \
-         instead — this rule is signed, gossiped and accepted from remote \
-         peers, and a copy that drifts breaks verification for every peer. \
-         Offending files: {offenders:?}"
+         instead — this rule is signed, gossiped and accepted verbatim from \
+         remote peers, and a copy that drifts breaks verification for every \
+         peer. Offending files: {offenders:?}"
     );
+}
+
+#[test]
+fn the_drift_guard_recognises_re_spellings_of_the_rule() {
+    // The guard is only worth having if it survives the obvious rewrites. Each
+    // of these is a real re-implementation and must be caught.
+    let variants = [
+        r#"hasher.update(contract.name.as_bytes()); for participant in &contract.participants { hasher.update(format!("{participant:?}").as_bytes()); }"#,
+        r#"hasher.update(contract.name.as_bytes()); for participant in &contract.participants { hasher.update(format!("{:?}", participant).as_bytes()); }"#,
+        r#"hasher.update(contract.name.as_bytes()); for p in &contract.participants { hasher.update(format!("{p:?}").as_bytes()); }"#,
+        r#"h.update(contract.name.as_bytes()); for p in &contract.participants { h.update(format!("{p:?}").as_bytes()); }"#,
+        r#"for p in &contract.participants { let d = format!("{p:?}"); hasher.update(d.as_bytes()); }"#,
+    ];
+    for (i, v) in variants.iter().enumerate() {
+        assert!(
+            re_implements_the_rule(v),
+            "variant {i} slipped past the drift guard: {v}"
+        );
+    }
+
+    // ...and must not fire on unrelated code that merely hashes something, or
+    // merely Debug-formats something.
+    let innocuous = [
+        r#"let mut hasher = Sha256::new(); hasher.update(payload); hasher.finalize()"#,
+        r#"tracing::debug!("participants: {:?}", contract.participants);"#,
+        r#"let code_hash = icn_ccl::compute_contract_code_hash(&contract);"#,
+    ];
+    for (i, v) in innocuous.iter().enumerate() {
+        assert!(
+            !re_implements_the_rule(v),
+            "innocuous snippet {i} was falsely flagged: {v}"
+        );
+    }
 }

--- a/icn/crates/icn-core/tests/contract_deployment_integration.rs
+++ b/icn/crates/icn-core/tests/contract_deployment_integration.rs
@@ -313,14 +313,11 @@ impl TestNode {
         other_participants: Vec<&TestNode>, // Other participant nodes to collect signatures from
         announce_to: Vec<&icn_identity::Did>,
     ) -> anyhow::Result<ContentHash> {
-        // Compute code hash (must match ContractActor::compute_code_hash)
-        use sha2::{Digest, Sha256};
-        let mut hasher = Sha256::new();
-        hasher.update(contract.name.as_bytes());
-        for participant in &contract.participants {
-            hasher.update(format!("{participant:?}").as_bytes());
-        }
-        let code_hash = ContentHash::from_bytes(hasher.finalize().into());
+        // The one authoritative definition of the rule, reached across the
+        // crate boundary rather than re-encoded here. This test signs and
+        // gossips the result, so a local replica could pass while disagreeing
+        // with what production actually deploys.
+        let code_hash = icn_ccl::compute_contract_code_hash(&contract);
 
         let installed_at = std::time::SystemTime::now()
             .duration_since(std::time::UNIX_EPOCH)?


### PR DESCRIPTION
<!-- ICN-DELIVERY-LIFECYCLE:BEGIN -->
**State:** FROZEN
**Lane:** N2-A (#2627) — Rule A contract code-hash consolidation
**Acceptance contract:** Consolidate the contract code-hash rule (Rule A) from ten independently
written copies into one owner in `icn-ccl`, preserving the rule byte for byte. Non-goals:
`Did::Eq`/`Hash`, `PeerId::Ord`, Rule B (`registry::compute_hash`), DID acceptance, persisted
identifiers, wire formats, §7.5.
**Review generation:** FULL, CLOSED — 0 BLOCKER · 3 FOLLOW_UP · 0 QUESTION · 1 NOT_A_FINDING.
Two follow-ups were in-scope defects in this PR's own anti-drift test and were fixed in this
batch; the third was this block's absence and is fixed by this block. A Copilot review thread
independently raised the same anti-drift defect; replied to and resolved. Unresolved threads: 0.
**Freeze head:** `b94292ac954ea08376752f89edd7d60013e9ff30`
**Freeze provenance:** the head did NOT change during integration. `b94292ac` is both the
review-remediated candidate and the freeze head; `main` has not moved from
`b0c1130a102c5f15189358b01c9f9193932fc8ba` since the candidate was validated, so no refresh,
effective-diff comparison or DELTA integration pass was required. The FULL review was generated
against `ec54b9b2` and its three follow-ups were remediated in `b94292ac`, which was then
re-verified in full.
**Required checks:** 11/11 SUCCESS at the freeze head.
**Non-required red:** `Security Audit` — reproduces on `main` at `b0c1130a` with `RUSTSEC-2026-0258`
scanning `Cargo.lock`; this PR changes no manifest or lockfile (effective diff is 7 `.rs` files),
so it is pre-existing and not attributable.
**Known blockers:** none.
**Follow-up ledger:**
- Rule B (`registry::compute_hash`, `blake3(serde_json)`) is a distinct migration-bearing surface
  owning the durable `contract:*` / `metadata:*` keyspace. Recorded on #2627; untouched here.
- All 7 tests in `icn-core/tests/contract_deployment_integration.rs` are `#[ignore]`d for QUIC
  flakiness, so CI compile-checks that file only. Run locally for this PR (7/7 pass). Pre-existing
  coverage gap, not addressed here.
<!-- ICN-DELIVERY-LIFECYCLE:END -->

## What this changes

The contract code hash — `SHA-256(name ‖ Debug(participant)…)` — was written out **ten times**
across the workspace with no shared function. This gives it one owner,
`icn_ccl::compute_contract_code_hash`, and routes all ten sites through it.

**The rule itself is unchanged, byte for byte.** This is an ownership change, not a migration.

## Why it matters

The resulting `ContentHash` is not a local value. It is **signed** by participants
(`compute_signing_bytes`), **gossiped** on `contracts:deploy`, and **accepted verbatim from remote
peers** — the remote install path takes `msg.code_hash` as given and never recomputes it. Ten
independent encodings of a value with those properties means any future change has ten places to
get right, and a copy that drifts produces validly-signed deployments no peer can verify.

N2-A / I7 (#2627) will eventually have to change this rule. This tranche makes that a one-site
edit.

## Inventory — ten sites, three of them production

Earlier passes on #2627 reported eight. That count came from searching the symbol
`compute_code_hash`. Searching for the **algorithm** finds two more.

| Kind | Site |
|---|---|
| production | `icn-ccl/src/actor.rs:305` — `ContractActor::compute_code_hash` |
| production | `icnctl/src/main.rs:5507` — deployment signing |
| production | `icnctl/src/main.rs:5709` — `handle_contract_prepare`, **previously unreported, no coupling comment at all** |
| twin | `icn-ccl/src/actor.rs:351` — in-crate test helper |
| twins ×5 | `icn-ccl/src/messages.rs:227, 294, 378, 434, 507` |
| twin | `icn-core/tests/contract_deployment_integration.rs:321` — cross-crate |

The third production site is the reason this is worth doing. It signs with an operator's unlocked
keystore key and nothing in the source said it was coupled to anything.

## Canonical owner

`icn/crates/icn-ccl/src/code_hash.rs`. `Contract` is defined in `icn-ccl::ast`, the output type is
`icn_ledger::ContentHash` and `icn-ccl` already depends on `icn-ledger`; `icn-core` and `icnctl`
both already depend on `icn-ccl`. **No dependency inversion, and no twin had to stay separate.**

Deliberately *not* named `compute_hash` — that name is already taken in the same crate by an
unrelated rule (see below).

## Rule A vs Rule B — a correction carried into #2627

`icn-ccl` contains **two** contract-hash rules, and #2627's evidence had conflated them:

* **Rule A** (this PR): `SHA-256(name ‖ Debug(participants))`, signed/gossiped/remote-accepted,
  keyed into the **in-memory** runtime. `ContractActor` has zero references to `ContractRegistry`
  and `ContractRuntime` holds no `Store`, so this is **not** the durable storage key.
* **Rule B** (untouched): `registry::compute_hash` = `blake3(serde_json(contract))`, which *is* the
  durable `contract:*` / `metadata:*` identity, and is independently DID-spelling- and
  order-sensitive.

Rule B is recorded on #2627 as a distinct, still-unresolved migration-bearing surface. It is not
modified here.

## Evidence

Goldens were captured from the **unmodified** production method at `b0c1130a`, before any duplicate
was removed, and pinned as hex constants. They were not derived from the new implementation.

13-case corpus: empty/minimal, ordinary and empty names, a name containing `"` `\` and a newline,
one and multiple participants, A,B vs B,A ordering, two accepted multibase spellings of one
principal, `Did::from_str` and `Did::from_anchor_id` construction paths, plus the two `icnctl`
input shapes and the `icn-core` integration shape.

`empty_minimal` is `e3b0c442…b855` — literally `sha256("")`, cross-checked out-of-band with
`sha256sum`. That pins the encoding's lack of any domain tag, length prefix or separator.

### Deliberately preserved defects

Two pinned properties look like bugs and are pinned *because* they look like bugs:

* **DID-spelling sensitivity** — two accepted spellings of one principal still produce two contract
  identities.
* **Concatenation ambiguity** — no separator between the name and the participant list.

Both are real. Both are I7 migration semantics (#2627): fixing either here would move live protocol
identifiers with no migration. The tests fail if either is "cleaned up".

### Mutation results — 9/9 caught

| Mutation | Result |
|---|---|
| SHA-256 → BLAKE3 | CAUGHT (4 tests) |
| `Debug` → `Display` | CAUGHT (3) |
| `Debug` → `as_str()` | CAUGHT (3) |
| sort participants | CAUGHT (3) |
| drop the name feed | CAUGHT (3) |
| insert a separator | CAUGHT (3) |
| principalize aliases early | CAUGHT (4) |
| add a domain-separation tag | CAUGHT (4) |
| reintroduce a silent duplicate at `handle_contract_prepare` | CAUGHT (anti-drift guard, names the file) |
| reintroduce it as the idiomatic `format!("{:?}", participant)` | CAUGHT (after review; missed by the first guard) |
| plant a verbatim copy under `apps/` | CAUGHT (after review; missed by the first guard) |

The last one is structural: `the_rule_is_implemented_exactly_once_in_the_workspace` scans `crates/`
and `bins/` for the algorithm's fingerprint outside the canonical module. Pasting the ten lines back
now fails CI instead of waiting to be discovered.

## Invariants

- [x] **Determinism** — identical inputs produce identical bytes; proven by pinned goldens.
- [x] **Canonical encodings** — encoding unchanged; changes to it are now a one-site edit.
- [x] **No panics** — the canonical function is total; no `unwrap`/`expect` in non-test code.
- [x] **Kernel/app boundaries** — no new dependency edges; every caller already depended on `icn-ccl`.
- [x] **Adversarial by default** — the rule is signed, gossiped and remote-accepted; the anti-drift
      guard exists because a drifting signer is the adversarial case.

## Non-goals held

No change to `Did::Eq`/`Hash`, `PeerId::Ord`, Rule B, DID acceptance, persisted identifiers, wire
formats, vector-clock semantics, discovery keying, or §7.5. No I7. Nothing from #2682/#2683.

Refs #2627.
