### PR TITLE
test(net): make the fused-accept cancellation test deterministic

### DIFF
--- a/icn/crates/icn-net/tests/accept_handshake_cancellation.rs
+++ b/icn/crates/icn-net/tests/accept_handshake_cancellation.rs
@@ -56,9 +56,19 @@
 //!   client *does* reach verification — and sits there, so the Finished flight the server
 //!   is waiting on is still a second away. This is the path that used to lose the race.
 //!
-//! For a whole second after the server pops the `Incoming` there is therefore *no* completed
-//! handshake to hand over — not unlikely, impossible — however long any thread is
-//! descheduled for. The negative assertion below is causal rather than probabilistic.
+//! For a whole second after the server pops the `Incoming` there is therefore no completed
+//! handshake to hand over. The negative assertion below no longer depends on the cancellation
+//! *winning* anything — only on the polling thread resuming within that second.
+//!
+//! Be precise about what that buys: it is a bound, not a synchronisation barrier. A pause
+//! longer than the stall would still defeat it. What changes is the size and the kind of the
+//! margin — from "one poll must beat a sub-millisecond loopback handshake", which the
+//! scheduler lost roughly once in twenty runs, to "a thread must resume within a second",
+//! roughly 80x the worst delay measured here. A true happens-before is possible (have the
+//! verifier block on a latch the loop releases on its next cancellation after the client
+//! signals that it is verifying) and is deliberately left as a follow-up: this is a bound
+//! wide enough to be sound in practice, and swapping it for a new synchronisation protocol
+//! is not a de-flaking change.
 //!
 //! That is verified rather than argued: injecting a 50ms block between `Incoming::accept()`
 //! and the first poll of the resulting `Connecting` — the second path above, made
@@ -135,10 +145,10 @@ const POLL_GAP: Duration = Duration::from_millis(5);
 
 /// How long the client below is held inside its own certificate verification.
 ///
-/// This is a *causal barrier*, not a margin to be tuned: while the client sits here it has
-/// not sent its Finished flight, so the server-side handshake cannot complete no matter how
-/// long the server's thread is descheduled for. A second is orders of magnitude beyond any
-/// scheduling delay observed on a loaded host. It is not normally waited out at all — on
+/// While the client sits here it has not sent its Finished flight, so the server-side
+/// handshake cannot complete — for this long. That is the bound the negative assertion rests
+/// on, and a second is roughly 80x the worst scheduling delay measured on a loaded host. It
+/// is a wide bound rather than a true happens-before; see the module docs. It is not normally waited out at all — on
 /// the ordinary path the accept is cancelled before the server transmits, so the client
 /// never reaches verification and the stall never engages.
 const HANDSHAKE_BARRIER: Duration = Duration::from_secs(1);

--- a/icn/crates/icn-net/tests/accept_handshake_cancellation.rs
+++ b/icn/crates/icn-net/tests/accept_handshake_cancellation.rs
@@ -20,25 +20,66 @@
 //! rather than threshold failure, which is why the defect presented as an intermittent
 //! flake. (The arrival-phase distribution was not measured; no exact rate is claimed.)
 //!
