### PR TITLE
fix(ops): make what-matters-now --json emit JSON instead of Python source

### DIFF
--- a/.github/workflows/agent-drift-check.yml
+++ b/.github/workflows/agent-drift-check.yml
@@ -19,6 +19,7 @@ on:
       - 'scripts/tests/test_skill_registry_invariants.py'
       - 'scripts/check-merge-policy-schema.py'
       - 'scripts/tests/test_merge_policy_schema.py'
+      - 'scripts/tests/test_what_matters_now_json.py'
       # icn#2651 stage B: the executable that owns ordinary-merge semantics, and its controls.
       - 'tools/icn-merge-pr/**'
       - 'scripts/tests/test_icn_merge_pr.py'
@@ -155,5 +156,15 @@ jobs:
             python3 -c "import json; json.load(open('${f}'))" && echo "OK: ${f}"
           done
 
-      - name: Verify what-matters-now script runs without errors
+      # icn#2638: --json was advertised in the script's own usage header and invoked by no
+      # workflow, skill or hook, so a 100% failure rate looked like silence. The step below
+      # used to be named for the whole script while running only --drift. Each mode now has
+      # an executing consumer, because a mode with no runner is how this hid.
+      - name: what-matters-now --drift (drift gate)
         run: bash ops/scripts/what-matters-now.sh --drift
