### PR TITLE
refactor(identity): make Did equality and hashing name the principal, not the spelling (I7)

### DIFF
--- a/icn/apps/governance/src/manager.rs
+++ b/icn/apps/governance/src/manager.rs
@@ -9217,7 +9217,11 @@ mod tests {
         let kp = icn_identity::KeyPair::generate().unwrap();
         let member = kp.did().clone();
         let alias = alias_spelling(&member);
-        assert_ne!(member, alias, "control: the spellings must differ");
+        assert_ne!(
+            member.as_str(),
+            alias.as_str(),
+            "control: the spellings must differ as *strings*. Comparing the `Did` values themselves stopped proving this at I7 (#2627): they now name one principal and compare equal, which is the property under test"
+        );
 
         let domain_id = GovernanceDomainId::new("quorum-alias");
         let mgr = GovernanceManager::new();
@@ -9270,7 +9274,11 @@ mod tests {
         let (mgr, domain_id, member_did) = make_manager_with_domain().await;
         let proposal_id = make_open_proposal(&mgr, &domain_id, &member_did).await;
         let alias = alias_spelling(&member_did);
-        assert_ne!(member_did, alias, "control: the spellings must differ");
+        assert_ne!(
+            member_did.as_str(),
+            alias.as_str(),
+            "control: the spellings must differ as *strings*. Comparing the `Did` values themselves stopped proving this at I7 (#2627): they now name one principal and compare equal, which is the property under test"
+        );
 
         // Two conflicting acts by one key, as a pre-#2641 binary left them.
         {
@@ -9307,10 +9315,13 @@ mod tests {
         let proposal_id = make_open_proposal(&mgr, &domain_id, &member_did).await;
         let alias = alias_spelling(&member_did);
 
-        // Control: the two spellings really are distinct `Did` values today.
+        // Control: the two spellings really are distinct *strings*. They are
+        // no longer distinct `Did` values — I7 (#2627) made them one
+        // principal, which is exactly what this test exercises.
         assert_ne!(
-            member_did, alias,
-            "control: spellings must differ under current Did equality"
+            member_did.as_str(),
+            alias.as_str(),
+            "control: the spellings must differ as *strings*. Comparing the `Did` values themselves stopped proving this at I7 (#2627): they now name one principal and compare equal, which is the property under test"
         );
 
         mgr.cast_vote(proposal_id.clone(), member_did, VoteChoice::For, None)

--- a/icn/apps/governance/tests/signed_governance_emission.rs
+++ b/icn/apps/governance/tests/signed_governance_emission.rs
@@ -1002,8 +1002,9 @@ async fn alias_spelled_did_cannot_add_a_second_vote_on_the_actor_path() {
     // cannot pass vacuously. If `Did` becomes key-equal (N2-A / #2627) this
     // assertion fails and the proof must be re-derived rather than assumed.
     assert_ne!(
-        node.did, alias,
-        "control: the two spellings must differ under current Did equality"
+        node.did.as_str(),
+        alias.as_str(),
+        "control: the spellings must differ as *strings*. Comparing the `Did` values themselves stopped proving this at I7 (#2627): they now name one principal and compare equal, which is the property under test"
     );
 
     node.ops
@@ -1094,19 +1095,36 @@ async fn alias_self_delegation_cannot_launder_a_second_vote_at_close() {
     let alias = Did::from_str(&format!("did:icn:f{}", hex::encode(bytes)))
         .expect("base16 multibase spelling must parse");
     assert_ne!(
-        node.did, alias,
-        "control: the two spellings must differ under current Did equality"
+        node.did.as_str(),
+        alias.as_str(),
+        "control: the spellings must differ as *strings*. Comparing the `Did` values themselves stopped proving this at I7 (#2627): they now name one principal and compare equal, which is the property under test"
     );
 
     // Delegate from the canonical spelling to an alias of the very same key.
-    node.ops
+    //
+    // **Updated by the I7 patch (#2627).** This used to be *accepted* — the two
+    // spellings were different `Did` values, so `add_delegation`'s
+    // self-delegation guard did not recognise it — and the laundering it
+    // enabled had to be caught downstream in the tally. I7 makes the two
+    // spellings one principal, so that existing guard now sees the delegation
+    // for what it is and the attack is refused at the door. The guard moved
+    // earlier; it did not disappear.
+    let refused = node
+        .ops
         .create_delegation(Delegation::new(
             node.did.clone(),
             alias.clone(),
             DelegationScope::Blanket,
         ))
         .await
-        .expect("self-delegation across spellings is accepted today");
+        .expect_err(
+            "a delegation from one spelling of a key to another spelling of the same key \
+             is self-delegation and must be refused",
+        );
+    assert!(
+        refused.to_string().to_lowercase().contains("yourself"),
+        "the refusal must name self-delegation, got: {refused}"
+    );
 
     // Vote once, as the delegate spelling.
     node.ops
@@ -1129,7 +1147,8 @@ async fn alias_self_delegation_cannot_launder_a_second_vote_at_close() {
     assert!(
         !matches!(closed.state, ProposalState::Accepted { .. }),
         "one key produced one vote of three eligible members, which cannot reach a 50% \
-         quorum; Accepted means the delegation expansion counted it twice (got {:?})",
+         quorum; Accepted means a second vote was manufactured for that key despite the \
+         self-delegation above being refused (got {:?})",
         closed.state
     );
     assert!(
@@ -1157,8 +1176,9 @@ async fn close_fails_closed_on_conflicting_alias_rows_rather_than_counting_both(
     let alias = Did::from_str(&format!("did:icn:f{}", hex::encode(bytes)))
         .expect("base16 multibase spelling must parse");
     assert_ne!(
-        node.did, alias,
-        "control: the two spellings must differ under current Did equality"
+        node.did.as_str(),
+        alias.as_str(),
+        "control: the spellings must differ as *strings*. Comparing the `Did` values themselves stopped proving this at I7 (#2627): they now name one principal and compare equal, which is the property under test"
     );
 
     // Two conflicting acts by one key, as a pre-#2641 binary would have left them.
@@ -1209,7 +1229,11 @@ async fn vote_change_over_legacy_duplicate_rows_refuses_without_mutating() {
     let bytes = node.did.identifier_bytes().expect("node DID must decode");
     let alias = Did::from_str(&format!("did:icn:f{}", hex::encode(bytes)))
         .expect("base16 multibase spelling must parse");
-    assert_ne!(node.did, alias, "control: the spellings must differ");
+    assert_ne!(
+        node.did.as_str(),
+        alias.as_str(),
+        "control: the spellings must differ as *strings*. Comparing the `Did` values themselves stopped proving this at I7 (#2627): they now name one principal and compare equal, which is the property under test"
+    );
 
     // Two *agreeing* rows for one principal, as a pre-#2641 binary left them.
     for voter in [node.did.clone(), alias] {
@@ -1274,7 +1298,11 @@ async fn filtered_close_fails_closed_on_conflicts_the_standing_filter_would_hide
     let bytes = node.did.identifier_bytes().expect("node DID must decode");
     let alias = Did::from_str(&format!("did:icn:f{}", hex::encode(bytes)))
         .expect("base16 multibase spelling must parse");
-    assert_ne!(node.did, alias, "control: the spellings must differ");
+    assert_ne!(
+        node.did.as_str(),
+        alias.as_str(),
+        "control: the spellings must differ as *strings*. Comparing the `Did` values themselves stopped proving this at I7 (#2627): they now name one principal and compare equal, which is the property under test"
+    );
 
     node.state
         .save_vote(
@@ -1321,7 +1349,11 @@ async fn quorum_denominator_counts_principals_not_did_spellings() {
     let bytes = node.did.identifier_bytes().expect("node DID must decode");
     let alias = Did::from_str(&format!("did:icn:f{}", hex::encode(bytes)))
         .expect("base16 multibase spelling must parse");
-    assert_ne!(node.did, alias, "control: the spellings must differ");
+    assert_ne!(
+        node.did.as_str(),
+        alias.as_str(),
+        "control: the spellings must differ as *strings*. Comparing the `Did` values themselves stopped proving this at I7 (#2627): they now name one principal and compare equal, which is the property under test"
+    );
 
     // One member, named twice. Quorum 100% makes the difference decisive:
     // 1/1 of the electorate reaches it, 1/2 does not.
@@ -1384,9 +1416,16 @@ async fn quorum_denominator_counts_principals_not_did_spellings() {
 /// #2641, competing delegations: where a membership list names one principal
 /// under several spellings and those spellings hold delegations to different
 /// voters, expanding whichever entry the resolver happens to list first would
-/// make list order the authority over a vote. Fail closed instead.
+/// make list order the authority over a vote.
+///
+/// **Renamed and re-scoped by the I7 patch (#2627).** It read
+/// `competing_delegations_across_spellings_fail_closed_at_close` and asserted
+/// that `close` refused the pair. I7 made the two spellings one principal, so
+/// `create_delegation` now refuses the second delegation outright and the
+/// conflicting state cannot be reached. The hazard is prevented rather than
+/// detected, which is the better place for it.
 #[tokio::test(flavor = "current_thread")]
-async fn competing_delegations_across_spellings_fail_closed_at_close() {
+async fn competing_delegations_across_spellings_are_refused_at_creation() {
     let node = Node::spawn(true).await;
     let domain_id = GovernanceDomainId("alias-delegation-conflict".to_string());
     let delegate_a = icn_identity::KeyPair::generate().unwrap().did().clone();
@@ -1395,7 +1434,11 @@ async fn competing_delegations_across_spellings_fail_closed_at_close() {
     let bytes = node.did.identifier_bytes().expect("node DID must decode");
     let alias = Did::from_str(&format!("did:icn:f{}", hex::encode(bytes)))
         .expect("base16 multibase spelling must parse");
-    assert_ne!(node.did, alias, "control: the spellings must differ");
+    assert_ne!(
+        node.did.as_str(),
+        alias.as_str(),
+        "control: the spellings must differ as *strings*. Comparing the `Did` values themselves stopped proving this at I7 (#2627): they now name one principal and compare equal, which is the property under test"
+    );
 
     node.ops
         .create_domain(
@@ -1434,6 +1477,14 @@ async fn competing_delegations_across_spellings_fail_closed_at_close() {
         .expect("open_proposal");
 
     // One key, two spellings, two different delegates.
+    //
+    // **Updated by the I7 patch (#2627).** The first delegation is accepted; the
+    // second names the *same principal* under a different spelling, so
+    // `add_delegation`'s duplicate guard now refuses it. Before I7 both were
+    // stored and the conflict had to be caught at close, where expanding
+    // whichever entry the resolver listed first would have made list order the
+    // authority over a vote. The conflicting state can no longer be built, so
+    // the hazard is prevented rather than detected.
     node.ops
         .create_delegation(Delegation::new(
             node.did.clone(),
@@ -1442,14 +1493,25 @@ async fn competing_delegations_across_spellings_fail_closed_at_close() {
         ))
         .await
         .expect("delegation from the canonical spelling");
-    node.ops
+    let refused = node
+        .ops
         .create_delegation(Delegation::new(
             alias,
             delegate_b.clone(),
             DelegationScope::Blanket,
         ))
         .await
-        .expect("delegation from the alias spelling");
+        .expect_err(
+            "a second competing delegation for one principal, spelled differently, must be \
+             refused rather than stored alongside the first",
+        );
+    assert!(
+        refused
+            .to_string()
+            .to_lowercase()
+            .contains("already exists"),
+        "the refusal must name the existing delegation, got: {refused}"
+    );
 
     // Both delegates vote, and they disagree.
     node.ops
@@ -1461,13 +1523,33 @@ async fn competing_delegations_across_spellings_fail_closed_at_close() {
         .await
         .expect("delegate b votes");
 
-    let err = node
-        .ops
+    // **Updated by the I7 patch (#2627).** This used to assert that `close`
+    // failed closed naming "competing delegations", because both delegations
+    // existed and the resolver would otherwise have let membership-list order
+    // pick a winner. With the second delegation refused above, there is nothing
+    // left to disagree about, so `close` completes and reaches a decision.
+    //
+    // The close-time guard in `compute_tally_with_delegations` is deliberately
+    // left in place as defence in depth: `DelegationManager` has no
+    // load-from-store path today, so the conflicting state is unreachable
+    // through the public API — but the tally takes a manager from its caller,
+    // and the guard is what keeps a future construction path honest.
+    node.ops
         .close_proposal(proposal_id.clone())
         .await
-        .expect_err("membership-list order must not choose which delegated act counts");
+        .expect("with the competing delegation refused, the tally has no conflict to fail on");
+
+    let closed = node
+        .ops
+        .get_proposal(&proposal_id)
+        .await
+        .expect("get_proposal")
+        .expect("proposal exists");
     assert!(
-        err.to_string().contains("competing delegations"),
-        "must name the competing delegations, got: {err}"
+        !matches!(closed.state, ProposalState::Open { .. }),
+        "the proposal must reach a decision rather than stay open (got {:?}). Which \
+         decision is #2677's tally contract, not I7's: what this test pins is that one \
+         principal holds one delegation however it is spelled.",
+        closed.state
     );
 }

--- a/icn/crates/icn-ccl/tests/value_did_hash.rs
+++ b/icn/crates/icn-ccl/tests/value_did_hash.rs
@@ -1,8 +1,8 @@
 //! `Value::Did` / `Value::Set` hash compatibility across DID spellings.
 //!
 //! ICN accepts more than one textual encoding for the same 32-byte principal
-//! identifier. `Did` equality is still spelling-sensitive today; N2-A (#2627)
-//! intends to make it principal-sensitive (`IDENTITY_SEMANTICS.md` §11, I7).
+//! identifier. `Did` equality is now principal-sensitive: N2-A / I7 (#2627)
+//! landed (`IDENTITY_SEMANTICS.md` §11, I7).
 //!
 //! Rust's contract is one-way:
 //!
@@ -11,14 +11,22 @@
 //! ```
 //!
 //! The converse is not required, so a hash may be *coarser* than equality. That
-//! is what lets this land before the equality flip: two spellings of one
-//! principal share a hash today while `Did` still calls them distinct — a
-//! deliberate collision, which `HashSet` resolves by comparing — and the same
-//! rule is already correct once they become equal.
+//! asymmetry is why this file could land (#2681) **before** the equality flip:
+//! two spellings of one principal shared a hash while `Did` still called them
+//! distinct — a deliberate collision, which `HashSet` resolved by comparing —
+//! and the same keying rule stayed correct once they became equal. It now is
+//! equality rather than a collision, and the rule did not have to change.
 //!
-//! These tests do not change or simulate `Did` equality in production. Where a
-//! test needs the post-I7 relation it builds it locally, from
-//! `Did::identifier_bytes`.
+//! Two tests here were regime-dependent by construction and were updated by the
+//! I7 patch: [`a_hash_map_keys_both_spellings_as_one_principal`] (which
+//! described the deliberate collision) and the non-vacuity guard in
+//! [`the_hash_eq_contract_holds_under_simulated_principal_equality`], whose
+//! witness was "unequal today, equal after I7" and can no longer be met.
+//!
+//! These tests still do not read production `Did` equality where they need the
+//! principal relation: they build it locally from `Did::identifier_bytes`, so
+//! the law below is checked against an independent definition rather than
+//! against itself.
 
 #![allow(unknown_lints, clippy::unwrap_used, clippy::expect_used)]
 
@@ -121,10 +129,17 @@ fn two_distinct_principals_stay_distinct_in_a_hash_set() {
 }
 
 #[test]
-fn a_hash_map_still_resolves_each_spelling_under_the_deliberate_collision() {
-    // Both spellings hash alike now but are still unequal under today's `Did`
-    // equality, so the map holds two entries in one bucket. Lookup must not
-    // confuse them: a colliding hash is resolved by `Eq`, not by the hash.
+fn a_hash_map_keys_both_spellings_as_one_principal() {
+    // **Updated by the I7 patch (#2627), as designed.** Before I7 these two
+    // spellings hashed alike but compared *unequal*, so the map held two
+    // entries in one bucket and this test asserted that lookup resolved them
+    // apart by `Eq`. I7 made `Did` equality principal equality, so the
+    // deliberate collision became genuine equality: one principal is one key,
+    // and the second insert *updates* the first instead of joining it.
+    //
+    // That is the intended destination — `Value::Set`, `participants` and CCL
+    // `in` checks must see one principal once, however it is spelled — not a
+    // regression to work around.
     let canonical = a_principal();
     let alias = alternate_spelling(&canonical);
 
@@ -132,7 +147,14 @@ fn a_hash_map_still_resolves_each_spelling_under_the_deliberate_collision() {
     map.insert(Value::Did(canonical.clone()), "canonical");
     map.insert(Value::Did(alias.clone()), "alias");
 
-    assert_eq!(map.get(&Value::Did(canonical)), Some(&"canonical"));
+    assert_eq!(
+        map.len(),
+        1,
+        "two accepted spellings of one principal must be one key, not two"
+    );
+
+    // Either spelling reads that one entry, and it holds the later write.
+    assert_eq!(map.get(&Value::Did(canonical)), Some(&"alias"));
     assert_eq!(map.get(&Value::Did(alias)), Some(&"alias"));
 }
 
@@ -361,15 +383,29 @@ fn the_hash_eq_contract_holds_under_simulated_principal_equality() {
                 hash_of(b),
                 "values equal after I7 must already hash equally:\n  {a:?}\n  {b:?}"
             );
-            if a != b {
-                proved_a_cross_spelling_pair = true;
+            // Non-vacuity witness. **Updated by the I7 patch (#2627).** This
+            // read `a != b` — "a pair today's equality separates and I7 will
+            // merge" — which cannot be met once production equality *is* the
+            // principal relation.
+            //
+            // Differing *spellings* is the same witness stated
+            // regime-independently: true before I7 and still true, and it is
+            // what makes the assertion above non-trivial, since two values that
+            // are textually identical hashing alike proves nothing. Narrowed to
+            // a `Did` pair on purpose — a `Value::Set` witness would be
+            // ambiguous, because two equal sets can render in different orders
+            // for reasons that have nothing to do with spelling.
+            if let (Value::Did(x), Value::Did(y)) = (a, b) {
+                if x.as_str() != y.as_str() {
+                    proved_a_cross_spelling_pair = true;
+                }
             }
         }
     }
 
     assert!(
         proved_a_cross_spelling_pair,
-        "the corpus must contain a pair that is unequal today but equal after I7, \
-         or this test passes vacuously"
+        "the corpus must contain two values that render differently yet are one \
+         principal, or this test passes vacuously"
     );
 }

--- a/icn/crates/icn-gossip/src/gossip.rs
+++ b/icn/crates/icn-gossip/src/gossip.rs
@@ -1374,11 +1374,20 @@ impl GossipActor {
             state.topics.len()
         );
 
-        // Restore vector clock
+        // Restore vector clock.
+        //
+        // The snapshot keys this map by DID *spelling* (`HashMap<String, u64>`),
+        // while the clock is keyed by principal since I7 (#2627). A pre-I7
+        // snapshot can therefore hold two spellings of one principal, and
+        // `HashMap` iteration order is unspecified — so `insert` would let an
+        // arbitrary one of them win, including the lower count, moving the
+        // local high-water mark backwards across a restart. `observe` applies
+        // the vector-clock merge rule (take the maximum) instead, which is the
+        // same rule the wire decoder uses and is correct in both regimes.
         self.clock.clear();
         for (did_str, count) in state.vector_clock {
             let did = Did::from_str(&did_str).context("Failed to parse DID from vector clock")?;
-            self.clock.insert(did, count);
+            self.clock.observe(did, count);
         }
 
         // Restore topic metadata (must happen before restoring subscriptions)

--- a/icn/crates/icn-gossip/src/vector_clock.rs
+++ b/icn/crates/icn-gossip/src/vector_clock.rs
@@ -53,7 +53,67 @@ pub struct VectorClock {
 /// Serialization wrapper that only includes count (not last_seen)
 #[derive(Serialize, Deserialize)]
 struct SerializedClock {
+    #[serde(deserialize_with = "deserialize_clock_merged_by_max")]
     clock: HashMap<Did, u64>,
+}
+
+/// Decode a clock map, merging entries that name the same principal by **max**.
+///
+/// I7 (#2627) makes `Did` equality principal equality, so two accepted multibase
+/// spellings of one node are one key here. `HashMap`'s derived `Deserialize`
+/// resolves that collapse by plain insertion — the last entry in the input wins
+/// — and postcard preserves whatever order the sender wrote. A clock carrying
+/// `{spelling_a: 9, spelling_b: 5}` would therefore decode to 5 and move a
+/// counter *backwards*, which for a vector clock means re-requesting entries
+/// already seen and, where a clock gates delivery, re-accepting them.
+///
+/// Vector clocks merge by maximum — that is what [`VectorClock::merge`] does —
+/// and this applies the same rule at the decode boundary, which is the only
+/// place a duplicate key can appear.
+///
+/// This is correct in both regimes and is not conditional on I7: before I7 no
+/// two keys collapse, so the fold is an identity over the derived behaviour;
+/// after I7 max is the only answer consistent with `merge`. It reads exactly the
+/// map shape the derive read and serialization is untouched, so **no wire byte
+/// changes**. `VectorClockProjection::from_entries` in `icn-kernel-api` already
+/// picks max for the same reason, and the N2-A0 inventory names it as the
+/// precedent (`docs/architecture/n2-a0-stored-key-inventory.md` §12.1, ordering
+/// constraint (ii)).
+fn deserialize_clock_merged_by_max<'de, D>(deserializer: D) -> Result<HashMap<Did, u64>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    struct MergeByMax;
+
+    impl<'de> serde::de::Visitor<'de> for MergeByMax {
+        type Value = HashMap<Did, u64>;
+
+        fn expecting(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            f.write_str("a map of node DID to sequence count")
+        }
+
+        fn visit_map<A>(self, mut access: A) -> Result<Self::Value, A::Error>
+        where
+            A: serde::de::MapAccess<'de>,
+        {
+            // Cap only the *pre-allocation*, so a declared length cannot size
+            // an allocation on its own. This is not an entry-count limit: the
+            // map still grows past `MAX_ENTRIES` if that many real entries
+            // arrive, exactly as the derived `HashMap` decoder did. `MAX_ENTRIES`
+            // is enforced by `maybe_evict` on increment/merge, not on decode —
+            // rejecting oversized clocks here would change what the wire
+            // accepts, which is a separate decision from I7.
+            let mut clock =
+                HashMap::with_capacity(access.size_hint().unwrap_or(0).min(MAX_ENTRIES));
+            while let Some((node, count)) = access.next_entry::<Did, u64>()? {
+                let entry = clock.entry(node).or_insert(0u64);
+                *entry = (*entry).max(count);
+            }
+            Ok(clock)
+        }
+    }
+
+    deserializer.deserialize_map(MergeByMax)
 }
 
 impl VectorClock {
@@ -233,6 +293,29 @@ impl VectorClock {
         self.entries.insert(node, ClockEntry::new(count));
     }
 
+    /// Record an observed count for a node, keeping whichever is greater.
+    ///
+    /// This is [`VectorClock::merge`]'s rule applied to a single entry, for
+    /// callers that rebuild a clock from a spelling-keyed source. Since I7
+    /// (#2627) two accepted spellings of one principal are one key here, so a
+    /// rebuild that used [`VectorClock::insert`] would let the last spelling it
+    /// happened to visit overwrite the first — and where the source is a
+    /// `HashMap<String, _>` that order is unspecified, so the survivor could be
+    /// the *lower* count and the clock would move backwards.
+    ///
+    /// Prefer this over `insert` whenever more than one source entry can name
+    /// the same principal. `insert` keeps its overwrite semantics for callers
+    /// that genuinely mean "set this node to exactly this count".
+    pub fn observe(&mut self, node: Did, count: u64) {
+        self.maybe_evict();
+        let entry = self
+            .entries
+            .entry(node)
+            .or_insert_with(|| ClockEntry::new(0));
+        entry.count = entry.count.max(count);
+        entry.touch();
+    }
+
     /// Clear all entries from the clock
     pub fn clear(&mut self) {
         self.entries.clear();
@@ -297,6 +380,209 @@ impl<'de> Deserialize<'de> for VectorClock {
 mod tests {
     use super::*;
     use icn_identity::KeyPair;
+
+    // -----------------------------------------------------------------------
+    // I7 (#2627): a clock whose entries alias one principal must merge by max.
+    // -----------------------------------------------------------------------
+
+    /// A second accepted spelling of the same principal.
+    ///
+    /// `did:icn:` identifiers are multibase, so the same 32 bytes have a
+    /// base58btc spelling and a base16 spelling (`f` + lowercase hex). Both
+    /// parse; both decode to one identifier; under I7 both are one `Did` key.
+    fn alternate_spelling(did: &Did) -> Did {
+        let bytes = did
+            .identifier_bytes()
+            .expect("a validated DID decodes to 32 identifier bytes");
+        let alias = Did::from_str(&format!("did:icn:f{}", hex::encode(bytes)))
+            .expect("a base16 multibase spelling of 32 bytes is a valid did:icn:");
+        assert_ne!(
+            did.as_str(),
+            alias.as_str(),
+            "CONTROL: the two spellings must differ, or the test proves nothing"
+        );
+        assert_eq!(
+            alias.identifier_bytes().expect("alias decodes"),
+            bytes,
+            "CONTROL: the alias must name the same principal"
+        );
+        alias
+    }
+
+    /// Serialize `(spelling, count)` pairs as a map, in exactly the given order.
+    ///
+    /// A `VectorClock` cannot produce an aliased encoding itself — post-I7 its
+    /// own `HashMap` has already merged the spellings — so the adversarial input
+    /// has to be built at the wire level. This writes the same postcard map
+    /// shape `SerializedClock` reads, with the entry order under test control,
+    /// which is the whole point: the surviving count must not depend on it.
+    struct OrderedClock<'a>(&'a [(String, u64)]);
+
+    impl serde::Serialize for OrderedClock<'_> {
+        fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            use serde::ser::SerializeMap;
+            let mut map = serializer.serialize_map(Some(self.0.len()))?;
+            for (spelling, count) in self.0 {
+                map.serialize_entry(spelling, count)?;
+            }
+            map.end()
+        }
+    }
+
+    #[derive(serde::Serialize)]
+    struct WireClock<'a> {
+        clock: OrderedClock<'a>,
+    }
+
+    fn decode_clock(entries: &[(String, u64)]) -> VectorClock {
+        let bytes = icn_encoding::encode(&WireClock {
+            clock: OrderedClock(entries),
+        })
+        .expect("encoding a clock map is infallible");
+        icn_encoding::decode(&bytes).expect("a well-formed clock map decodes")
+    }
+
+    #[test]
+    fn an_aliased_clock_merges_to_the_maximum_count_in_either_order() {
+        let node = KeyPair::generate().unwrap().did().clone();
+        let alias = alternate_spelling(&node);
+
+        // The high count written first, so plain last-writer-wins insertion
+        // would keep 5 and move the counter *backwards*.
+        let high_first = decode_clock(&[
+            (node.as_str().to_string(), 9),
+            (alias.as_str().to_string(), 5),
+        ]);
+        assert_eq!(
+            high_first.get(&node),
+            9,
+            "two spellings of one principal must merge to the maximum, not to \
+             whichever entry happened to deserialize last"
+        );
+
+        // And the other order, where last-writer-wins would coincidentally be
+        // right — so a green result here is not order luck.
+        let low_first = decode_clock(&[
+            (alias.as_str().to_string(), 5),
+            (node.as_str().to_string(), 9),
+        ]);
+        assert_eq!(
+            low_first.get(&node),
+            9,
+            "the merge must not depend on order"
+        );
+
+        assert_eq!(
+            high_first, low_first,
+            "the same aliased clock in two input orders is the same clock"
+        );
+
+        // One principal, so one entry — not two.
+        assert_eq!(high_first.len(), 1, "aliases are one entry, not two");
+
+        // Looking it up under the other spelling finds the same count.
+        assert_eq!(
+            high_first.get(&alias),
+            9,
+            "either spelling must read the principal's count"
+        );
+    }
+
+    #[test]
+    fn observe_keeps_the_high_water_mark_whatever_order_spellings_arrive_in() {
+        // The snapshot restore path (`GossipActor::restore_state`) rebuilds this
+        // clock from a `HashMap<String, u64>` whose iteration order is
+        // unspecified. Since I7 two spellings of one principal are one key, so
+        // the rebuild must not let arrival order decide the count.
+        let node = KeyPair::generate().unwrap().did().clone();
+        let alias = alternate_spelling(&node);
+
+        // High count first: a plain `insert` would leave 5 behind.
+        let mut high_first = VectorClock::new();
+        high_first.observe(node.clone(), 9);
+        high_first.observe(alias.clone(), 5);
+        assert_eq!(
+            high_first.get(&node),
+            9,
+            "a lower count arriving later must not lower the clock"
+        );
+
+        let mut low_first = VectorClock::new();
+        low_first.observe(alias.clone(), 5);
+        low_first.observe(node.clone(), 9);
+        assert_eq!(
+            low_first.get(&node),
+            9,
+            "and the result is order-independent"
+        );
+
+        assert_eq!(high_first, low_first);
+        assert_eq!(high_first.len(), 1, "one principal is one entry");
+
+        // Contrast with `insert`, which deliberately keeps overwrite semantics
+        // for callers that mean "set this node to exactly this count".
+        let mut overwritten = VectorClock::new();
+        overwritten.insert(node.clone(), 9);
+        overwritten.insert(alias, 5);
+        assert_eq!(
+            overwritten.get(&node),
+            5,
+            "control: `insert` still overwrites, which is why the restore path \
+             must not use it"
+        );
+    }
+
+    #[test]
+    fn merging_by_max_does_not_disturb_a_clock_without_aliases() {
+        // The fold must be an identity on ordinary input: distinct principals
+        // keep their own counts, and nothing is merged that should not be.
+        let a = KeyPair::generate().unwrap().did().clone();
+        let b = KeyPair::generate().unwrap().did().clone();
+        assert_ne!(
+            a.identifier_bytes().unwrap(),
+            b.identifier_bytes().unwrap(),
+            "CONTROL: two generated keypairs must differ"
+        );
+
+        let decoded = decode_clock(&[(a.as_str().to_string(), 3), (b.as_str().to_string(), 7)]);
+
+        assert_eq!(decoded.len(), 2, "two principals stay two entries");
+        assert_eq!(decoded.get(&a), 3);
+        assert_eq!(decoded.get(&b), 7);
+    }
+
+    #[test]
+    fn a_round_tripped_clock_is_unchanged_and_the_wire_shape_is_a_plain_map() {
+        // Serialization is untouched by the merge: a clock encodes as the same
+        // map it always did, and decoding it returns the same clock. This is the
+        // "no wire byte changes" half of I7 for this type.
+        let a = KeyPair::generate().unwrap().did().clone();
+        let b = KeyPair::generate().unwrap().did().clone();
+
+        let mut clock = VectorClock::new();
+        clock.increment(&a);
+        clock.increment(&a);
+        clock.increment(&b);
+
+        let bytes = icn_encoding::encode(&clock).expect("encode");
+        let back: VectorClock = icn_encoding::decode(&bytes).expect("decode");
+        assert_eq!(back, clock, "a round trip must not change the clock");
+
+        // The encoding is byte-identical to the equivalent plain map, so the
+        // custom decoder reads exactly what the derive wrote.
+        let equivalent = icn_encoding::encode(&WireClock {
+            clock: OrderedClock(&[(a.as_str().to_string(), 2), (b.as_str().to_string(), 1)]),
+        })
+        .expect("encode");
+        let from_map: VectorClock = icn_encoding::decode(&equivalent).expect("decode");
+        assert_eq!(
+            from_map, clock,
+            "the wire shape is a plain DID -> count map, unchanged by I7"
+        );
+    }
 
     #[test]
     fn test_new_clock() {

--- a/icn/crates/icn-governance/src/store.rs
+++ b/icn/crates/icn-governance/src/store.rs
@@ -1225,9 +1225,21 @@ mod did_spelling_vote_integrity {
             "control requires both spellings to decode to one key"
         );
         assert_ne!(
+            canonical.as_str(),
+            alias.as_str(),
+            "control requires the two spellings to be distinct *strings*; if this \
+             fails the alias helper is not producing a re-spelling and the rest of \
+             this test proves nothing"
+        );
+        // The `Did` values themselves are no longer distinct: I7 (#2627) made
+        // equality principal equality, so these two spellings are one principal.
+        // This assertion used to read `assert_ne!(canonical, alias)` and warned
+        // that its failure would mean `Did` had become key-equal. It has, on
+        // purpose — #2641's premise is now the implementation, so what is
+        // asserted here is the textual distinctness the control actually needs.
+        assert_eq!(
             canonical, alias,
-            "control requires the spellings to be distinct under today's Did equality; \
-             if this fails, Did is already key-equal and #2641's premise changed"
+            "post-I7 the two spellings name one principal and must compare equal"
         );
     }
 

--- a/icn/crates/icn-governance/src/tally.rs
+++ b/icn/crates/icn-governance/src/tally.rs
@@ -375,15 +375,27 @@ mod tests {
     /// #2641: where `eligible_voters` names one principal under several
     /// spellings and those spellings delegate to voters who disagree, counting
     /// the first one encountered would make list order the authority over a
-    /// vote. Fail closed instead.
+    /// vote.
+    ///
+    /// **Renamed and re-scoped by the I7 patch (#2627).** It read
+    /// `competing_alias_delegations_fail_closed` and asserted that the *tally*
+    /// refused such a pair. Once `Did` equality became principal equality,
+    /// `add_delegation` stopped accepting the second delegation at all, so the
+    /// conflicting state can no longer be built and there is nothing left for
+    /// the tally to fail on. The guarantee moved earlier and got stronger; the
+    /// close-time guard stays as defence in depth (see the closing comment).
     #[test]
-    fn competing_alias_delegations_fail_closed() {
+    fn competing_alias_delegations_are_refused_before_they_can_conflict() {
         use crate::delegation::{Delegation, DelegationManager, DelegationScope};
 
         let kp = icn_identity::KeyPair::generate().unwrap();
         let delegator = kp.did().clone();
         let alias = alias_spelling(&delegator);
-        assert_ne!(delegator, alias, "control: the spellings must differ");
+        assert_ne!(
+            delegator.as_str(),
+            alias.as_str(),
+            "control: the spellings must differ as *strings*. Comparing the `Did` values themselves stopped proving this at I7 (#2627): they now name one principal and compare equal, which is the property under test"
+        );
 
         let delegate_a = icn_identity::KeyPair::generate().unwrap().did().clone();
         let delegate_b = icn_identity::KeyPair::generate().unwrap().did().clone();
@@ -391,6 +403,14 @@ mod tests {
         let proposal_id = ProposalId::generate();
 
         // One key, two spellings, two different delegates.
+        //
+        // **Updated by the I7 patch (#2627).** Both `add_delegation` calls used
+        // to succeed, because the two spellings were different `Did` values, and
+        // the resulting conflict had to be caught here in the tally. I7 makes
+        // them one principal, so the duplicate guard in `add_delegation` refuses
+        // the second one and the conflicting state can no longer be built
+        // through the public API. The hazard is now prevented rather than
+        // detected, which is strictly the better place for it.
         let mut manager = DelegationManager::new();
         manager
             .add_delegation(Delegation::new(
@@ -399,40 +419,57 @@ mod tests {
                 DelegationScope::Blanket,
             ))
             .unwrap();
-        manager
+        let refused = manager
             .add_delegation(Delegation::new(
                 alias.clone(),
                 delegate_b.clone(),
                 DelegationScope::Blanket,
             ))
-            .unwrap();
+            .expect_err(
+                "a second delegation for the same principal, spelled differently, must be \
+                 refused rather than stored alongside the first",
+            );
+        assert!(
+            refused
+                .to_string()
+                .to_lowercase()
+                .contains("already exists"),
+            "the refusal must name the existing delegation, got: {refused}"
+        );
 
-        // Both delegates vote, and they disagree.
+        // Only the first delegation survives, so one principal has exactly one
+        // delegate however the eligible list spells it — the property the
+        // close-time guard existed to protect.
+        assert_eq!(
+            manager.resolve_delegate(&delegator, &domain_id, &proposal_id),
+            manager.resolve_delegate(&alias, &domain_id, &proposal_id),
+            "both spellings of one principal must resolve to the same delegate"
+        );
+
+        // The tally therefore completes instead of failing closed: there is no
+        // longer a disagreement for eligible-list order to arbitrate.
         let votes = vec![
             Vote::new(proposal_id.clone(), delegate_a, VoteChoice::For),
             Vote::new(proposal_id.clone(), delegate_b, VoteChoice::Against),
         ];
         let eligible = vec![delegator, alias];
 
-        let err =
-            compute_tally_with_delegations(&votes, &eligible, &manager, &domain_id, &proposal_id)
-                .expect_err("eligible-list order must not choose which delegated act counts");
-        assert!(
-            err.to_string().contains("competing delegations"),
-            "must name the competing delegations, got: {err}"
-        );
-
-        let detailed = compute_detailed_tally_with_delegations(
+        compute_tally_with_delegations(&votes, &eligible, &manager, &domain_id, &proposal_id)
+            .expect("with no competing delegation, the tally has no conflict to fail on");
+        compute_detailed_tally_with_delegations(
             &votes,
             &eligible,
             &manager,
             &domain_id,
             &proposal_id,
-        );
-        assert!(
-            detailed.is_err(),
-            "the detailed twin must fail closed on the same evidence"
-        );
+        )
+        .expect("the detailed twin must agree with its counterpart");
+
+        // The close-time guard in `compute_tally_with_delegations` is left in
+        // place on purpose. `DelegationManager` has no load-from-store path
+        // today, so this state is unreachable through the public API — but the
+        // tally takes a manager from its caller, and the guard is what keeps a
+        // future construction path from reintroducing the hazard silently.
     }
 
     #[test]

--- a/icn/crates/icn-identity/src/lib.rs
+++ b/icn/crates/icn-identity/src/lib.rs
@@ -209,7 +209,7 @@ pub fn identifier_bytes_of_spelling(spelling: &str) -> Result<[u8; 32]> {
 /// - They start with "did:icn:" prefix
 /// - The identifier part is valid multibase (base58btc)
 /// - The decoded bytes are exactly 32 bytes (Ed25519 public key size)
-#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize)]
+#[derive(Debug, Clone, Serialize)]
 #[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
 #[cfg_attr(feature = "utoipa", schema(value_type = String, example = "did:icn:z6MkhaXMJznR4sC15gTfA7b6jJ4i7b6jJ4i7b6jJ4i7b"))]
 pub struct Did(String);
@@ -339,6 +339,78 @@ impl Did {
     /// (e.g., anchor module creating DIDs from anchor IDs).
     pub(crate) fn new_unchecked(s: String) -> Self {
         Did(s)
+    }
+}
+
+// I7 (#2627) — `Did` equality and hashing name the **principal**, not the spelling.
+//
+// A `did:icn:` identifier is a multibase encoding of 32 bytes, and multibase has
+// 23 spellings of those same bytes that `Did::from_str` accepts. Deriving
+// `PartialEq`/`Hash` over the inner `String` therefore made one cryptographic
+// principal into up to 23 distinct `HashMap` keys, `HashSet` members and
+// eligible voters. `docs/architecture/IDENTITY_SEMANTICS.md` §11 I7 requires the
+// opposite: equality is *key* equality.
+//
+// **This changes comparison, never representation.** `Debug`, `Display`,
+// `as_str`, `Serialize` and `Deserialize` are untouched, so every durable key,
+// wire byte and signing input a `Did` reaches is byte-for-byte what it was. That
+// is what makes the change rollback-safe — a binary reverted to spelling
+// equality reads exactly the same stored rows
+// (`docs/architecture/n2-a0-stored-key-inventory.md` §12.1 item 5). The other
+// mechanism §11 permits, pinning one encoding at parse time, would instead
+// change what `from_str` *accepts* and strand every alternate-spelled row
+// already on disk, so it is deliberately not what this does.
+//
+// Values that name no principal stay discriminated rather than merged into the
+// decoded population. In production that arm is unreachable: `from_public_key`
+// and `from_str` both validate, `from_anchor_id` encodes exactly 32 bytes, and
+// `new_unchecked` is `pub(crate)` with `from_anchor_id` as its only non-test
+// caller. It exists so that a value naming no principal can never test equal to
+// one that does, however the bytes happen to line up.
+impl PartialEq for Did {
+    fn eq(&self, other: &Self) -> bool {
+        // Identical spellings are the same principal without decoding anything:
+        // `identifier_bytes` is a pure function of the string, so equal strings
+        // take the same arm below and produce the same answer. This keeps the
+        // overwhelmingly common case — one canonical spelling compared with
+        // itself — as cheap as the derive it replaces.
+        if self.0 == other.0 {
+            return true;
+        }
+
+        match (self.identifier_bytes(), other.identifier_bytes()) {
+            // The principals the two spellings name.
+            (Ok(a), Ok(b)) => a == b,
+            // Neither names a principal, so spelling is the only relation left.
+            // Stated rather than folded into the fast path above so this arm
+            // remains correct on its own.
+            (Err(_), Err(_)) => self.0 == other.0,
+            // One names a principal and the other names none: never the same
+            // identity, whatever the bytes look like.
+            (Ok(_), Err(_)) | (Err(_), Ok(_)) => false,
+        }
+    }
+}
+
+impl Eq for Did {}
+
+impl std::hash::Hash for Did {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        match self.identifier_bytes() {
+            // Every accepted spelling of one principal hashes alike, which is
+            // what collapses them to a single entry in a `HashMap`/`HashSet`.
+            Ok(identifier) => {
+                0u8.hash(state);
+                identifier.hash(state);
+            }
+            // A value naming no principal can only be keyed by its spelling.
+            // The discriminant keeps that population from colliding with a
+            // decoded identifier.
+            Err(_) => {
+                1u8.hash(state);
+                self.0.hash(state);
+            }
+        }
     }
 }
 
@@ -611,6 +683,14 @@ impl DidSigner for KeyPair {
 mod tests {
     use super::*;
 
+    /// Hash one value with a fixed-seed hasher so two values can be compared.
+    fn hash_of<T: std::hash::Hash>(value: &T) -> u64 {
+        use std::hash::Hasher as _;
+        let mut hasher = std::collections::hash_map::DefaultHasher::new();
+        value.hash(&mut hasher);
+        hasher.finish()
+    }
+
     #[test]
     fn test_generate_keypair() {
         let kp = KeyPair::generate().unwrap();
@@ -682,6 +762,119 @@ mod tests {
             [2u8; 32],
             "identifier bytes must still resolve"
         );
+    }
+
+    // ---------------------------------------------------------------------
+    // I7 (#2627): the discriminated fallback for values that name no principal.
+    //
+    // These live here rather than in `tests/did_principal_equality.rs` because
+    // `new_unchecked` is `pub(crate)` — the non-decoding population is
+    // deliberately unconstructible from outside the crate, and unreachable in
+    // production (see the note on the `PartialEq` impl). It still needs its own
+    // coverage: the whole point of discriminating it is that it can never be
+    // confused with a decoded principal.
+    // ---------------------------------------------------------------------
+
+    /// Two values that name no principal are compared by spelling, not merged.
+    #[test]
+    fn non_decoding_dids_fall_back_to_spelling_equality() {
+        let a = Did::new_unchecked("did:key:not-an-icn-did".to_string());
+        let b = Did::new_unchecked("did:key:not-an-icn-did".to_string());
+        let c = Did::new_unchecked("did:key:a-different-non-did".to_string());
+
+        assert!(
+            a.identifier_bytes().is_err(),
+            "control: `a` decodes to nothing"
+        );
+        assert!(
+            c.identifier_bytes().is_err(),
+            "control: `c` decodes to nothing"
+        );
+
+        assert_eq!(a, b, "one spelling that names no principal equals itself");
+        assert_eq!(
+            hash_of(&a),
+            hash_of(&b),
+            "equal values must hash equally, whichever arm they take"
+        );
+        assert_ne!(
+            a, c,
+            "two different non-decoding spellings are not one value"
+        );
+    }
+
+    /// A value naming no principal can never equal one that does.
+    ///
+    /// This is what the discriminant in `Hash` buys: without it, a spelling
+    /// whose bytes happened to line up with a decoded identifier could collide
+    /// with a real principal, and `HashMap` would then have to rely on `Eq`
+    /// alone to keep them apart.
+    #[test]
+    fn a_non_decoding_did_never_equals_a_decoded_principal() {
+        let real = KeyPair::generate().unwrap().did().clone();
+        let bytes = real.identifier_bytes().expect("a validated DID decodes");
+
+        // A non-decoding value built from the *same* bytes, so the only thing
+        // keeping them apart is the discrimination itself.
+        let impostor = Did::new_unchecked(format!("did:key:{}", hex::encode(bytes)));
+        assert!(
+            impostor.identifier_bytes().is_err(),
+            "control: the impostor must take the fallback arm"
+        );
+
+        assert_ne!(real, impostor, "a decoded principal is not a spelling");
+        assert_ne!(impostor, real, "and the inequality is symmetric");
+        assert_ne!(
+            hash_of(&real),
+            hash_of(&impostor),
+            "the discriminant must keep the two populations from colliding"
+        );
+
+        let mut set = std::collections::HashSet::new();
+        set.insert(real);
+        set.insert(impostor);
+        assert_eq!(set.len(), 2, "they must occupy two entries, not one");
+    }
+
+    /// `Did` equality is an equivalence relation across both populations.
+    #[test]
+    fn did_equality_is_reflexive_symmetric_and_transitive() {
+        let principal = KeyPair::generate().unwrap().did().clone();
+        let bytes = principal.identifier_bytes().unwrap();
+        let corpus = [
+            principal.clone(),
+            // Two more spellings of that same principal.
+            Did::from_str(&format!(
+                "did:icn:{}",
+                multibase::encode(multibase::Base::Base16Lower, bytes)
+            ))
+            .unwrap(),
+            Did::from_anchor_id(&bytes),
+            // A different principal.
+            KeyPair::generate().unwrap().did().clone(),
+            // Two values naming no principal.
+            Did::new_unchecked("did:key:x".to_string()),
+            Did::new_unchecked("did:key:y".to_string()),
+        ];
+
+        for a in &corpus {
+            assert_eq!(a, a, "reflexive");
+            for b in &corpus {
+                assert_eq!(a == b, b == a, "symmetric: {a:?} vs {b:?}");
+                if a == b {
+                    assert_eq!(
+                        hash_of(a),
+                        hash_of(b),
+                        "equal values must hash equally: {a:?} vs {b:?}"
+                    );
+                }
+                for c in &corpus {
+                    if a == b && b == c {
+                        assert_eq!(a, c, "transitive: {a:?} == {b:?} == {c:?}");
+                    }
+                }
+            }
+        }
     }
 
     #[test]

--- a/icn/crates/icn-identity/tests/did_principal_equality.rs
+++ b/icn/crates/icn-identity/tests/did_principal_equality.rs
@@ -1,0 +1,405 @@
+//! #2627 / I7 — `Did` equality and hashing name the principal, not the spelling.
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+//!
+//! # What this file pins
+//!
+//! A `did:icn:` identifier is a multibase encoding of 32 bytes, and multibase has many
+//! accepted spellings of the same bytes. Before I7, `Did` derived `PartialEq`/`Hash` over
+//! its inner `String`, so one cryptographic principal was up to 23 distinct map keys. I7
+//! makes equality and hashing key on [`Did::identifier_bytes`] instead.
+//!
+//! Two things must both hold, and they pull in opposite directions:
+//!
+//! * **comparison** collapses the spellings of one principal to one identity;
+//! * **representation** — `Debug`, `Display`, `as_str`, `Serialize` — keeps every spelling
+//!   exactly as it was, because every durable key, wire byte and signing input is built
+//!   from those. That is what makes I7 rollback-safe: a binary reverted to spelling
+//!   equality reads the same stored rows
+//!   (`docs/architecture/n2-a0-stored-key-inventory.md` §12.1 item 5).
+//!
+//! The representation half is asserted here as explicitly as the comparison half, because a
+//! patch that "fixed" equality by canonicalizing the string would pass every equality test
+//! in this file and silently re-key live deployments.
+//!
+//! # Non-vacuity
+//!
+//! Every test that claims two spellings are one principal first proves they are **different
+//! strings** that decode to the **same** 32 bytes. A green result therefore cannot come from
+//! the alias being unrepresentable or from the two values being literally identical.
+
+use icn_identity::{Did, KeyPair};
+use std::collections::hash_map::DefaultHasher;
+use std::collections::{HashMap, HashSet};
+use std::hash::{Hash, Hasher};
+
+/// Every multibase base `Did::from_str` accepts, minus `Identity` — which `multibase::encode`
+/// cannot apply to arbitrary key bytes at all. Same corpus the #2640 replay suite and the
+/// `PeerId` tripwire drive, so the three agree on what "an accepted spelling" means.
+const ALTERNATE_SPELLINGS: &[(&str, multibase::Base)] = &[
+    ("base2", multibase::Base::Base2),
+    ("base8", multibase::Base::Base8),
+    ("base10", multibase::Base::Base10),
+    ("base16-lower", multibase::Base::Base16Lower),
+    ("base16-upper", multibase::Base::Base16Upper),
+    ("base32-lower", multibase::Base::Base32Lower),
+    ("base32-upper", multibase::Base::Base32Upper),
+    ("base32-pad-lower", multibase::Base::Base32PadLower),
+    ("base32-pad-upper", multibase::Base::Base32PadUpper),
+    ("base32-hex-lower", multibase::Base::Base32HexLower),
+    ("base32-hex-upper", multibase::Base::Base32HexUpper),
+    ("base32-hex-pad-lower", multibase::Base::Base32HexPadLower),
+    ("base32-hex-pad-upper", multibase::Base::Base32HexPadUpper),
+    ("base32-z", multibase::Base::Base32Z),
+    ("base36-lower", multibase::Base::Base36Lower),
+    ("base36-upper", multibase::Base::Base36Upper),
+    ("base58-flickr", multibase::Base::Base58Flickr),
+    ("base64", multibase::Base::Base64),
+    ("base64-pad", multibase::Base::Base64Pad),
+    ("base64-url", multibase::Base::Base64Url),
+    ("base64-url-pad", multibase::Base::Base64UrlPad),
+    ("base256-emoji", multibase::Base::Base256Emoji),
+];
+
+fn a_principal() -> Did {
+    KeyPair::generate().unwrap().did().clone()
+}
+
+fn hash_of<T: Hash>(v: &T) -> u64 {
+    let mut h = DefaultHasher::new();
+    v.hash(&mut h);
+    h.finish()
+}
+
+/// Re-spell one principal under one base, proving the alias is a different string naming the
+/// same identifier before returning it.
+///
+/// A spelling that stops parsing is a failure, not a skip: letting a rejection quietly reduce
+/// coverage is how this kind of suite rots.
+fn alias_in(base: multibase::Base, label: &str, canonical: &Did) -> Did {
+    let bytes = canonical.identifier_bytes().unwrap();
+    let alias = Did::from_str(&format!("did:icn:{}", multibase::encode(base, bytes)))
+        .unwrap_or_else(|e| {
+            panic!(
+                "the {label} spelling is accepted by `Did::from_str` under current policy and \
+                 this suite's coverage depends on it; it was rejected: {e}. I7 changes \
+                 comparison, not acceptance — if acceptance has been tightened, that is a \
+                 different change and belongs asserted explicitly."
+            )
+        });
+    assert_ne!(
+        alias.as_str(),
+        canonical.as_str(),
+        "CONTROL: the {label} alias must be a different *string*, or it proves nothing"
+    );
+    assert_eq!(
+        alias.identifier_bytes().unwrap(),
+        bytes,
+        "CONTROL: the {label} alias must name the *same principal*, or it is a different DID"
+    );
+    alias
+}
+
+/// One principal, spelled every accepted way: canonical first, then all 22 aliases.
+fn one_principal_every_spelling() -> Vec<(&'static str, Did)> {
+    let canonical = a_principal();
+    let mut out = vec![("base58btc-canonical", canonical.clone())];
+    out.extend(
+        ALTERNATE_SPELLINGS
+            .iter()
+            .map(|(label, base)| (*label, alias_in(*base, label, &canonical))),
+    );
+    out
+}
+
+// ---------------------------------------------------------------------------
+// 1. Two spellings of one principal are one identity.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn two_spellings_of_one_principal_compare_equal() {
+    // Reflexivity first: every spelling equals its own clone.
+    for (label, alias) in one_principal_every_spelling().into_iter().skip(1) {
+        let same = alias.clone();
+        assert_eq!(alias, same, "{label}: a value must equal itself");
+    }
+
+    let canonical = a_principal();
+    for (label, base) in ALTERNATE_SPELLINGS {
+        let alias = alias_in(*base, label, &canonical);
+        assert_eq!(
+            canonical, alias,
+            "{label} spells the same 32 identifier bytes as the canonical form, so it names \
+             the same principal and must compare equal (#2627 / I7)"
+        );
+        assert_eq!(alias, canonical, "{label}: equality must be symmetric");
+    }
+}
+
+#[test]
+fn two_spellings_of_one_principal_hash_identically() {
+    let canonical = a_principal();
+    for (label, base) in ALTERNATE_SPELLINGS {
+        let alias = alias_in(*base, label, &canonical);
+        assert_eq!(
+            hash_of(&canonical),
+            hash_of(&alias),
+            "{label}: equal values must hash equally, or `HashMap<Did, _>` is unsound"
+        );
+    }
+}
+
+#[test]
+fn every_spelling_of_one_principal_is_one_hash_set_member() {
+    let spellings = one_principal_every_spelling();
+    assert_eq!(spellings.len(), 23, "canonical plus 22 aliases");
+
+    let set: HashSet<Did> = spellings.iter().map(|(_, d)| d.clone()).collect();
+    assert_eq!(
+        set.len(),
+        1,
+        "23 accepted spellings of one principal must collapse to one `HashSet` member, got {}",
+        set.len()
+    );
+}
+
+#[test]
+fn every_spelling_of_one_principal_is_one_map_identity() {
+    let spellings = one_principal_every_spelling();
+
+    // Insert under each spelling in turn; each must land on the same entry.
+    let mut map: HashMap<Did, u32> = HashMap::new();
+    for (_, did) in &spellings {
+        *map.entry(did.clone()).or_insert(0) += 1;
+    }
+
+    assert_eq!(
+        map.len(),
+        1,
+        "23 spellings of one principal must be one key, got {}",
+        map.len()
+    );
+    assert_eq!(
+        map.values().next(),
+        Some(&23),
+        "all 23 insertions must have accumulated on that one key"
+    );
+
+    // And a lookup under any spelling finds the entry stored under any other.
+    for (label, did) in &spellings {
+        assert!(
+            map.contains_key(did),
+            "{label} must find the entry stored under the canonical spelling"
+        );
+    }
+}
+
+// ---------------------------------------------------------------------------
+// 2. Two distinct principals stay two.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn two_distinct_principals_stay_unequal_and_stay_two_keys() {
+    let a = a_principal();
+    let b = a_principal();
+    assert_ne!(
+        a.identifier_bytes().unwrap(),
+        b.identifier_bytes().unwrap(),
+        "CONTROL: two generated keypairs must actually differ"
+    );
+
+    assert_ne!(a, b, "distinct principals must not be merged");
+
+    let set: HashSet<Did> = [a.clone(), b.clone()].into_iter().collect();
+    assert_eq!(set.len(), 2, "two principals are two hash keys");
+
+    // Over-collapse guard across the whole spelling class: no spelling of `a` may ever
+    // equal any spelling of `b`.
+    for (la, base_a) in ALTERNATE_SPELLINGS {
+        let sa = alias_in(*base_a, la, &a);
+        for (lb, base_b) in ALTERNATE_SPELLINGS {
+            let sb = alias_in(*base_b, lb, &b);
+            assert_ne!(
+                sa, sb,
+                "{la} of one principal must never equal {lb} of another"
+            );
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// 3. The non-decoding population stays discriminated.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn an_anchor_derived_principal_keys_by_its_identifier() {
+    // `from_anchor_id` bypasses parsing, so its 32 bytes need not be an Ed25519 point — but
+    // it still encodes exactly 32 bytes, so it takes the *decoded* arm, not the fallback.
+    // This is the production constructor that could otherwise have reached the fallback.
+    let anchor = Did::from_anchor_id(&[7u8; 32]);
+    assert!(
+        anchor.to_verifying_key().is_err(),
+        "CONTROL: this anchor id is deliberately not a valid Ed25519 point"
+    );
+    assert_eq!(
+        anchor.identifier_bytes().unwrap(),
+        [7u8; 32],
+        "CONTROL: the decoded arm is the one this DID takes"
+    );
+
+    assert_eq!(
+        anchor,
+        Did::from_anchor_id(&[7u8; 32]),
+        "one anchor is one principal"
+    );
+    assert_ne!(
+        anchor,
+        Did::from_anchor_id(&[8u8; 32]),
+        "two anchors are two principals"
+    );
+    assert_eq!(
+        hash_of(&anchor),
+        hash_of(&Did::from_anchor_id(&[7u8; 32])),
+        "equal anchors must hash equally"
+    );
+}
+
+#[test]
+fn a_principal_and_an_anchor_naming_the_same_bytes_are_the_same_principal() {
+    // The two construction paths must not disagree about identity: `from_anchor_id` and
+    // `from_str` over the same 32 bytes name one principal.
+    let key = a_principal();
+    let bytes = key.identifier_bytes().unwrap();
+    let anchored = Did::from_anchor_id(&bytes);
+
+    assert_eq!(
+        anchored.identifier_bytes().unwrap(),
+        bytes,
+        "CONTROL: both name the same identifier"
+    );
+    assert_eq!(
+        key, anchored,
+        "construction path must not change which principal a DID names"
+    );
+    assert_eq!(
+        hash_of(&key),
+        hash_of(&anchored),
+        "equal values hash equally"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// 4. Representation is untouched. This is the rollback guarantee.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn equality_is_principal_sensitive_but_representation_stays_spelling_sensitive() {
+    let canonical = a_principal();
+
+    for (label, base) in ALTERNATE_SPELLINGS {
+        let alias = alias_in(*base, label, &canonical);
+
+        // Equal as identities...
+        assert_eq!(canonical, alias, "{label}: same principal");
+
+        // ...and still distinguishable as representations. Every durable key, wire byte and
+        // signing input in the workspace is built from one of these four, so if any of them
+        // collapsed, I7 would be moving persisted bytes — which it must not.
+        assert_ne!(
+            canonical.as_str(),
+            alias.as_str(),
+            "{label}: `as_str` must still return the original spelling"
+        );
+        assert_ne!(
+            canonical.to_string(),
+            alias.to_string(),
+            "{label}: `Display` must still render the original spelling"
+        );
+        assert_ne!(
+            format!("{canonical:?}"),
+            format!("{alias:?}"),
+            "{label}: `Debug` must still render the original spelling — \
+             `icn-ccl`'s contract code hash is SHA-256 over `Debug` of each participant"
+        );
+        assert_ne!(
+            serde_json::to_string(&canonical).unwrap(),
+            serde_json::to_string(&alias).unwrap(),
+            "{label}: serde must still emit the original spelling"
+        );
+    }
+}
+
+#[test]
+fn representation_round_trips_byte_for_byte_under_every_spelling() {
+    // Pin the exact bytes rather than only their inequality: a `Did` renders as its spelling
+    // and nothing else, and a serde round-trip returns the same spelling it was given.
+    for (label, did) in one_principal_every_spelling() {
+        let spelling = did.as_str().to_string();
+
+        assert_eq!(
+            did.to_string(),
+            spelling,
+            "{label}: `Display` is the spelling"
+        );
+        assert_eq!(
+            format!("{did:?}"),
+            format!("Did({spelling:?})"),
+            "{label}: `Debug` is the derived newtype form over the spelling"
+        );
+
+        let json = serde_json::to_string(&did).unwrap();
+        assert_eq!(
+            json,
+            serde_json::to_string(&spelling).unwrap(),
+            "{label}: a `Did` serializes exactly as the string that spells it"
+        );
+
+        let back: Did = serde_json::from_str(&json).unwrap();
+        assert_eq!(
+            back.as_str(),
+            spelling,
+            "{label}: a serde round-trip must not canonicalize the spelling"
+        );
+
+        // `icn-encoding` (postcard) is the wire and storage codec, so pin it too.
+        let wire = icn_encoding::encode(&did).unwrap();
+        assert_eq!(
+            wire,
+            icn_encoding::encode(&spelling).unwrap(),
+            "{label}: the wire encoding of a `Did` is the encoding of its spelling"
+        );
+        let back: Did = icn_encoding::decode(&wire).unwrap();
+        assert_eq!(
+            back.as_str(),
+            spelling,
+            "{label}: a wire round-trip must not canonicalize the spelling"
+        );
+    }
+}
+
+#[test]
+fn acceptance_is_unchanged_by_i7() {
+    // I7 changes comparison, not parsing. Every spelling that parsed before still parses,
+    // and the things that were rejected still are. If a future tranche pins an encoding at
+    // parse time, this test is where that shows up.
+    let canonical = a_principal();
+    let bytes = canonical.identifier_bytes().unwrap();
+    for (label, base) in ALTERNATE_SPELLINGS {
+        assert!(
+            Did::from_str(&format!("did:icn:{}", multibase::encode(*base, bytes))).is_ok(),
+            "{label} must still be accepted"
+        );
+    }
+
+    for bad in [
+        "did:key:z6MkhaXMJznR4sC15gTfA7b6jJ4i7b6jJ4i7b6jJ4i7b",
+        "did:icn:",
+        "did:icn:!!!not-multibase!!!",
+        "not-a-did",
+        "",
+    ] {
+        assert!(
+            Did::from_str(bad).is_err(),
+            "{bad:?} must still be rejected"
+        );
+    }
+}

--- a/icn/crates/icn-net/src/topology.rs
+++ b/icn/crates/icn-net/src/topology.rs
@@ -50,8 +50,35 @@ impl PartialOrd for PeerId {
 
 impl Ord for PeerId {
     fn cmp(&self, other: &Self) -> std::cmp::Ordering {
-        // Order by DID string representation
-        self.0.to_string().cmp(&other.0.to_string())
+        // I7 (#2627): order by the principal the DID names, not by its spelling.
+        //
+        // `PeerId` derives `PartialEq`/`Eq`/`Hash` from `Did`, so when `Did`
+        // equality became principal equality this comparator had to move in the
+        // same commit. Rust's ordered containers require the biconditional
+        // `a == b  <=>  a.cmp(b) == Ordering::Equal`, and `NeighborSets` keeps
+        // the same peers in four `BTreeSet`s *and* a `HashMap`: if the two
+        // notions disagree, `remove_neighbor` drops a peer from one and orphans
+        // its metadata row in the other, and the cardinality of those sets —
+        // which `enforce_limit` reads to decide whether a neighbour class is
+        // full — starts counting one principal several times.
+        // `tests/peerid_i7_ordering_tripwire.rs` asserts that biconditional
+        // directly rather than either side's current value.
+        match (self.0.identifier_bytes(), other.0.identifier_bytes()) {
+            // The principals the two spellings name — the same bytes `Did`'s
+            // equality and hash now key on.
+            (Ok(a), Ok(b)) => a.cmp(&b),
+            // Values naming no principal are ordered among themselves by
+            // spelling, which is the relation `Did` equality falls back to for
+            // exactly that population.
+            (Err(_), Err(_)) => self.0.as_str().cmp(other.0.as_str()),
+            // The two populations never interleave, so a value naming no
+            // principal can never compare `Equal` to one that does — which is
+            // what `Did`'s equality says about that pair. Ordering within each
+            // class is total and the classes are totally ordered, so this is a
+            // total order.
+            (Ok(_), Err(_)) => std::cmp::Ordering::Less,
+            (Err(_), Ok(_)) => std::cmp::Ordering::Greater,
+        }
     }
 }
 

--- a/icn/crates/icn-net/tests/peerid_i7_ordering_tripwire.rs
+++ b/icn/crates/icn-net/tests/peerid_i7_ordering_tripwire.rs
@@ -44,7 +44,7 @@
 //! implementer to delete it.
 //!
 //! That property is easy to lose by accident, so it is measured rather than assumed. Every
-//! test here except [`pre_i7_regime_record_every_spelling_is_its_own_peer`] — which is
+//! test here except [`post_i7_regime_record_every_spelling_is_one_peer`] — which is
 //! deliberately regime-dependent and says so — was run against a simulated correct I7 patch
 //! (`Did` equality and hash over `identifier_bytes`, `PeerId::Ord` over the same, both with a
 //! defined order for identifiers that do not decode) and stayed green. Anything added here
@@ -229,13 +229,17 @@ fn ordered_and_hashed_agree_on_one_respelled_principal() {
     );
 }
 
-/// A record of which regime production is in. **Expected to be edited by the I7 patch.**
+/// A record of which regime production is in. **Edited by the I7 patch, as designed.**
 ///
 /// Unlike every other test here this one is deliberately regime-*dependent*, so that the count
-/// change is visible in the I7 diff rather than implicit. It is not a requirement that the
-/// count stay 23.
+/// change is visible in the I7 diff rather than implicit. It read 23 — one peer per accepted
+/// spelling — until `Did` equality became principal equality (#2627); it now reads 1.
+///
+/// The flip was made only after every regime-agnostic test in this file was green under the
+/// new implementation, which is the order the pre-I7 version of this test demanded. It is the
+/// single expectation in this suite that I7 was permitted to move.
 #[test]
-fn pre_i7_regime_record_every_spelling_is_its_own_peer() {
+fn post_i7_regime_record_every_spelling_is_one_peer() {
     let spellings = one_principal_every_spelling();
     assert_eq!(spellings.len(), 23, "canonical plus 22 aliases");
 
@@ -246,15 +250,14 @@ fn pre_i7_regime_record_every_spelling_is_its_own_peer() {
 
     assert_eq!(
         ordered.len(),
-        23,
-        "one principal spelled 23 ways currently counts as {} peers, not 23.\n\
+        1,
+        "one principal spelled 23 ways counts as {} peers, not 1.\n\
          \n\
-         If it is 1, `Did` equality has adopted I7 (#2627) — that is the intended destination, \
-         not a bug. Confirm that \
-         `peerid_eq_and_ord_must_agree_in_whatever_regime_production_is_in` and the \
-         `NeighborSets` tests in this file are green, then change this expectation to 1. Do \
-         not change it while any of those is red: that would be recording the half-completed \
-         state as if it were the goal.",
+         If it is 23, `Did` equality has reverted to comparing spellings and I7 (#2627) has \
+         been undone — the 23 accepted multibase spellings of one identifier are one \
+         cryptographic principal, and `PeerId` must hold one peer for them. Any other value \
+         means `PeerId::Ord` and the derived `Eq`/`Hash` disagree; see \
+         `peerid_eq_and_ord_must_agree_in_whatever_regime_production_is_in`.",
         ordered.len()
     );
 }


### PR DESCRIPTION
Implements **N2-A invariant I7** (#2627): `Did` equality and hashing name the
**cryptographic principal**, not the textual DID spelling.

`docs/architecture/IDENTITY_SEMANTICS.md` §11 I7 permits two mechanisms. This PR
takes **equality/hash over decoded identifier bytes**, not encoding-pinned-at-parse.
The N2-A0 inventory §12.1 item 5 is decisive: equality-over-bytes changes no durable
byte and no acceptance, so a binary rolled back to spelling equality reads exactly the
same stored rows. Pin-at-parse changes what `Did::from_str` accepts and would strand
every alternate-spelled row already on disk.

**I7 changes identity comparison semantics, not representation semantics.**

## The atomic set

Both production changes are in one commit because neither is coherent alone (#2684
established this).

### 1. `Did` — `icn-identity/src/lib.rs`

Derived `PartialEq`/`Eq`/`Hash` removed and written out. Equality and hashing key on
`Did::identifier_bytes()`. Values that name no principal stay **discriminated** —
hashed under a `1u8` tag over the spelling, never equal to a decoded principal — so
the non-decoding spelling space cannot collide with a real principal.

`eq` short-circuits on identical spellings. That is sound because
`identifier_bytes_of_spelling` is a pure function of the string, so equal strings take
the same arm and give the same answer; it keeps the common case as cheap as the derive.

The fallback arm is **unreachable in production**, re-verified against the checkout:
`from_public_key` and `from_str` validate, `from_anchor_id` encodes exactly 32 bytes,
and `new_unchecked` is `pub(crate)` with `from_anchor_id` as its only non-test caller.

### 2. `PeerId::Ord` — `icn-net/src/topology.rs`

Ordered by the same decoded bytes, with a total tie-break: values naming no principal
form a second class ordered by spelling, and the two classes never interleave — so a
non-decoding value can never compare `Equal` to a decoded principal unless `Eq` agrees.

This **must** move in the same commit. `PeerId` derives `Eq`/`Hash` from `Did`, and
`NeighborSets` keeps the same peers in four `BTreeSet`s *and* a `HashMap`. If the two
notions disagree, `remove_neighbor` orphans metadata rows and `local_cluster.len()` —
an admission limit at `handshake.rs` / `hello.rs` — counts one principal many times.

### 3. Gossip vector clock — `icn-gossip/src/vector_clock.rs`

`SerializedClock { clock: HashMap<Did, u64> }` deserialized via the derive, which is
last-writer-wins. Once aliases can collapse, a clock carrying `{spelling_a: 9,
spelling_b: 5}` decodes to **5** — a vector-clock counter moving backwards. A custom
`visit_map` folds duplicate principals by **max**, matching `VectorClock::merge` and
the `VectorClockProjection::from_entries` precedent the inventory names (§12.1 (ii)).

Safe in both regimes (pre-I7 nothing collapses, so the fold is an identity), reads the
same postcard map shape, and **serialization is untouched** — no wire byte changes.

## Representation is unchanged — proven, not asserted

`Debug`, `Display`, `as_str()`, serde and the postcard wire encoding are byte-for-byte
what they were. `representation_round_trips_byte_for_byte_under_every_spelling` pins
the exact bytes for all 23 spellings, and
`equality_is_principal_sensitive_but_representation_stays_spelling_sensitive` asserts
the intentional split: two spellings are **equal as identities** and **distinguishable
as representations**.

This is load-bearing beyond rollback: `icn-ccl`'s contract code hash is SHA-256 over
`Debug` of each participant, so `contract_code_hash_golden.rs` — including
`discriminates_aliases_being_principalized_early` — stays green *only because* `Debug`
is untouched. It is unchanged.

## The tripwire, and the regime-dependent expectations

`icn-net/tests/peerid_i7_ordering_tripwire.rs` was run **before** any expectation
was edited. All 9 regime-agnostic coherence tests went green under the new
implementation; the single deliberately regime-dependent record was the only
failure. Only then was it flipped **23 → 1**, and renamed
`pre_i7_…is_its_own_peer` → `post_i7_…is_one_peer` so the name does not assert
the opposite of what it checks.

**Correction to the cutover-readiness assessment.** It predicted "exactly one
test is designed to flip." There are **fifteen**, and none is a production
behaviour change:

| Where | Count | What |
|---|---|---|
| `peerid_i7_ordering_tripwire.rs` | 1 | the designed 23 → 1 flip |
| `icn-ccl/tests/value_did_hash.rs` | 2 | #2681's own record of the deliberate hash/equality gap that I7 closes |
| governance (4 files) | 12 | controls of the form `assert_ne!(did_a, did_b, "the spellings must differ")` |

The twelve governance ones are a single class: the intent was *textual*
distinctness but the assertion compared `Did` **values**. They now compare
`as_str()`, which is what they were always about and is true in both regimes.
`icn-governance/src/store.rs` carried an explicit self-documenting tripwire —
*"if this fails, `Did` is already key-equal and #2641's premise changed"* — which
fired exactly as designed; it now asserts textual distinctness **and** that the
two spellings compare equal, so the file records that I7 landed.

Every governance edit is inside `#[cfg(test)]`, verified by hunk position
against each file's `#[cfg(test)]` marker. The production surface is three files.

## Three delegation tests re-scoped — I7 moved a guard earlier

`add_delegation`'s existing self-delegation (`delegator == delegate`) and
duplicate (`get_active_delegation`) guards are written in terms of `Did`
equality, so I7 makes them principal-aware for free. Two attacks #2641 had to
catch downstream now fail at creation:

* delegating from one spelling of your key to another (vote laundering);
* holding two competing delegations under two spellings (list-order arbitrage).

The tests were written to *build* that hazardous state and assert `close` failed
closed. The state can no longer be built, so they now assert the earlier
refusal. **The close-time guard in `compute_tally_with_delegations` is kept**:
`DelegationManager` has no load-from-store path today and delegations are not
persisted, but the tally takes a manager from its caller, so the guard is what
keeps a future construction path honest. That reasoning is recorded in the tests
rather than left for someone to rediscover and "tidy up".

## Mutation evidence

Reverting `Did::eq`/`hash` to `self.0 == other.0` while keeping the new
expectations:

| Suite | Failed under mutation |
|---|---|
| `icn-identity/tests/did_principal_equality.rs` | **5 of 10** |
| `icn-net/tests/peerid_i7_ordering_tripwire.rs` | **6 of 10**, incl. `peerid_eq_and_ord_must_agree_…` |
| `icn-gossip` vector clock | `an_aliased_clock_merges_to_the_maximum_count_in_either_order` |

`representation_round_trips_byte_for_byte_under_every_spelling` and
`acceptance_is_unchanged_by_i7` stayed green in **both** regimes — they are meant
to be regime-insensitive, and a suite where everything flipped would mean the
representation tests were secretly testing equality. `Compiling icn-identity` /
`Compiling icn-net` were confirmed in every run, since a preserved-mtime restore
silently serves a stale rlib.

## Scope

Not changed: Rule A / `icn-ccl/src/code_hash.rs`, Rule B / `registry::compute_hash`,
contract hashing/encoding, DID canonicalization, DID parsing/acceptance,
`icn-commons` weak-holder IDs, `EntityId::from_did`, `StewardId::from_did`, ZKP
spelling-derived hashes, `icn-net/src/discovery.rs`, the kernel `Did = String` alias
(N2-H #2629), unvalidated constructors (N2-B #2628), §7.5 persisted membership or vote
re-keying, the startup fail-closed guard, the load/write-back migration audit,
deployment scanning, quiescence, #2682 / #2683, and the dormant
`CompressedVectorClock` (verified: no constructor outside its own file and tests).

**This PR changes no persisted key bytes.** The concrete evidence is
`SledGovernanceStore::vote_key`, the most safety-sensitive keyspace in the repo:
it is `format!("vote:{}:{}", proposal_id.0, voter)`, i.e. `Display`, which I7
does not touch. Two alias-spelled votes therefore still persist as two distinct
rows — which is exactly what keeps the §7.5 fail-closed guard able to detect a
conflict. Had I7 canonicalized the spelling instead, those rows would have
merged at write time and the conflict would have become undetectable. No
migration is run and no stored data is rewritten. The N2-A deployment/cutover
lane remains separately blocked.

## Known cost

`Did::hash` now performs a multibase decode on every hash, where it previously
hashed a string; `eq` has an equal-spelling fast path but `hash` cannot have one,
since it must be spelling-independent. With ~71 `HashMap<Did, _>` sites this is a
real hot-path cost. Caching decoded bytes in `Did` would change the struct layout
and put the `#[derive(Serialize)]` newtype transparency at risk — precisely the
representation invariant this PR exists to preserve — so it belongs in its own
change, not here.

## §7.5 boundary

No persisted governance membership or vote row is re-keyed.

The intended side effect is stated rather than discovered: `HashSet<Did>::contains` on
a membership list becomes principal-aware, so a valid alternate spelling can satisfy
membership for the same principal. Verified this changes no count — `icn-governance`'s
tally is keyed by `VotingPrincipal([u8; 32])` throughout (`counted`, `vote_map`,
`DelegationResolution`), so one cryptographic voter is one effective vote and the
quorum denominator is unaffected, independently of `Did::Eq` (#2677).

## Closes

Part of #2627. Does not close it — the cutover lane is separate.