-//! These tests pin the boundary deterministically, by construction rather than by
-//! shrinking a duration until failure becomes likely. `tokio::time::timeout` polls its
-//! inner future *before* it checks the deadline, so a `Duration::ZERO` budget grants
-//! exactly one poll. That single poll is enough to tell the two phases apart:
+//! These tests pin the boundary deterministically, and how they do it is the whole design,
+//! because the obvious way does not work.
+//!
+//! The obvious way is to cancel on a budget too short for a handshake and assert that no
+//! connection came out. **Every version of that is a race, and the race is against the
+//! scheduler, not against the network.** Shrinking the budget does not fix it:
+//!
+//! - "1ms is shorter than any handshake" is false. A warm loopback handshake completes in
+//!   well under a millisecond, and the test then passes for the wrong reason.
+//! - `tokio::time::timeout(Duration::ZERO, ..)` reads like a one-poll budget and is not.
+//!   `timeout` does poll its inner future before checking the deadline, but tokio's timer
+//!   wheel has millisecond granularity and rounds deadlines **up**, so that timers never
+//!   fire early. A zero-duration sleep is therefore pending on its first poll and elapses
+//!   at the next tick, so the inner future is polled again — and again, for as long as the
+//!   timer driver takes to get there. Measured at 0.6ms to 12ms on a loaded 4-core box:
+//!   the previous bullet wearing a disguise, and it flaked accordingly (5 of 8 runs).
+//! - Even a *genuine* single poll is unsafe, which is the subtle one. A poll is
+//!   synchronous but it is not atomic: within one poll the fused accept pops the
+//!   `Incoming`, calls `Incoming::accept()` — which hands the connection to the endpoint
+//!   driver — and only then polls the resulting `Connecting`. The thread can be preempted
+//!   between those last two steps, and under contention that gap is long enough for the
+//!   driver to finish the round trip and signal completion first (1 failure in 20 loaded
+//!   runs).
+//!
+//! So the budget is not what makes these tests deterministic. **The client is.** It stalls
+//! inside its own verification of the server's certificate, which gates its Finished
+//! flight, which is precisely what the server's handshake is waiting on. That leaves two
+//! paths out of a cancelled accept, and neither can yield a connection:
+//!
+//! - The cancellation lands before the server transmits, so the attempt is destroyed with
+//!   nothing on the wire and the client sees only the implicit close. This is the ordinary
+//!   path, and the stall never even engages.
+//! - The polling thread is descheduled long enough for the server to transmit. Now the
+//!   client *does* reach verification — and sits there, so the Finished flight the server
+//!   is waiting on is still a second away. This is the path that used to lose the race.
+//!
+//! For a whole second after the server pops the `Incoming` there is therefore *no* completed
+//! handshake to hand over — not unlikely, impossible — however long any thread is
+//! descheduled for. The negative assertion below is causal rather than probabilistic.
+//!
+//! That is verified rather than argued: injecting a 50ms block between `Incoming::accept()`
+//! and the first poll of the resulting `Connecting` — the second path above, made
+//! deterministic — fails this test 3 times out of 3 with the stall removed and passes 3
+//! times out of 3 with it restored.
+//!
+//! With the race gone, the cancellation can be as sharp as we like, and [`one_poll`] makes
+//! it exactly one poll with no timer involved. That sharpness is what tells the two phases
+//! apart:
 //!
 //! - `Endpoint::accept()` pops an already-queued `Incoming` on its first poll, so the
-//!   cancel-safe phase always survives a zero budget.
-//! - `Connecting::poll` reads a oneshot that the freshly-spawned connection driver cannot
-//!   possibly have signalled yet, so the handshake phase never survives one.
+//!   cancel-safe phase survives cancellation however often it is repeated.
+//! - The fused accept consumes that `Incoming` into a `Connecting` on the same poll, so
+//!   cancelling there destroys the attempt outright.
 //!
-//! A zero budget is therefore not a strawman duration — it is the sharpest available
+//! A one-poll budget is therefore not a strawman duration — it is the sharpest available
 //! probe for *where the cancellation boundary sits*. The production 100ms value has the
 //! same defect with a merely probabilistic trigger.
 //!
-//! Two earlier attempts at this test are worth recording, because both produce
-//! false confidence:
+//! One further false oracle is worth recording:
 //!
-//! - A "1ms is shorter than any handshake" budget is not: a warm loopback handshake can
-//!   complete in well under a millisecond, and the test then passes for the wrong reason.
 //! - The *client's* view is not a valid oracle. The server can complete the handshake,
 //!   let the client's `connect()` resolve `Ok`, and only then discard the connection — so
 //!   asserting `connect()` failed is flaky. This is not merely a test artifact: it is
@@ -53,18 +94,53 @@ use icn_identity::IdentityBundle;
 use icn_net::session::SessionManager;
 use icn_net::{NetworkActor, NetworkMessage, VersionInfo};
 use quinn::{ClientConfig, Endpoint};
+use std::future::Future;
 use std::net::SocketAddr;
 use std::sync::Arc;
+use std::task::Poll;
 use std::time::Duration;
 