+
+      - name: what-matters-now --json is machine-readable (Refs icn#2638)
+        run: python3 scripts/tests/test_what_matters_now_json.py
+
+      - name: what-matters-now human mode still renders
+        run: bash ops/scripts/what-matters-now.sh > /dev/null

--- a/ops/scripts/what-matters-now.sh
+++ b/ops/scripts/what-matters-now.sh
@@ -140,7 +140,10 @@ if d.get('cadence') == 'dormant' or d.get('active_sprint') is None:
 else:
     print('Sprint %s (%s)' % (d.get('active_sprint'), d.get('status','?')))
 " 2>/dev/null || echo "unresolved (sprint owner unreadable)")
-SPRINT_ACTIVE=$(python3 -c "import json; d=json.load(open('${SPRINT_FILE}')); v=d.get('active_sprint'); print(repr(v) if isinstance(v,(int,type(None))) else repr(str(v)))" 2>/dev/null || echo "None")
+# Emitted as JSON, not as Python source. The --json payload consumes this with json.loads;
+# repr() was only ever correct because the payload used to be built by splicing shell values
+# into Python source, which is the defect icn#2638 names.
+SPRINT_ACTIVE_JSON=$(python3 -c "import json; d=json.load(open('${SPRINT_FILE}')); v=d.get('active_sprint'); print(json.dumps(v if isinstance(v,(int,type(None))) else str(v)))" 2>/dev/null || echo "null")
 SPRINT_STATUS=$(python3 -c "import json; d=json.load(open('${SPRINT_FILE}')); print(d.get('status','?'))" 2>/dev/null || echo "?")
 SPRINT_TASKS=$(python3 -c "
 import json
@@ -176,28 +179,71 @@ print(str(len(checks)) + ' required checks')
 # ─── Output ──────────────────────────────────────────────────────────────────
 
 if [[ "${MODE}" == "--json" ]]; then
-  python3 - <<EOF
-import json, subprocess
+  # Values reach Python as ENVIRONMENT, never as interpolated Python source (Refs icn#2638).
+  # The previous form spliced shell values into the heredoc body, so every field had to be
+  # valid *Python source*: the shell booleans below arrived as the bare names `true`/`false`
+  # and the mode died with NameError before json.dumps ever ran. Passing by environment
+  # removes the entire class of defect -- a value can no longer be syntax.
+  WMN_REPO_ROOT="${REPO_ROOT}" \
+  WMN_BRANCH="${BRANCH}" \
+  WMN_DIRTY_STATUS="${DIRTY_STATUS}" \
+  WMN_SPRINT_SUMMARY="${SPRINT_SUMMARY}" \
+  WMN_SPRINT_ACTIVE_JSON="${SPRINT_ACTIVE_JSON}" \
+  WMN_SPRINT_STATUS="${SPRINT_STATUS}" \
+  WMN_SPRINT_TASKS="${SPRINT_TASKS}" \
+  WMN_PR_STATE="${PR_STATE}" \
+  WMN_POLICY_CHECKS="${POLICY_CHECKS}" \
+  WMN_DRIFT_ERRORS="${DRIFT_ERRORS}" \
+  WMN_TRUTH_OK="${TRUTH_OK}" \
+  WMN_SYMLINKS_OK="${SYMLINKS_OK}" \
+  python3 - <<'PY_JSON_EOF'
+import json, os
+
+
+def env(name):
+    return os.environ.get(name, "")
+
+
+def flag(name):
+    """The shell sets these to the literal strings "true"/"false"."""
+    return env(name) == "true"
+
+
+repo_root = env("WMN_REPO_ROOT")
+
+# active_sprint is genuinely nullable: a dormant cadence is a truthful answer, not a gap.
+try:
+    sprint_active = json.loads(env("WMN_SPRINT_ACTIVE_JSON"))
+except ValueError:
+    sprint_active = None
 
 data = {
-  "repo_root": "${REPO_ROOT}",
-  "workspace_root": "${REPO_ROOT}/icn",
-  "branch": "${BRANCH}",
-  "working_tree": "${DIRTY_STATUS}",
-  "sprint": {"summary": "${SPRINT_SUMMARY}", "active_sprint": ${SPRINT_ACTIVE}, "status": "${SPRINT_STATUS}", "tasks": "${SPRINT_TASKS}"},
-  "current_work_owner": "live issue/PR query — see live_issue_state / live_pr_state in ops/state/truth/sources.json",
-  "open_prs": "${PR_STATE}",
-  "merge_policy": "${POLICY_CHECKS} (read ops/state/truth/policy.json)",
-  "drift_errors": ${DRIFT_ERRORS},
-  "truth_files_ok": $([[ "${TRUTH_OK}" == "true" ]] && echo "true" || echo "false"),
-  "symlinks_ok": $([[ "${SYMLINKS_OK}" == "true" ]] && echo "true" || echo "false"),
-  "canonical_truth": "ops/state/truth/sources.json",
-  "canonical_policy": "ops/state/truth/policy.json",
-  "canonical_agents": "ops/state/truth/agents.json",
-  "canonical_skills": "ops/state/truth/skills.json"
+    "repo_root": repo_root,
+    "workspace_root": repo_root + "/icn",
+    "branch": env("WMN_BRANCH"),
+    "working_tree": env("WMN_DIRTY_STATUS"),
+    "sprint": {
+        "summary": env("WMN_SPRINT_SUMMARY"),
+        "active_sprint": sprint_active,
+        "status": env("WMN_SPRINT_STATUS"),
+        "tasks": env("WMN_SPRINT_TASKS"),
+    },
+    "current_work_owner": (
+        "live issue/PR query \u2014 see live_issue_state / live_pr_state "
+        "in ops/state/truth/sources.json"
+    ),
+    "open_prs": env("WMN_PR_STATE"),
+    "merge_policy": env("WMN_POLICY_CHECKS") + " (read ops/state/truth/policy.json)",
+    "drift_errors": int(env("WMN_DRIFT_ERRORS") or 0),
+    "truth_files_ok": flag("WMN_TRUTH_OK"),
+    "symlinks_ok": flag("WMN_SYMLINKS_OK"),
+    "canonical_truth": "ops/state/truth/sources.json",
+    "canonical_policy": "ops/state/truth/policy.json",
+    "canonical_agents": "ops/state/truth/agents.json",
+    "canonical_skills": "ops/state/truth/skills.json",
 }
 print(json.dumps(data, indent=2))
-EOF
+PY_JSON_EOF
   exit ${DRIFT_ERRORS}
 fi
 

--- a/ops/scripts/what-matters-now.sh
+++ b/ops/scripts/what-matters-now.sh
@@ -120,7 +120,15 @@ done
 
 # ─── Phase 4: live git state ─────────────────────────────────────────────────
 
-BRANCH=$(git -C "${REPO_ROOT}" branch --show-current 2>/dev/null || echo "unknown")
+BRANCH=$(git -C "${REPO_ROOT}" branch --show-current 2>/dev/null || true)
+if [[ -z "${BRANCH}" ]]; then
+  # A detached HEAD is not an error: `git branch --show-current` exits 0 and prints
+  # nothing, so the `|| echo "unknown"` fallback this replaces could never fire. CI
+  # checks out detached on pull_request, so --json shipped "branch": "" to every
+  # consumer and the human mode printed a bare "Branch:". Found by the --json runner
+  # added for icn#2638 -- the mode had no consumer to notice before.
+  BRANCH="detached at $(git -C "${REPO_ROOT}" rev-parse --short HEAD 2>/dev/null || echo "unknown")"
+fi
 DIRTY=$(git -C "${REPO_ROOT}" status --porcelain 2>/dev/null | wc -l | tr -d ' ')
 DIRTY_STATUS=$([[ "${DIRTY}" == "0" ]] && echo "clean" || echo "${DIRTY} uncommitted change(s)")
 

--- a/scripts/tests/test_what_matters_now_json.py
+++ b/scripts/tests/test_what_matters_now_json.py
@@ -1,0 +1,174 @@
+#!/usr/bin/env python3
+"""Executable consumer + regression gate for `what-matters-now.sh --json` (icn#2638).
+
+`--json` was advertised in the script's own usage header but invoked by no workflow,
+skill or hook, so its 100% failure rate looked like silence. It built its payload by
+splicing shell values into a Python heredoc, which made every field have to be valid
+*Python source*. Two distinct defects followed from that one root cause:
+
+  1. shell `true`/`false` arrived as the bare Python names `true`/`false`
+     -> NameError: name 'true' is not defined      (the reported bug, 100% of runs)
+  2. a *legal* git branch name containing `"` closed the string early
+     -> SyntaxError: unterminated string literal   (reachable, never reported)
+
+The fix passes every value by environment, so a value can no longer be syntax. This
+file is the runner that mode never had, plus a structural gate that stops the class
+from coming back. Structural, not behavioural: asserting "no interpolation reaches the
+Python body" forbids defect 2 without needing a checkout on a hostile branch name.
+
+Run: python3 scripts/tests/test_what_matters_now_json.py
+"""
+import json
+import pathlib
+import re
+import subprocess
+import sys
+
+ROOT = pathlib.Path(__file__).resolve().parents[2]
+SCRIPT = ROOT / "ops" / "scripts" / "what-matters-now.sh"
+
+failures = []
+
+
+def check(desc, cond):
+    print(("  ok   " if cond else "  FAIL ") + desc)
+    if not cond:
+        failures.append(desc)
+
+
+def json_heredoc_body(text):
+    """Return (delimiter, body) for the --json payload heredoc, or (None, None)."""
+    m = re.search(r"python3 - <<(['\"]?)([A-Z_][A-Z0-9_]*)\1\n(.*?)\n\2\n", text, re.S)
+    if not m:
+        return None, None
+    return m.group(1), m.group(3)
+
+
+print("--- the mode runs at all (this is the consumer it never had) ---")
+
+proc = subprocess.run(
+    ["bash", str(SCRIPT), "--json"],
+    capture_output=True, text=True, cwd=str(ROOT),
+)
+
+check("--json emits bytes on stdout", len(proc.stdout) > 0)
+
+payload = None
+try:
+    payload = json.loads(proc.stdout)
+    check("--json stdout is parseable JSON", True)
+except ValueError as exc:
+    check("--json stdout is parseable JSON (%s; stderr: %s)"
+          % (exc, proc.stderr.strip().splitlines()[-1:] or ""), False)
+
+if payload is not None:
+    # The documented contract: --json exits with the drift count it reports.
+    check("exit status equals the drift_errors it reports (%d == %d)"
+          % (proc.returncode, payload["drift_errors"]),
+          proc.returncode == payload["drift_errors"])
+
+    # The reported defect, stated as a type assertion. A string "true" would parse
+    # fine as JSON and still be wrong, so parseability alone does not cover this.
+    for key in ("truth_files_ok", "symlinks_ok"):
+        check("%s is a JSON boolean, not a string (%r)" % (key, payload[key]),
+              isinstance(payload[key], bool))
+
+    check("drift_errors is an integer (%r)" % (payload["drift_errors"],),
+          isinstance(payload["drift_errors"], int)
+          and not isinstance(payload["drift_errors"], bool))
+
+    # #2636 added these and --json is their only consumer, so nothing else exercises
+    # them end to end.
+    check("sprint block is present with its three cadence fields",
+          isinstance(payload.get("sprint"), dict)
+          and {"summary", "active_sprint", "status"} <= set(payload["sprint"]))
+
+    check("active_sprint is null or a scalar, never the string 'None'",
+          payload["sprint"]["active_sprint"] != "None")
+
+    check("current_work_owner routes to the live query, not to a file",
+          "live_issue_state" in payload.get("current_work_owner", ""))
+
+    for key in ("repo_root", "workspace_root", "branch", "canonical_truth"):
+        check("payload carries %s" % key, isinstance(payload.get(key), str)
+              and payload[key] != "")
+
+
+print()
+print("--- the defect class cannot return (structural) ---")
+
+text = SCRIPT.read_text(encoding="utf-8")
+delim_quote, body = json_heredoc_body(text)
+
+check("the --json payload heredoc was located", body is not None)
+
+if body is not None:
+    check("its delimiter is quoted, so the shell does not expand the body "
+          "(delimiter quote=%r)" % (delim_quote,), delim_quote in ("'", '"'))
+    check("no ${...} parameter expansion reaches the Python body",
+          "${" not in body)
+    check("no $(...) command substitution reaches the Python body",
+          "$(" not in body)
+    check("the two reported booleans are read from the environment, not spliced",
+          'flag("WMN_TRUTH_OK")' in body and 'flag("WMN_SYMLINKS_OK")' in body)
+
+
+print()
+print("--- MUST-FAIL controls (a gate that cannot fail is not a gate) ---")
+
+# Reconstruct the real pre-fix form and prove each structural assertion above would
+# have rejected it. Without these, the gate could be passing vacuously.
+PRE_FIX = (
+    'python3 - <<EOF\n'
+    'import json\n'
+    'data = {\n'
+    '  "branch": "${BRANCH}",\n'
+    '  "truth_files_ok": $([[ "${TRUTH_OK}" == "true" ]] && echo "true"'
+    ' || echo "false"),\n'
+    '}\n'
+    'EOF\n'
+)
+pre_quote, pre_body = json_heredoc_body(PRE_FIX)
+check("CONTROL: the pre-fix heredoc is still recognised by the matcher",
+      pre_body is not None)
+check("CONTROL: the unquoted-delimiter assertion rejects the pre-fix form",
+      pre_quote == "")
+check("CONTROL: the ${...} assertion rejects the pre-fix form",
+      pre_body is not None and "${" in pre_body)
+check("CONTROL: the $(...) assertion rejects the pre-fix form",
+      pre_body is not None and "$(" in pre_body)
+
+# And prove the pre-fix form really did fail, rather than trusting the bug report.
+pre_run = subprocess.run(
+    ["bash", "-c", 'set -euo pipefail\nBRANCH=main\nTRUTH_OK=true\n' + PRE_FIX],
+    capture_output=True, text=True,
+)
+check("CONTROL: the pre-fix form dies with NameError on the shell boolean",
+      pre_run.returncode != 0 and "NameError" in pre_run.stderr
+      and "'true'" in pre_run.stderr)
+
+# Defect 2: a branch name git itself accepts. Not hypothetical -- `git check-ref-format`
+# permits `"`, so this was reachable on any checkout that used such a branch.
+ref_ok = subprocess.run(
+    ["git", "check-ref-format", "--branch", 'quote"branch'],
+    capture_output=True, text=True,
+)
+check("CONTROL: git accepts a branch name containing a double quote",
+      ref_ok.returncode == 0)
+
+pre_run2 = subprocess.run(
+    ["bash", "-c",
+     'set -euo pipefail\nBRANCH=\'quote"branch\'\nTRUTH_OK=true\n' + PRE_FIX],
+    capture_output=True, text=True,
+)
+check("CONTROL: the pre-fix form dies with SyntaxError on that legal branch name",
+      pre_run2.returncode != 0 and "SyntaxError" in pre_run2.stderr)
+
+
+print()
+if failures:
+    print("test_what_matters_now_json: %d FAILURE(S)" % len(failures))
+    for f in failures:
+        print("  - " + f)
+    sys.exit(1)
+print("test_what_matters_now_json: all checks passed")

--- a/scripts/tests/test_what_matters_now_json.py
+++ b/scripts/tests/test_what_matters_now_json.py
@@ -39,7 +39,13 @@ def check(desc, cond):
 
 
 def json_heredoc_body(text):
-    """Return (delimiter, body) for the --json payload heredoc, or (None, None)."""
+    """Return (quote, body) for the --json payload heredoc, or (None, None).
+
+    `quote` is the character quoting the heredoc *delimiter* -- "'", '"', or ""
+    when the delimiter is unquoted. It is what decides whether the shell expands
+    the body, which is the property under test; the delimiter word itself is not
+    returned because nothing here needs its name.
+    """
     m = re.search(r"python3 - <<(['\"]?)([A-Z_][A-Z0-9_]*)\1\n(.*?)\n\2\n", text, re.S)
     if not m:
         return None, None
@@ -60,8 +66,9 @@ try:
     payload = json.loads(proc.stdout)
     check("--json stdout is parseable JSON", True)
 except ValueError as exc:
-    check("--json stdout is parseable JSON (%s; stderr: %s)"
-          % (exc, proc.stderr.strip().splitlines()[-1:] or ""), False)
+    err_lines = proc.stderr.strip().splitlines()
+    check("--json stdout is parseable JSON (%s; last stderr line: %s)"
+          % (exc, err_lines[-1] if err_lines else "<none>"), False)
 
 if payload is not None:
     # The documented contract: --json exits with the drift count it reports.

--- a/scripts/tests/test_what_matters_now_json.py
+++ b/scripts/tests/test_what_matters_now_json.py
@@ -21,8 +21,10 @@ Run: python3 scripts/tests/test_what_matters_now_json.py
 import json
 import pathlib
 import re
+import shutil
 import subprocess
 import sys
+import tempfile
 
 ROOT = pathlib.Path(__file__).resolve().parents[2]
 SCRIPT = ROOT / "ops" / "scripts" / "what-matters-now.sh"
@@ -163,6 +165,70 @@ pre_run2 = subprocess.run(
 )
 check("CONTROL: the pre-fix form dies with SyntaxError on that legal branch name",
       pre_run2.returncode != 0 and "SyntaxError" in pre_run2.stderr)
+
+
+print()
+print("--- branch is reported truthfully on a detached HEAD (CI's own checkout) ---")
+
+# actions/checkout leaves a detached HEAD on pull_request events. `git branch
+# --show-current` exits 0 there and prints nothing, so the script's original
+# `|| echo "unknown"` fallback was dead code and --json shipped "branch": "" to every
+# consumer. This was invisible until --json got the runner icn#2638 asked for.
+tmp = tempfile.mkdtemp()
+try:
+    def git(*args):
+        return subprocess.run(("git", "-C", tmp) + args,
+                              capture_output=True, text=True)
+
+    subprocess.run(["git", "init", "-q", tmp], capture_output=True)
+    git("config", "user.email", "t@example.invalid")
+    git("config", "user.name", "t")
+    git("commit", "-q", "--allow-empty", "-m", "one")
+    git("checkout", "-q", "--detach", "HEAD")
+
+    probe = git("branch", "--show-current")
+    check("CONTROL: on a detached HEAD `git branch --show-current` exits 0 and prints "
+          "nothing, so an `|| echo` fallback on it is dead code",
+          probe.returncode == 0 and probe.stdout.strip() == "")
+
+    # The whole script cannot run outside a real checkout -- it derives REPO_ROOT from
+    # its own location and aborts early under `set -euo pipefail`, which icn#2638 records
+    # as a trap that masks defects. So extract the SHIPPED branch-resolution block and
+    # execute that verbatim against the detached repo: real code, no re-implementation.
+    block = re.search(
+        r"^BRANCH=\$\(git -C .*?\n(?:.*?\n)*?^fi$",
+        SCRIPT.read_text(encoding="utf-8"), re.M)
+    check("the shipped branch-resolution block was located", block is not None)
+
+    if block is not None:
+        det = subprocess.run(
+            ["bash", "-c",
+             'set -euo pipefail\nREPO_ROOT="$1"\n' + block.group(0) + '\nprintf "%s" "$BRANCH"',
+             "_", tmp],
+            capture_output=True, text=True,
+        )
+        branch = det.stdout
+        check("branch resolution succeeds on a detached HEAD (rc=%d, stderr=%r)"
+              % (det.returncode, det.stderr.strip()[:80]), det.returncode == 0)
+        check('branch is non-empty on a detached HEAD -- CI emitted "" here -- got %r'
+              % (branch,), branch.strip() != "")
+        check("branch says it is detached rather than naming a branch that is not "
+              "checked out -- got %r" % (branch,), "detached" in branch)
+
+        # Control: the same block on an attached checkout still names the branch.
+        subprocess.run(["git", "-C", tmp, "checkout", "-q", "-b", "some-branch"],
+                       capture_output=True)
+        att = subprocess.run(
+            ["bash", "-c",
+             'set -euo pipefail\nREPO_ROOT="$1"\n' + block.group(0) + '\nprintf "%s" "$BRANCH"',
+             "_", tmp],
+            capture_output=True, text=True,
+        )
+        check("CONTROL: an attached checkout still reports its real branch name "
+              "(got %r) -- the fix did not replace branches with 'detached'"
+              % (att.stdout,), att.stdout.strip() == "some-branch")
+finally:
+    shutil.rmtree(tmp, ignore_errors=True)
 
 
 print()


### PR DESCRIPTION
## Delivery

- **Delivery lane**: FAST
- **Acceptance contract**: `ops/scripts/what-matters-now.sh --json` exits with its reported drift count and emits parseable JSON whose `truth_files_ok` / `symlinks_ok` are JSON booleans; all three script modes have an executing CI consumer.
- **Explicit non-goals**: no change to the human or `--drift` output; no change to the `--json` key set; no change to what any truth owner says.

<!-- ICN-DELIVERY-LIFECYCLE:BEGIN -->
```
ICN DELIVERY LIFECYCLE
State:                FROZEN  (11/11 required contexts green on the exact head;
                      awaiting explicit human merge authorization)
Lane:                 FAST
Acceptance contract:  --json emits parseable JSON with correctly typed booleans; no shell-derived
                      value can become Python SYNTAX; branch is reported truthfully on a detached
                      HEAD; every supported mode has an executing consumer in CI
Review generation:    1 bounded FULL review on a58757bd -> 0 BLOCKER, 3 FOLLOW_UP, 0 QUESTION,
                      2 NOT_A_FINDING. Generation CLOSED; review is now DELTA only.
Freeze head:          a58757bdd168feeb30e6ca053c15d76b643f7348
Base:                 main 3c1e4f863 -- merge-base equals origin/main (strict:true satisfied)
Known blockers:       none open
Unresolved threads:   0 (3 threads, all resolved)
Non-required red:     Security Audit only -- red on main itself, owned by icn#2579, not caused
                      here and not fixable from this branch
Follow-up ledger:     (1) icn#2723 -- set -e plus ((DRIFT_ERRORS++)) aborts at the first drift, so
                          the required drift gate's DRIFT DETECTED block is unreachable
                          (pre-existing; fails `introduced_here`)
                      (2) icn#2722 -- ${SPRINT_FILE} still spliced into python3 source at
                          :145/:154/:155/:158 (pre-existing; narrower vector than the branch name)
                      (3) the exit-status assertion at test_what_matters_now_json.py:76 cannot
                          reach a non-zero drift count until icn#2723 is fixed -- folded into
                          #2723's acceptance criteria
                      (4) align --json branch reporting to ops/mcp readBranchState's
                          {branch: null, detached: true} shape -- adds a key, deliberately not
                          widened into this PR
```
<!-- ICN-DELIVERY-LIFECYCLE:END -->

## Summary

`--json` has never worked. At every commit that has contained it, it exits 1 with zero bytes on stdout.

The payload was built by splicing shell values into a Python heredoc, so every field had to be valid **Python source**. Two distinct defects follow from that single root cause. Both were reproduced before the fix:

| # | Trigger | Result | Reported? |
|---|---|---|---|
| 1 | shell `true`/`false` arrive as the bare Python names `true`/`false` | `NameError: name 'true' is not defined` | yes — #2638, 100% of runs |
| 2 | a branch name containing `"`, which `git check-ref-format` **accepts** | `SyntaxError: unterminated string literal` | no — reachable, never hit |

Patching the two booleans fixes (1) and leaves (2). Instead, every value now reaches Python **through the environment**, and the heredoc delimiter is quoted so the shell does not expand the body at all. A value can no longer *be syntax*, which retires the class rather than the instance.

**A third defect, found by the new runner on its first CI run.** The test went red on `payload carries branch`. The assertion was right and the script was wrong: `git branch --show-current` exits 0 and prints nothing on a detached HEAD, so `|| echo "unknown"` could never fire — the `||` only triggers on non-zero status, and a detached HEAD is not an error. `actions/checkout` leaves a detached HEAD on `pull_request`, so **every CI run of this script emitted `"branch": ""`** to `--json` and printed a bare `Branch:` in human mode. Same shape as the original defect: a path nothing executed. Adding the consumer surfaced it immediately. `BRANCH` now falls back on *emptiness* rather than exit status and reports `detached at <short-sha>` — what is actually true, rather than naming a branch that is not checked out.

**Why it survived.** `--json` was advertised in the script's own usage header (line 9) and invoked by no workflow, skill, or hook. The one CI step named for the script — "Verify what-matters-now script runs without errors" — ran only `--drift`. A mode with no runner cannot fail visibly, so a 100% failure rate looked like silence. That step name has been corrected to describe what it actually covers, and each of the three modes now has its own consumer.

## Layer classification

- [x] ops/coordination (process, refinery, hygiene)

## Boundary check

Non-goals, explicitly: no institution-specific meaning enters ICN core; no private operational data is added; no public-website claim is made; no new ICN primitive is introduced. This PR changes **how a status payload is serialised**, not what any truth owner says. `current_work_owner` still routes to the live `live_issue_state` / `live_pr_state` query rather than naming a file — the test asserts this, so a future edit cannot quietly turn the payload into a second owner of current work.

## What changed

- `ops/scripts/what-matters-now.sh` — `--json` payload built from environment variables inside a quote-delimited heredoc; `SPRINT_ACTIVE` loses its `repr()` hack and emits JSON (`SPRINT_ACTIVE_JSON`), consumed by `json.loads`. The `repr()` was only ever correct *because* the payload was Python source.
- `ops/scripts/what-matters-now.sh` — `BRANCH` falls back on emptiness, not exit status, so a detached HEAD reports `detached at <sha>` instead of `""`.
- `scripts/tests/test_what_matters_now_json.py` — new. The runner the mode never had, plus a structural gate and the detached-HEAD case.
- `.github/workflows/agent-drift-check.yml` — runs the new test; splits the over-named step so `--drift`, `--json`, and human mode are each covered; registers the test in the push paths filter.

## What did not change

- The `--json` key set, and `exit ${DRIFT_ERRORS}` semantics — same 15 keys, same exit contract. Only the two booleans change type, from *unrepresentable* to `true`/`false`.
- `--drift` output — byte-for-byte.
- Human output — unchanged on **any attached checkout**. On a detached HEAD the `Branch:` line changes from empty to `detached at <sha>`, which is the defect being fixed, not a regression.
- The phase-5 sprint helpers still interpolate `${SPRINT_FILE}` into `python3 -c` source. That is the same *pattern* but not this defect, and it is only reachable via a repo path containing a quote. Left alone deliberately to keep this PR at its issue boundary; noted in the follow-up ledger above rather than silently widened.

## Testing

`python3 scripts/tests/test_what_matters_now_json.py` — **31 checks, all passing.**

The test asserts the booleans are **JSON booleans**, not merely that the output parses: the string `"true"` would parse fine and still be wrong. It then asserts *structurally* that no `${...}` or `$(...)` reaches the Python body, which forbids defect (2) without needing a checkout on a hostile branch name.

Eight are MUST-FAIL controls. They reconstruct the real pre-fix form and prove each assertion rejects it — including executing it to confirm the `NameError`, and running `git check-ref-format --branch 'quote"branch'` to confirm git really does accept the branch name defect (2) needs. It also proves `git branch --show-current` exits 0 with empty output on a detached HEAD — the mechanism that made the old fallback dead code — and includes an attached-checkout control confirming the fix did not simply replace every branch name with `detached`. Without those, the gate could pass vacuously.

The detached-HEAD cases execute the branch-resolution block **extracted from the shipped script**, not a re-implementation: the whole script cannot run outside a real checkout, which #2638 records as a trap that masks defects, so the real block is executed verbatim instead.

Local gates re-run clean: `drift-check.sh`, `check-preflight-consistency.sh`, `check-truth-spine.py`, `test_sprint_state_invariants.py`.

## Related

- Issues: `Closes #2638` — intentional. The issue is exactly this defect and this PR discharges it in full, including the CI runner the issue asks for. Refs #2634, #2636.

## Cross-repo dependency status

- Upstream PR(s): none. Downstream PR(s): none. Depends on upstream merging first: **no**.

## Work mode

- [x] Delivery tranche

## Risk

Low, and bounded to agent tooling. No Rust, no public API, no wire format, no runtime path. The failure mode this could introduce is a *wrong* payload rather than a missing one — which is why the test type-checks fields instead of only parsing. If the environment-passing form regressed, `--json` would fail loudly in CI now instead of silently as before.

Not covered: this proves the mode emits well-formed JSON, not that any consumer reads it correctly — there are still no non-test consumers of `--json`.