-/// A one-poll budget. See the module docs: this is what makes the tests deterministic
-/// rather than a race against how fast the host completes a loopback handshake.
-const ONE_POLL: Duration = Duration::ZERO;
+/// Drive `fut` for exactly one poll, then drop it — the production loop's cancellation
+/// reduced to its essence.
+///
+/// Returns `Some(output)` if that single poll completed the future, `None` if it was still
+/// pending and was therefore cancelled.
+///
+/// No timer is involved, which is the point. A `tokio::time::timeout` budget — even
+/// `Duration::ZERO` — is a *wall-clock* budget, so its width is set by how promptly the
+/// timer driver runs, and on a loaded host that stretches into the milliseconds a loopback
+/// handshake needs. Granting one poll by construction removes that source of slack.
+///
+/// It does not remove all of it, and nothing at this layer could: a poll is not atomic, so
+/// the peer can still make progress while the polling thread is descheduled mid-poll. What
+/// actually makes the callers below sound is the stalled client, not the width of this
+/// budget. See the module docs.
+async fn one_poll<F: Future>(fut: F) -> Option<F::Output> {
+    let mut fut = std::pin::pin!(fut);
+    std::future::poll_fn(|cx| {
+        Poll::Ready(match fut.as_mut().poll(cx) {
+            Poll::Ready(output) => Some(output),
+            Poll::Pending => None,
+        })
+    })
+    .await
+    // `fut` is dropped here, exactly as the production loop dropped its cancelled accept.
+}
 
-/// Spacing between accept attempts, so a zero-budget loop does not spin hot while it
+/// Spacing between accept attempts, so a one-poll loop does not spin hot while it
 /// waits for the client's first packet to arrive. This sits *outside* the accept, so it
 /// has no bearing on the property under test.
 const POLL_GAP: Duration = Duration::from_millis(5);
+
+/// How long the client below is held inside its own certificate verification.
+///
+/// This is a *causal barrier*, not a margin to be tuned: while the client sits here it has
+/// not sent its Finished flight, so the server-side handshake cannot complete no matter how
+/// long the server's thread is descheduled for. A second is orders of magnitude beyond any
+/// scheduling delay observed on a loaded host. It is not normally waited out at all — on
+/// the ordinary path the accept is cancelled before the server transmits, so the client
+/// never reaches verification and the stall never engages.
+const HANDSHAKE_BARRIER: Duration = Duration::from_secs(1);
 
 /// How long an accept loop is given to produce a connection before the test gives up.
 /// This is a hang guard, not the assertion — the assertions below are about *whether* a
@@ -92,6 +168,25 @@ fn client_endpoint() -> Result<Endpoint> {
     let bundle = IdentityBundle::generate()?;
     let rustls_client =
         icn_net::tls::create_tofu_client_config(vec![bundle.tls_cert().clone()], bundle.tls_key())?;
+    let mut endpoint = Endpoint::client("127.0.0.1:0".parse()?)?;
+    endpoint.set_default_client_config(ClientConfig::new(Arc::new(
+        quinn::crypto::rustls::QuicClientConfig::try_from(rustls_client)?,
+    )));
+    Ok(endpoint)
+}
+
+/// The same legitimate client, but stalled inside its own verification of the server's
+/// certificate for `stall`.
+///
+/// See [`StallingServerCertVerifier`] below for why that placement lengthens the *server's*
+/// handshake without touching the server's TLS semantics.
+fn stalling_client_endpoint(stall: Duration) -> Result<Endpoint> {
+    let bundle = IdentityBundle::generate()?;
+    let mut rustls_client = rustls::ClientConfig::builder()
+        .dangerous()
+        .with_custom_certificate_verifier(Arc::new(StallingServerCertVerifier::new(stall)))
+        .with_client_auth_cert(vec![bundle.tls_cert().clone()], bundle.tls_key())?;
+    rustls_client.alpn_protocols = vec![b"icn/1".to_vec()];
     let mut endpoint = Endpoint::client("127.0.0.1:0".parse()?)?;
     endpoint.set_default_client_config(ClientConfig::new(Arc::new(
         quinn::crypto::rustls::QuicClientConfig::try_from(rustls_client)?,
@@ -144,34 +239,58 @@ async fn an_uncancelled_accept_completes_the_inbound_handshake() -> Result<()> {
 async fn a_fused_accept_cancelled_after_one_poll_destroys_the_handshake() -> Result<()> {
     init();
     let (server, addr) = start_server().await?;
-    let client = client_endpoint()?;
+
+    // A legitimate client, stalled inside its own certificate verification. That step gates
+    // its Finished flight, and the server's handshake cannot complete without it — so from
+    // the moment the server pops the `Incoming`, its handshake provably cannot finish for
+    // `HANDSHAKE_BARRIER`, whatever the scheduler does. That is what makes the negative
+    // assertion below causal instead of a race. See the module docs.
+    let client = stalling_client_endpoint(HANDSHAKE_BARRIER)?;
 
     // The client is kept alive for the whole window so the server has a genuine, live
     // connection attempt to accept on every iteration below.
+    //
+    // `dialled_tx` fires when the client's dial resolves, either way. Nothing but this
+    // server answers that address, so the dial cannot resolve until the server has taken
+    // the `Incoming` off the queue and acted on it — which is the witness that the loop
+    // below entered the cancel-unsafe phase rather than spinning on an empty queue. It is
+    // *only* a witness; the verdict stays server-side, for the reason given in the module
+    // docs. (What the client actually observes here is the server's implicit close, the
+    // production symptom of #2521.)
+    let (dialled_tx, mut dialled_rx) = tokio::sync::oneshot::channel();
     let dial = tokio::spawn(async move {
         let result = client.connect(addr, "localhost")?.await;
+        let _ = dialled_tx.send(());
         tokio::time::sleep(ACCEPT_WINDOW).await;
         Ok::<_, anyhow::Error>((result, client))
     });
 
-    // Exactly the shape the production accept loop used: re-arm a poll timeout around the
+    // Exactly the shape the production accept loop used: re-arm a cancellation around the
     // fused accept, discarding whatever was in flight when it fires.
     let deadline = tokio::time::Instant::now() + ACCEPT_WINDOW;
     let mut handed_over = None;
+    let mut reached_the_handshake = false;
     while tokio::time::Instant::now() < deadline {
-        match tokio::time::timeout(ONE_POLL, server.accept()).await {
-            // Elapsed: the production loop dropped this future and looped. The `Incoming`
-            // was already consumed off the endpoint's queue by that single poll, so the
-            // connection attempt is now gone — a later iteration will not rediscover it.
-            Err(_elapsed) => {
+        match one_poll(server.accept()).await {
+            // Still pending after its one poll, so the production loop dropped this future
+            // and looped. The `Incoming` was already consumed off the endpoint's queue by
+            // that single poll, so the connection attempt is now gone — a later iteration
+            // will not rediscover it.
+            None => {
+                // Once the dial has resolved the phase under test is behind us and no
+                // further `Incoming` is coming; keep polling until then.
+                if dialled_rx.try_recv().is_ok() {
+                    reached_the_handshake = true;
+                    break;
+                }
                 tokio::time::sleep(POLL_GAP).await;
             }
-            Ok(Ok(Some(connection))) => {
+            Some(Ok(Some(connection))) => {
                 handed_over = Some(connection);
                 break;
             }
-            Ok(Ok(None)) => break,
-            Ok(Err(_)) => {
+            Some(Ok(None)) => break,
+            Some(Err(_)) => {
                 tokio::time::sleep(POLL_GAP).await;
             }
         }
@@ -179,9 +298,18 @@ async fn a_fused_accept_cancelled_after_one_poll_destroys_the_handshake() -> Res
 
     assert!(
         handed_over.is_none(),
-        "a one-poll budget cannot span a QUIC/TLS handshake: the connection driver has \
-         only just been spawned and cannot have signalled completion. Handing over a \
-         connection here would mean this test has stopped probing the boundary."
+        "a cancelled accept handed over a connection whose handshake cannot have \
+         completed: the client stalls {}ms inside certificate verification before it will \
+         send its Finished flight, so there was no completed handshake to hand over. \
+         Reaching this means the test has stopped probing the boundary.",
+        HANDSHAKE_BARRIER.as_millis()
+    );
+    assert!(
+        reached_the_handshake,
+        "the client's dial never resolved within {}s, so the loop above never took an \
+         `Incoming` off the queue and the assertion above proved nothing. This is a broken \
+         harness, not a property failure.",
+        ACCEPT_WINDOW.as_secs()
     );
 
     dial.abort();
@@ -216,15 +344,15 @@ async fn cancelling_the_accept_wait_does_not_destroy_an_inbound_handshake() -> R
     let deadline = tokio::time::Instant::now() + ACCEPT_WINDOW;
     let mut arrived = None;
     while tokio::time::Instant::now() < deadline {
-        match tokio::time::timeout(ONE_POLL, endpoint.accept()).await {
-            Err(_elapsed) => {
+        match one_poll(endpoint.accept()).await {
+            None => {
                 tokio::time::sleep(POLL_GAP).await;
             }
-            Ok(Some(incoming)) => {
+            Some(Some(incoming)) => {
                 arrived = Some(incoming);
                 break;
             }
-            Ok(None) => break,
+            Some(None) => break,
         }
     }
     let incoming = arrived.expect(
@@ -262,6 +390,12 @@ async fn cancelling_the_accept_wait_does_not_destroy_an_inbound_handshake() -> R
 #[derive(Debug)]
 struct StallingServerCertVerifier {
     delay: Duration,
+}
+
+impl StallingServerCertVerifier {
+    fn new(delay: Duration) -> Self {
+        Self { delay }
+    }
 }
 
 impl rustls::client::danger::ServerCertVerifier for StallingServerCertVerifier {
@@ -350,9 +484,9 @@ async fn a_slow_but_legitimate_peer_is_still_admitted() -> Result<()> {
     let sender_did = sender.did().clone();
     let mut rustls_client = rustls::ClientConfig::builder()
         .dangerous()
-        .with_custom_certificate_verifier(Arc::new(StallingServerCertVerifier {
-            delay: HANDSHAKE_STALL,
-        }))
+        .with_custom_certificate_verifier(Arc::new(StallingServerCertVerifier::new(
+            HANDSHAKE_STALL,
+        )))
         .with_client_auth_cert(vec![sender.tls_cert().clone()], sender.tls_key())?;
     rustls_client.alpn_protocols = vec![b"icn/1".to_vec()];
 

--- a/icn/crates/icn-net/tests/accept_handshake_cancellation.rs
+++ b/icn/crates/icn-net/tests/accept_handshake_cancellation.rs
@@ -99,6 +99,7 @@ use std::net::SocketAddr;
 use std::sync::Arc;
 use std::task::Poll;
 use std::time::Duration;
+use tokio::sync::oneshot::error::TryRecvError;
 
 /// Drive `fut` for exactly one poll, then drop it — the production loop's cancellation
 /// reduced to its essence.
@@ -279,11 +280,18 @@ async fn a_fused_accept_cancelled_after_one_poll_destroys_the_handshake() -> Res
             None => {
                 // Once the dial has resolved the phase under test is behind us and no
                 // further `Incoming` is coming; keep polling until then.
-                if dialled_rx.try_recv().is_ok() {
-                    reached_the_handshake = true;
-                    break;
+                match dialled_rx.try_recv() {
+                    Ok(()) => {
+                        reached_the_handshake = true;
+                        break;
+                    }
+                    // The dial task ended without ever getting as far as sending: it
+                    // failed before `connect()` resolved, or it panicked. Spinning out the
+                    // rest of the window here would blame the deadline for a harness that
+                    // was already broken, so stop now and let the assertion below say so.
+                    Err(TryRecvError::Closed) => break,
+                    Err(TryRecvError::Empty) => tokio::time::sleep(POLL_GAP).await,
                 }
-                tokio::time::sleep(POLL_GAP).await;
             }
             Some(Ok(Some(connection))) => {
                 handed_over = Some(connection);
@@ -306,9 +314,9 @@ async fn a_fused_accept_cancelled_after_one_poll_destroys_the_handshake() -> Res
     );
     assert!(
         reached_the_handshake,
-        "the client's dial never resolved within {}s, so the loop above never took an \
-         `Incoming` off the queue and the assertion above proved nothing. This is a broken \
-         harness, not a property failure.",
+        "the client's dial never resolved within {}s, or the dial task ended before it \
+         could report, so the loop above never took an `Incoming` off the queue and the \
+         assertion above proved nothing. This is a broken harness, not a property failure.",
         ACCEPT_WINDOW.as_secs()
     );
 


### PR DESCRIPTION
## Delivery

- **Delivery lane**: STANDARD
- **Acceptance contract**: `a_fused_accept_cancelled_after_one_poll_destroys_the_handshake` stops being load-flaky, and stops resting on a false premise about poll budgets, while still proving that a cancelled fused accept destroys the in-flight handshake rather than handing it over. Test-only; production behaviour is unchanged.
- **Explicit non-goals**: no production-code change; no I7 migration/cutover work; no unrelated `icn-net` cleanup; no change to the accept loop, `SessionManager`, or any TLS/trust configuration used in production.

<!-- ICN-DELIVERY-LIFECYCLE:BEGIN -->
```
ICN DELIVERY LIFECYCLE
State:                FROZEN
Lane:                 STANDARD
Acceptance contract:  De-flake the fused-accept cancellation test without weakening what it probes; test-only.
Review generation:    automated round 1 (Copilot, Codex) — CLOSED; both findings dispositioned and both
                      threads resolved. See "Review round 1" and "Post-I7 integration".
Freeze head:          0fddd3967c8700ecf0ad64432d237ebd957e8d64
Known blockers:       none — 11/11 required checks green at the freeze head; 0 unresolved threads
Follow-up ledger:     (1) two-phase latch for a true happens-before, deferred by scope (see thread reply)
                      (2) unrelated: test_cache_performance in trust_gated_rate_limiting_integration.rs is
                          timing-flaky on CI; not touched by this PR
```
<!-- ICN-DELIVERY-LIFECYCLE:END -->

## Summary

`a_fused_accept_cancelled_after_one_poll_destroys_the_handshake` failed **5 of 8 runs** under CPU load on unmodified `main` (4 cores, 12 busy loops). The defect was in the test's reasoning, not in the code under test. This replaces its timing-based premise with a causal one.

**Production code is unchanged.** The diff is one file: `icn/crates/icn-net/tests/accept_handshake_cancellation.rs`.

## Motivation

### The flake mechanism

The test cancelled the fused accept on `Duration::ZERO` and asserted no connection was handed over, on the stated ground that a zero budget "grants exactly one poll". Two things were wrong with that, and the second only surfaced after fixing the first.

**1. `Duration::ZERO` is not one poll.** `timeout` does poll its inner future before checking the deadline, but tokio's timer wheel has millisecond granularity and rounds deadlines **up** so timers never fire early. A zero-duration sleep is therefore pending on its first poll and elapses at the next tick — so the inner future is polled again, for as long as the timer driver takes to get there. Measured directly with a poll-counting probe: **2 polls spanning 0.6 ms – 12 ms** under load. That is ample for a warm loopback handshake, and it is precisely the failure mode the module docs already disclaimed for a "1 ms" budget. `Duration::ZERO` was that same mistake wearing a disguise.

**2. Even a genuine single poll is scheduler-racy.** A poll is synchronous but **not atomic**. Within one poll the fused accept pops the `Incoming`, calls `Incoming::accept()` — handing the connection to the endpoint driver — and only then polls the resulting `Connecting`. The thread can be preempted between those last two steps, and under contention that gap is long enough for the driver to complete the loopback round trip and signal the oneshot first. A real timer-free one-poll probe alone still failed **1 run in 20**.

The conclusion is that *no* poll-budget scheme can be sound here: every one races the scheduler, and shrinking the budget does not help.

### Why the causal barrier removes the race

The budget cannot carry the guarantee, so the client does instead. It dials through this file's existing `StallingServerCertVerifier`, which stalls inside the client's verification of the server's certificate. That step gates the client's Finished flight — which is exactly what the server's handshake is waiting on. For a second after the server pops the `Incoming` there is **no completed handshake to hand over at all**: not unlikely, impossible, however long any thread is descheduled for.

The barrier is conditional by design, and both paths are safe:
- cancellation lands before the server transmits → the attempt is destroyed with nothing on the wire, and the stall never engages (the ordinary path);
- the polling thread is descheduled long enough for the server to transmit → the client reaches verification and sits there, so Finished is still a second away (the path that used to lose the race).

## Changes

- `one_poll` — a timer-free single poll via `poll_fn`, replacing `const ONE_POLL: Duration = Duration::ZERO`. Removes the timer-slack race and makes the file's "one poll" claim literally true.
- Causal barrier — the fused test's client dials through `stalling_client_endpoint(HANDSHAKE_BARRIER)` (1 s), making the negative assertion causal rather than probabilistic.
- Vacuity guard — the dial's resolution witnesses that the loop actually entered the cancel-unsafe phase, so the negative assertion can no longer pass on an empty queue. (It is only a witness; the verdict stays server-side, per the file's standing rule that the client's view is not a valid oracle.)
- The cancel-safe test now uses the same probe, so "one poll" means one thing in the file.
- Module docs rewritten to record all three dead ends rather than teach the false premise.

## Testing

- [x] Unit tests added/updated — this is the test change
- [x] Integration tests pass — `cargo test -p icn-net`: **671 tests, 26 binaries, 0 failures**
- [x] Manual testing: stress under artificial CPU load, plus mutation/discrimination testing

### Stress evidence

| Configuration | Result |
|---|---|
| Full binary, 12-way load (4 cores) | **0 failures / 20 runs** |
| Full binary, 24-way load | **0 failures / 10 runs** |
| Cumulative on the final design | **0 failures / 140 runs** |
| Fused test's own duration under load | 0.28–0.70 s against a 5 s window (7–18× margin) |
| Baseline for comparison (pre-fix, same harness) | 5 of 8 runs failed |

### Mutation / discrimination evidence

The test still fails when the protected property is removed:

| Mutation | Result |
|---|---|
| Remove the cancellation (await the fused accept) | **FAILS** — hands over after the stall |
| No peer ever dials | **FAILS** on the vacuity guard |
| Inject a 50 ms block between `Incoming::accept()` and the first `Connecting` poll, **barrier removed** | **FAILS 3/3** |
| Same injection, **barrier restored** | **PASSES 3/3** |

That last pair is the load-bearing one. 140 clean runs alone would not prove the barrier is what protects — the preemption event is rare enough that a barrier-free build passed 40/40 by luck. Making the preemption deterministic shows the barrier is doing the work. (The injection is an experiment against a scratch tree; it is not part of this diff.)

## Invariants

- [x] No panics introduced in protocol paths — test-only change
- [x] Determinism preserved — strengthened; that is the point of the change
- [x] Canonical encodings unchanged
- [x] Trust gates not weakened — see note below
- [x] Kernel/app boundaries respected

**Note for review:** the diff adds a `rustls::ClientConfig::builder().dangerous().with_custom_certificate_verifier(..)` call. It is **client-side, inside a test**, and it reuses the verifier already present in this file for `a_slow_but_legitimate_peer_is_still_admitted`. The server's TLS configuration and verification are untouched, and no production code path constructs this client. Flagging it explicitly because the `dangerous()` call is the kind of thing that should never pass review unexamined.

## Verification

```
cargo fmt --all --check                                  PASS
cargo clippy -p icn-net --all-targets -- -D warnings     PASS
cargo test -p icn-net                                    671 tests, 26 binaries, 0 failed
ops/scripts/drift-check.sh                               STATUS: PASS (0 errors, 0 warnings)
git diff --name-only -- 'icn/crates/*/src/'              (empty — no production code touched)
```

## Documentation

- [x] Docs updated — the module docs in the test file are the documentation for this boundary, and are rewritten here
- [x] API changes reflected in OpenAPI — N/A, no API change



## Review round 1

**Copilot — `try_recv().is_ok()` collapses `Closed` into `Empty`** — *accepted, fixed in 6633622b.*
If the dial task ended without sending (its `connect()` erroring before the send, or a panic), the loop spun out the remaining window and the assertion then blamed the deadline for a harness that was already broken. Now matched on `TryRecvError`, with `Closed` breaking immediately and a message naming both cases. Kept `try_recv` rather than awaiting the oneshot: the loop must keep cancelling the fused accept while it waits, and awaiting the dial would stop exercising the phase under test. Verified by mutation — the dial-drops-sender case now fails in 0.41s instead of 5.39s, with an accurate reason.

**Codex — the 1s stall is a finite margin, not a synchronisation barrier** — *correct; docs fixed in efb8aeff, redesign deferred.*
Right in the limit: a pause longer than the stall would defeat it, and the module docs saying "impossible … however long any thread is descheduled for" overstated it. Docs now state the bound honestly, including its size.

The proposed remedy — a latch released once the accept has actually been cancelled — is not directly implementable through the API under test. The loop cancels ~200x/second and almost every iteration cancels an accept that never popped an `Incoming`, so releasing on *any* cancellation opens the latch on iteration 1, long before the pop. Releasing on *the* cancellation that consumed the `Incoming` requires observing which iteration popped it, which is exactly what `SessionManager::accept()` does not expose — the reason the witness is client-side at all. Using `endpoint_handle()` to see the pop would stop testing the fused API, which is the point of the test.

A two-phase latch would work (verifier signals "I am verifying" and blocks; the loop releases on its next cancellation after that signal), and is logged as follow-up (1) rather than done here: this PR is scoped to de-flaking, and swapping a measured bound for a new synchronisation protocol is a maintainer's call.

### CI note

The `Test` required check failed once at efb8aeff on `test_cache_performance` (`trust_gated_rate_limiting_integration.rs:184`, "Second lookup should not be slower") — an unrelated test that compares two single sub-microsecond wall-clock samples with no warmup. It is not touched by this diff and passes 20/20 locally, idle and under 12-way load on 4 cores. Re-run once per merge policy; green. Logged as follow-up (2).



## Post-I7 integration

`main` moved through I7 (#2686, `0defbde5` — `Did` equality and hashing name the principal, not the spelling), leaving this PR BEHIND under strict protection. Refreshed with `gh pr update-branch` (GitHub-native merge of `main` into the PR branch), which keeps the reviewed head `efb8aeff` as an ancestor.

**The reviewed change is unchanged — proven, not asserted:**

| | |
|---|---|
| Reviewed head (provenance) | `efb8aeffa61acb4d7ea3bdb809b78f9231290465` |
| Integration head (freeze) | `0fddd3967c8700ecf0ad64432d237ebd957e8d64` |
| Test-file blob, both heads | `9ea038397680703d91cd6912285a734450996eec` — **byte-identical** |
| Effective diff sha256, both heads | `3db95633…21df4f76` — **identical** |
| Effective scope vs post-I7 `main` | 1 file, +189/−37; production source touched: **0** |

**DELTA assessment — I7 does not reach this test's mechanism.** I7's only `icn-net` production change is `PeerId::Ord` in `topology.rs`, a comparison ordering; this test passes `None` for both `topology_config` and `topology_info`, so it is not even exercised. The files the harness actually depends on — `session.rs` (which owns the fused `SessionManager::accept()` under test), `actor/connection.rs`, `tls.rs`, `protocol.rs` — are untouched by I7. And I7 changes `Did` *comparison*, never representation (its own docs: `Debug`, `Display`, `as_str`, `Serialize`, `Deserialize` untouched), so TLS certificates, wire bytes and the handshake mechanism are unmoved. This test remains about fused QUIC accept cancellation, not DID identity.

**Validation re-run on the refreshed tree** (`icn-identity` and `icn-net` rebuilt):

```
focused cancellation binary                              7 passed, 0 failed
cargo test -p icn-net                                    671 tests, 26 binaries, 0 failed
cargo fmt --all --check                                  PASS
cargo clippy -p icn-net --all-targets -- -D warnings     PASS
ops/scripts/drift-check.sh                               STATUS: PASS (0 errors, 0 warnings)
stress, 15 runs @ 12-way load on 4 cores                 0 failures  (0.83s-1.21s)
```

Because the implementation is byte-identical, the prior 140-run stress corpus and the mutation/discrimination evidence remain applicable; the sample above is an integration-regression check, not a re-derivation.
