### PR TITLE
feat(agent): give a session a checkpoint ICN can read without the harness

### DIFF
--- a/.github/workflows/agent-drift-check.yml
+++ b/.github/workflows/agent-drift-check.yml
@@ -34,6 +34,8 @@ on:
       - 'scripts/check-preflight-consistency.sh'
       - 'scripts/check-truth-spine.py'
       - 'scripts/tests/test_public_docs_boundary.py'
+      # icn#2689: the portable session-checkpoint exporter and its controls.
+      - 'scripts/tests/test_session_checkpoint.py'
       - 'ops/state/config/**'
       - 'CLAUDE.md'
       - 'ops/CLAUDE.md'
@@ -103,6 +105,12 @@ jobs:
 
       - name: Sprint-state currency + SessionStart source guard tests (Refs icn#2634)
         run: python3 scripts/tests/test_sprint_state_invariants.py
+
+      # The checkpoint format's whole claim is that it works without the harness that wrote it,
+      # so its controls run the exporter against throwaway git repositories and read only the
+      # files it produced. No provider directory, no vendor API, no transcript required.
+      - name: Portable session-checkpoint controls (Refs icn#2689)
+        run: python3 scripts/tests/test_session_checkpoint.py
 
       # icn#2651: the canonical merge policy must not name a field that cannot hold the value it
       # is compared against, and must not duplicate values it owns. Both got past every other gate

--- a/docs/architecture/AGENT_RUNTIME.md
+++ b/docs/architecture/AGENT_RUNTIME.md
@@ -618,6 +618,29 @@ Three properties are deliberate:
 `verify` re-hashes every artifact and **fails** on a mismatch or an unknown schema, so a
 checkpoint stays checkable after being copied off this machine.
 
+### 10.3.1 Disclosure boundary — a checkpoint is exportable data
+
+A checkpoint is built to cross a trust boundary: Claude to Codex, this machine to another, one
+harness to the next. It is therefore **exportable data, not a dump of trusted local process
+state**, and its disclosure rules are stricter than ordinary local diagnostic tooling.
+
+The boundary is an **allowlist**, not redaction. Every field in `observed` is named individually;
+nothing serialises an environment, an argv, or a remote URL wholesale and cleans it afterwards.
+Concretely, the Git remote is *parsed* into `{remote, form, host, owner, name}` and the URL string
+itself is never written, so a remote carrying `https://x-access-token:<token>@…` — or a token in a
+query string, or a fragment — has no field to leak through. A parser emitting five known fields
+cannot disclose a shape it never anticipated; a redactor must anticipate every one.
+
+`assert_no_credentials` re-scans the finished manifest for credential-shaped text and aborts the
+export rather than writing it. That is **defence in depth behind the allowlist, not the boundary
+itself**, and it deliberately does not print what it matched.
+
+One surface stays outside this guarantee and must be understood as such: an attached provider
+transcript is **opaque vendor evidence**, copied verbatim and never parsed. Whatever a session
+printed is in it. It is optional for exactly this reason — a checkpoint is complete without one —
+and attaching a transcript to a checkpoint that will leave a trust boundary is a decision the
+operator makes per export, not a default.
+
 **Integrity, not attestation.** SHA-256 content hashes only. ICN has signing primitives, and
 reaching for them here would produce a weak ceremony rather than a real guarantee — the signer
 would be an agent process with no standing to attest anything. Stronger attestation is a later

--- a/docs/architecture/AGENT_RUNTIME.md
+++ b/docs/architecture/AGENT_RUNTIME.md
@@ -544,3 +544,97 @@ seam, so this layer relies on the positive path instead: a supported primitive, 
 startup context. The attempt is preserved on `ops/agent-wait-guard`.
 
 Every wait is bounded. Indefinite blocking is available only behind an explicit flag.
+
+---
+
+## 10. Session checkpoints — state ICN owns
+
+### 10.1 The failure that motivated this
+
+A session finished successfully and its harness's own export malfunctioned. Recovery meant
+locating that harness's private transcript file by hand and reconstructing a handoff separately.
+Nothing was lost, but the incident named a real property of the current arrangement: a session's
+reconstructable state existed **only** inside a specific vendor's tooling, in a format that
+vendor owns, reachable only through a command that vendor implements.
+
+That is a portability failure rather than a harness defect. It would have looked the same in any
+other agent product.
+
+### 10.2 The principle
+
+> ICN's canonical development state, authority, evidence and workflow must not depend on the
+> continued availability or proprietary behaviour of a specific model provider or agent harness.
+
+Operational corollary:
+
+> A proprietary harness feature may accelerate development. State produced through it that the
+> project depends on must also have a representation ICN can read without that harness.
+
+Stated as a direction, not a status. **ICN is not harness-independent today.** §7 already records
+how narrow the non-Claude surface is: only Cursor declares the ops MCP server, no other provider
+gets automatic registration, and the Claude Code hook seam is the only launcher that registers a
+session at all. The rule this section adds is about *how the gap closes*: when a proprietary
+harness owns a strategically important function, or causes an actual portability failure, that
+responsibility is extracted below the vendor boundary **one bounded feature at a time** — not by
+designing a replacement for the harness.
+
+Checkpointing is the first such extraction. It is one tooth of a ratchet, not a plan.
+
+### 10.3 `ops/scripts/icn-session-checkpoint`
+
+```
+icn-session-checkpoint create --out DIR [--handoff F] [--transcript F]
+                              [--provider NAME] [--ref R]... [--note TEXT]...
+icn-session-checkpoint verify DIR
+```
+
+It writes `manifest.json` plus an `artifacts/` directory, and is a helper capability like any
+other — declared with a `#: capability:` header, discovered by §7's generator, so no launcher or
+prompt is edited to make it reachable.
+
+**The manifest keeps three kinds of fact apart**, because a consumer that cannot tell a
+re-derivable fact from a stale one will act on the stale one:
+
+| Block | What it holds | How a consumer must treat it |
+|---|---|---|
+| `observed` | repository, worktree, branch, HEAD, base, ahead/behind, dirty state, changed files, recent commits — derived here from Git | re-derivable, and cheap to re-derive |
+| `captured` | the branch's pull request and its check buckets, as GitHub reported them at `created_at` | historical the moment it was written; requery before acting |
+| `generated` | a handoff file and notes supplied by a person or agent | not derived from anything here, and not verified by anything here |
+
+This is the §2.5 field classification applied to a different artefact, and for the same reason:
+the runtime stores the **reference**, never the state.
+
+Three properties are deliberate:
+
+* **It works with no transcript.** A provider transcript is optional. When one is supplied it is
+  copied into `artifacts/` and hashed, and is **never parsed** — vendor evidence, not a
+  dependency. A Codex or local-model adapter attaches its own stream on identical terms.
+* **Artifacts are copied, not referenced.** A checkpoint pointing into a harness's private
+  directory would reproduce the dependency the format removes.
+* **It invents nothing.** Where a fact cannot be resolved — no PR for the branch, several PRs for
+  one branch, `gh` absent — the manifest records `resolved: null` with the reason. Narrative is
+  carried through from `--handoff`/`--note` and is never synthesised.
+
+`verify` re-hashes every artifact and **fails** on a mismatch or an unknown schema, so a
+checkpoint stays checkable after being copied off this machine.
+
+**Integrity, not attestation.** SHA-256 content hashes only. ICN has signing primitives, and
+reaching for them here would produce a weak ceremony rather than a real guarantee — the signer
+would be an agent process with no standing to attest anything. Stronger attestation is a later
+question, to be answered when there is a principal whose signature would mean something.
+
+**What a checkpoint is not.** It is not authority. Branch, PR, issue and CI state have owners
+named in `ops/state/truth/sources.json`, and those owners are authoritative. A checkpoint is
+memory and evidence, on exactly the terms `.agents/skills/handoff` already states for a handoff.
+
+### 10.4 Deliberately not built
+
+A normalized session **event stream** — `session.started`, `context.loaded`, `tool.called`,
+`file.changed`, `decision.recorded`, `test.completed`, `git.commit`, `pr.created`,
+`checkpoint.created` — is the obvious next primitive, and the ops MCP already has an events table
+(`ops/mcp/src/state/events.ts`) that a normalized stream would extend rather than replace. It is
+recorded here as a design note and nothing more. Building it now would be designing the whole
+future instead of adding the next tooth.
+
+Also not built, and not implied: an agent orchestrator, a model router, a UI, or any change to
+MCP. Model adapters remain vendor-specific; the checkpoint format and its exporter do not.

--- a/docs/reference/project-index/generated/agent-capabilities.json
+++ b/docs/reference/project-index/generated/agent-capabilities.json
@@ -473,6 +473,13 @@
       "safety": "modifies_local"
     },
     {
+      "name": "icn-session-checkpoint",
+      "path": "ops/scripts/icn-session-checkpoint",
+      "capability": "session-checkpoint-export",
+      "summary": "Export a portable, harness-neutral checkpoint of a development session.",
+      "safety": "modifies_local"
+    },
+    {
       "name": "icn-wait",
       "path": "ops/scripts/icn-wait",
       "capability": "safe-waiting",

--- a/ops/scripts/icn-session-checkpoint
+++ b/ops/scripts/icn-session-checkpoint
@@ -1,0 +1,445 @@
+#!/usr/bin/env python3
+#: capability: session-checkpoint-export
+#: summary: Export a portable, harness-neutral checkpoint of a development session.
+#: safety: modifies_local
+#
+# icn-session-checkpoint — a session's durable state, in a form ICN owns.
+#
+# WHY THIS EXISTS
+#
+#   A session's reconstructable state currently lives inside whichever agent
+#   harness produced it. When one harness's own export failed, the recovery was
+#   to locate its private transcript file by hand. That is a portability
+#   failure, not a harness bug: project-critical state had no representation
+#   under ICN's control.
+#
+#   This tool is the smallest correction. It writes a checkpoint directory that
+#   another agent — Claude Code, Codex, a local model, a future one — can read
+#   without the originating harness, its export command, or its file formats.
+#
+# WHAT A CHECKPOINT IS NOT
+#
+#   It is not authority. Branch, PR, issue and CI state are live queries whose
+#   owners are named in ops/state/truth/sources.json. A checkpoint records what
+#   was observed and when; the next session requeries before acting. The
+#   manifest keeps the three kinds apart on purpose:
+#
+#     observed   — derived here from Git and the filesystem, re-derivable.
+#     captured   — point-in-time GitHub state. Historical the moment it is
+#                  written. Never a basis for action.
+#     generated  — narrative a person or agent wrote. This tool does not
+#                  synthesise it and will not pretend to.
+#
+#   Nothing here signs anything. Artifacts carry SHA-256 content hashes so a
+#   checkpoint can be verified after being copied; attestation is a later
+#   question and is deliberately not answered by inventing a weak version now.
+#
+# PROVIDER BOUNDARY
+#
+#   A provider transcript is optional, opaque and never parsed — it is copied
+#   and hashed as evidence. The format works with no transcript at all, so a
+#   Codex or local-model adapter attaches its own stream on the same terms.
+#
+# Usage:
+#   icn-session-checkpoint create --out DIR [options]
+#   icn-session-checkpoint verify DIR
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import shutil
+import subprocess
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+SCHEMA = "icn-session-checkpoint/v1"
+MANIFEST_NAME = "manifest.json"
+ARTIFACT_DIR = "artifacts"
+
+
+# ── shelling out ────────────────────────────────────────────────────────────
+
+
+def run(args: list[str], cwd: Path | None = None, raw: bool = False) -> str | None:
+    """Return stdout, or None when the command is unavailable or fails.
+
+    Absence is reported as null in the manifest rather than as an empty string,
+    so a consumer can tell "not determined" from "determined to be empty".
+
+    `raw` keeps leading whitespace, which matters for column-oriented output:
+    `git status --porcelain` puts a space in column 1 for an unstaged change,
+    and trimming it shifts every path one character left.
+    """
+    try:
+        out = subprocess.run(
+            args,
+            cwd=str(cwd) if cwd else None,
+            capture_output=True,
+            text=True,
+            timeout=60,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return None
+    if out.returncode != 0:
+        return None
+    return out.stdout.rstrip("\n") if raw else out.stdout.strip()
+
+
+def git(root: Path, *args: str) -> str | None:
+    return run(["git", *args], cwd=root)
+
+
+def sha256_of(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as fh:
+        for chunk in iter(lambda: fh.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+# ── observed state ──────────────────────────────────────────────────────────
+
+
+def resolve_root(start: Path) -> Path:
+    root = run(["git", "rev-parse", "--show-toplevel"], cwd=start)
+    if not root:
+        sys.exit(f"icn-session-checkpoint: {start} is not inside a git worktree")
+    return Path(root)
+
+
+def observe(root: Path) -> dict:
+    """Everything derivable here and now, without asking a network service."""
+    branch = git(root, "branch", "--show-current") or None
+    head = git(root, "rev-parse", "HEAD")
+    upstream = git(root, "rev-parse", "--abbrev-ref", "--symbolic-full-name", "@{u}")
+
+    # The comparison base is the merge-base with the upstream default, because
+    # "how far ahead" is only meaningful against a named base.
+    base_ref = "origin/main"
+    merge_base = git(root, "merge-base", "HEAD", base_ref)
+
+    ahead = behind = None
+    counts = git(root, "rev-list", "--left-right", "--count", f"{base_ref}...HEAD")
+    if counts and len(counts.split()) == 2:
+        behind_s, ahead_s = counts.split()
+        behind, ahead = int(behind_s), int(ahead_s)
+
+    porcelain = run(["git", "status", "--porcelain"], cwd=root, raw=True) or ""
+    changed = [line[3:] for line in porcelain.splitlines() if len(line) > 3]
+
+    return {
+        "repository": {
+            "root": str(root),
+            "remote_origin": git(root, "remote", "get-url", "origin"),
+        },
+        "worktree": {
+            "path": str(root),
+            "name": root.name,
+            "is_linked_worktree": (root / ".git").is_file(),
+        },
+        "git": {
+            "branch": branch,
+            "head": head,
+            "upstream": upstream,
+            "base_ref": base_ref,
+            "merge_base": merge_base,
+            "commits_ahead_of_base": ahead,
+            "commits_behind_base": behind,
+            "dirty": bool(changed),
+            "changed_files": changed,
+            "recent_commits": (git(root, "log", "--oneline", "-10") or "").splitlines(),
+        },
+    }
+
+
+# ── captured state ──────────────────────────────────────────────────────────
+
+
+def capture_pull_request(root: Path, branch: str | None) -> dict:
+    """The PR for this branch, when exactly one is deterministically discoverable.
+
+    Ambiguity is reported, never guessed: two open PRs for one branch means the
+    checkpoint says so rather than picking the first.
+    """
+    if not branch:
+        return {"resolved": None, "reason": "no branch (detached HEAD)"}
+    if shutil.which("gh") is None:
+        return {"resolved": None, "reason": "gh not on PATH"}
+
+    raw = run(
+        [
+            "gh", "pr", "list", "--head", branch, "--state", "all", "--limit", "10",
+            "--json", "number,title,state,url,headRefOid,isDraft,mergeable,"
+                      "mergeStateStatus,reviewDecision",
+        ],
+        cwd=root,
+    )
+    if raw is None:
+        return {"resolved": None, "reason": "gh query failed or unauthenticated"}
+
+    try:
+        prs = json.loads(raw)
+    except json.JSONDecodeError:
+        return {"resolved": None, "reason": "gh returned unparseable JSON"}
+
+    if not prs:
+        return {"resolved": None, "reason": "no pull request for this branch"}
+    if len(prs) > 1:
+        return {
+            "resolved": None,
+            "reason": "several pull requests share this branch",
+            "candidates": [p.get("number") for p in prs],
+        }
+    return {"resolved": prs[0]}
+
+
+def capture_checks(root: Path, pr_number: int | None) -> dict:
+    """Check states as GitHub reported them, counted by bucket.
+
+    Deliberately NOT a merge-readiness verdict. Which checks are *required* is
+    branch-protection state this tool does not read, so a consumer must not
+    infer readiness from these counts — that is the ci-status skill's job,
+    against live state.
+    """
+    if pr_number is None or shutil.which("gh") is None:
+        return {"resolved": None, "reason": "no pull request, or gh unavailable"}
+
+    raw = run(
+        ["gh", "pr", "checks", str(pr_number), "--json", "name,bucket,state"],
+        cwd=root,
+    )
+    if raw is None:
+        return {"resolved": None, "reason": "gh pr checks failed or returned non-zero"}
+    try:
+        checks = json.loads(raw)
+    except json.JSONDecodeError:
+        return {"resolved": None, "reason": "gh returned unparseable JSON"}
+
+    buckets: dict[str, int] = {}
+    for check in checks:
+        bucket = check.get("bucket") or "unknown"
+        buckets[bucket] = buckets.get(bucket, 0) + 1
+    return {
+        "resolved": {
+            "total": len(checks),
+            "by_bucket": dict(sorted(buckets.items())),
+            "failing": sorted(
+                c.get("name", "?") for c in checks if c.get("bucket") == "fail"
+            ),
+        },
+        "required_checks_not_resolved": (
+            "branch protection was not queried; these counts include "
+            "non-required checks"
+        ),
+    }
+
+
+# ── artifacts ───────────────────────────────────────────────────────────────
+
+
+def adopt_artifact(out: Path, source: Path, role: str, extra: dict) -> dict:
+    """Copy a file into the checkpoint and record its hash.
+
+    Copied rather than referenced: a checkpoint that points at a path inside a
+    harness's private directory is exactly the dependency this tool removes.
+    """
+    if not source.is_file():
+        sys.exit(f"icn-session-checkpoint: {role} file not found: {source}")
+
+    artifacts = out / ARTIFACT_DIR
+    artifacts.mkdir(parents=True, exist_ok=True)
+    dest = artifacts / source.name
+    shutil.copyfile(source, dest)
+
+    record = {
+        "path": f"{ARTIFACT_DIR}/{dest.name}",
+        "role": role,
+        "bytes": dest.stat().st_size,
+        "sha256": sha256_of(dest),
+        "source_path": str(source),
+    }
+    record.update(extra)
+    return record
+
+
+# ── commands ────────────────────────────────────────────────────────────────
+
+
+def cmd_create(args: argparse.Namespace) -> int:
+    root = resolve_root(Path(args.cwd or os.getcwd()).resolve())
+    out = Path(args.out).resolve()
+    out.mkdir(parents=True, exist_ok=True)
+
+    observed = observe(root)
+    branch = observed["git"]["branch"]
+
+    pull_request = capture_pull_request(root, branch)
+    pr_number = (pull_request.get("resolved") or {}).get("number")
+
+    artifacts: list[dict] = []
+    if args.handoff:
+        artifacts.append(
+            adopt_artifact(out, Path(args.handoff).resolve(), "handoff", {})
+        )
+    if args.transcript:
+        artifacts.append(
+            adopt_artifact(
+                out,
+                Path(args.transcript).resolve(),
+                "provider-transcript",
+                {
+                    "provider": args.provider or "unknown",
+                    "opaque": True,
+                    "note": (
+                        "Vendor-format evidence. Copied and hashed, never parsed. "
+                        "The checkpoint is complete without it."
+                    ),
+                },
+            )
+        )
+
+    manifest = {
+        "schema": SCHEMA,
+        "created_at": datetime.now(timezone.utc).isoformat(timespec="seconds"),
+        "truth_classes": {
+            "observed": (
+                "Derived here from Git and the filesystem at created_at. "
+                "Re-derivable, and cheap to re-derive."
+            ),
+            "captured": (
+                "Point-in-time GitHub state. Historical the moment it was "
+                "written. Requery before acting on it."
+            ),
+            "generated": (
+                "Narrative supplied by a person or an agent. Not derived from "
+                "anything here, and not verified by anything here."
+            ),
+        },
+        "provider": {
+            "harness": args.provider,
+            "note": (
+                "Which agent product produced the session. Recorded for "
+                "provenance; nothing in this format depends on it."
+            ),
+        },
+        "observed": observed,
+        "captured": {
+            "pull_request": pull_request,
+            "checks": capture_checks(root, pr_number),
+            "references": [
+                {"ref": r, "state": "not queried — resolve live"} for r in args.ref
+            ],
+        },
+        "generated": {
+            "handoff": next(
+                (a["path"] for a in artifacts if a["role"] == "handoff"), None
+            ),
+            "notes": args.note,
+        },
+        "artifacts": artifacts,
+        "authority": {
+            "live_state_owners": "ops/state/truth/sources.json",
+            "warning": (
+                "This checkpoint is memory and evidence. It is not the "
+                "authority on any volatile fact it records."
+            ),
+        },
+    }
+
+    (out / MANIFEST_NAME).write_text(
+        json.dumps(manifest, indent=2, sort_keys=False) + "\n", encoding="utf-8"
+    )
+
+    print(f"checkpoint: {out}")
+    print(f"  schema:   {SCHEMA}")
+    print(f"  branch:   {branch} @ {(observed['git']['head'] or '')[:12]}")
+    print(f"  dirty:    {observed['git']['dirty']} ({len(observed['git']['changed_files'])} file(s))")
+    pr = pull_request.get("resolved")
+    print(f"  pr:       {('#' + str(pr['number'])) if pr else pull_request.get('reason')}")
+    for artifact in artifacts:
+        print(f"  artifact: {artifact['path']}  {artifact['sha256'][:16]}…")
+    return 0
+
+
+def cmd_verify(args: argparse.Namespace) -> int:
+    out = Path(args.checkpoint).resolve()
+    manifest_path = out / MANIFEST_NAME
+    if not manifest_path.is_file():
+        print(f"verify: no {MANIFEST_NAME} in {out}", file=sys.stderr)
+        return 1
+
+    try:
+        manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        print(f"verify: {MANIFEST_NAME} is not valid JSON: {exc}", file=sys.stderr)
+        return 1
+
+    schema = manifest.get("schema")
+    if schema != SCHEMA:
+        # A different version is not automatically wrong, but this binary must
+        # not claim to have verified something it does not understand.
+        print(f"verify: unknown schema {schema!r} (this tool writes {SCHEMA})", file=sys.stderr)
+        return 1
+
+    failures = 0
+    for artifact in manifest.get("artifacts", []):
+        path = out / artifact["path"]
+        if not path.is_file():
+            print(f"verify: MISSING {artifact['path']}", file=sys.stderr)
+            failures += 1
+            continue
+        actual = sha256_of(path)
+        if actual != artifact.get("sha256"):
+            print(f"verify: HASH MISMATCH {artifact['path']}", file=sys.stderr)
+            failures += 1
+        else:
+            print(f"verify: ok {artifact['path']} ({artifact['bytes']} bytes)")
+
+    print(f"verify: schema ok, {len(manifest.get('artifacts', []))} artifact(s), {failures} failure(s)")
+    return 1 if failures else 0
+
+
+def main(argv: list[str]) -> int:
+    parser = argparse.ArgumentParser(
+        prog="icn-session-checkpoint",
+        description="Export or verify a portable, harness-neutral session checkpoint.",
+    )
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    create = sub.add_parser("create", help="write a checkpoint directory")
+    create.add_argument("--out", required=True, help="checkpoint directory to write")
+    create.add_argument("--cwd", help="worktree to describe (default: cwd)")
+    create.add_argument("--handoff", help="agent-authored handoff markdown to include")
+    create.add_argument(
+        "--transcript",
+        help="provider transcript to copy in as opaque evidence (optional)",
+    )
+    create.add_argument("--provider", help="agent harness that produced the session")
+    create.add_argument(
+        "--ref",
+        action="append",
+        default=[],
+        help="issue/PR reference to record (repeatable); state is not queried",
+    )
+    create.add_argument(
+        "--note",
+        action="append",
+        default=[],
+        help="agent-authored note (repeatable); recorded as generated, not derived",
+    )
+    create.set_defaults(func=cmd_create)
+
+    verify = sub.add_parser("verify", help="re-hash a checkpoint's artifacts")
+    verify.add_argument("checkpoint", help="checkpoint directory")
+    verify.set_defaults(func=cmd_verify)
+
+    args = parser.parse_args(argv)
+    return args.func(args)
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/ops/scripts/icn-session-checkpoint
+++ b/ops/scripts/icn-session-checkpoint
@@ -418,7 +418,32 @@ def adopt_artifact(out: Path, source: Path, role: str, extra: dict) -> dict:
 def cmd_create(args: argparse.Namespace) -> int:
     root = resolve_root(Path(args.cwd or os.getcwd()).resolve())
     out = Path(args.out).resolve()
-    out.mkdir(parents=True, exist_ok=True)
+
+    # A checkpoint is assembled in a sibling staging directory and moved into
+    # place only once it is complete.
+    #
+    # Writing in place left whatever a previous run had put there. Re-using a
+    # directory for a checkpoint with fewer artifacts kept the old ones on disk
+    # while the new manifest listed none, so `verify` passed over stale session
+    # data that was neither declared nor hashed — a portable artifact silently
+    # carrying a previous session's transcript. Observed during this feature's
+    # own dogfooding: 2.19 MB of undeclared bytes in a checkpoint whose manifest
+    # said it held nothing.
+    #
+    # Staging also means a failed export cannot damage the checkpoint that is
+    # already there: nothing under `out` is touched until the new one is whole.
+    if out.exists() and any(out.iterdir()) and not args.replace:
+        sys.exit(
+            f"icn-session-checkpoint: {out} is not empty. Pass --replace to "
+            f"replace the checkpoint there, so stale artifacts cannot survive "
+            f"into a manifest that does not list them."
+        )
+
+    staging = out.parent / f".{out.name}.staging-{os.getpid()}"
+    if staging.exists():
+        shutil.rmtree(staging)
+    staging.mkdir(parents=True)
+    out_final, out = out, staging
 
     observed = observe(root)
     branch = observed["git"]["branch"]
@@ -502,6 +527,18 @@ def cmd_create(args: argparse.Namespace) -> int:
         json.dumps(manifest, indent=2, sort_keys=False) + "\n", encoding="utf-8"
     )
 
+    # Swap the completed checkpoint into place. The previous one is moved aside
+    # first and removed only after the new one has landed, so an interruption
+    # leaves one of the two intact rather than neither.
+    superseded = None
+    if out_final.exists():
+        superseded = out_final.parent / f".{out_final.name}.superseded-{os.getpid()}"
+        out_final.rename(superseded)
+    out.rename(out_final)
+    if superseded is not None:
+        shutil.rmtree(superseded, ignore_errors=True)
+    out = out_final
+
     print(f"checkpoint: {out}")
     print(f"  schema:   {SCHEMA}")
     print(f"  branch:   {branch} @ {(observed['git']['head'] or '')[:12]}")
@@ -536,12 +573,17 @@ def cmd_verify(args: argparse.Namespace) -> int:
     # A tampered manifest is the case this command exists for, so every field
     # it reads is checked before it is used. Raising a KeyError here would turn
     # a detected tamper into a crash, and a crash is not a verdict.
-    artifacts = manifest.get("artifacts")
-    if artifacts is None:
-        artifacts = []
-    if not isinstance(artifacts, list):
-        print("verify: MALFORMED artifacts (not a list)", file=sys.stderr)
+    # v1 requires the index to be present and list-valued. Treating a missing
+    # or null member as "no artifacts" let a stripped manifest verify clean
+    # while real artifact files sat beside it unhashed.
+    if "artifacts" not in manifest or not isinstance(manifest["artifacts"], list):
+        print(
+            "verify: MALFORMED artifacts index (absent or not a list); a v1 "
+            "manifest must list its artifacts, even when there are none",
+            file=sys.stderr,
+        )
         return 1
+    artifacts = manifest["artifacts"]
 
     failures = 0
     for index, artifact in enumerate(artifacts):
@@ -589,6 +631,20 @@ def cmd_verify(args: argparse.Namespace) -> int:
         else:
             print(f"verify: ok {relative} ({path.stat().st_size} bytes)")
 
+    # Defence in depth behind the staging swap: a file under `artifacts/` that
+    # the manifest does not list is undeclared and unhashed, and would travel
+    # with the checkpoint as though it belonged to it.
+    declared = {a["path"] for a in artifacts if isinstance(a, dict) and isinstance(a.get("path"), str)}
+    artifact_root = out / ARTIFACT_DIR
+    if artifact_root.is_dir():
+        for path in sorted(artifact_root.rglob("*")):
+            if not path.is_file():
+                continue
+            relative = path.relative_to(out).as_posix()
+            if relative not in declared:
+                print(f"verify: UNDECLARED {relative}", file=sys.stderr)
+                failures += 1
+
     print(f"verify: schema ok, {len(artifacts)} artifact(s), {failures} failure(s)")
     return 1 if failures else 0
 
@@ -609,6 +665,12 @@ def main(argv: list[str]) -> int:
         help="provider transcript to copy in as opaque evidence (optional)",
     )
     create.add_argument("--provider", help="agent harness that produced the session")
+    create.add_argument(
+        "--replace",
+        action="store_true",
+        help="replace an existing checkpoint at --out (it is swapped in whole, "
+             "never merged into, so stale artifacts cannot survive)",
+    )
     create.add_argument(
         "--ref",
         action="append",

--- a/ops/scripts/icn-session-checkpoint
+++ b/ops/scripts/icn-session-checkpoint
@@ -50,13 +50,20 @@ import argparse
 import hashlib
 import json
 import os
+import re
 import shutil
 import subprocess
 import sys
 from datetime import datetime, timezone
-from pathlib import Path
+from pathlib import Path, PurePosixPath
 
 SCHEMA = "icn-session-checkpoint/v1"
+# One explicit string: adjacent literals inside an argv list read exactly like a
+# missing comma, which is how an argument list silently loses an element.
+PR_JSON_FIELDS = (
+    "number,title,state,url,headRefOid,isDraft,mergeable,"
+    + "mergeStateStatus,reviewDecision"
+)
 MANIFEST_NAME = "manifest.json"
 ARTIFACT_DIR = "artifacts"
 
@@ -104,6 +111,102 @@ def sha256_of(path: Path) -> str:
 # ── observed state ──────────────────────────────────────────────────────────
 
 
+def repository_identity(url: str | None, remote: str = "origin") -> dict:
+    """Parse a Git remote into the identity fields, and nothing else.
+
+    # Why this parses instead of redacting
+
+    A checkpoint is meant to be copied between machines and handed to another
+    agent harness, so it is exportable data rather than a dump of trusted local
+    process state. The safe construction is therefore an **allowlist**: name the
+    fields a downstream reader actually needs — which host, whose namespace,
+    which repository — and never serialise the remote string itself.
+
+    Redaction is the weaker model, because it must anticipate every shape a
+    secret can take. A remote can carry a credential in userinfo
+    (`https://x-access-token:<token>@host/...`), and a URL can also carry a
+    query string or fragment. A parser that emits four known fields cannot leak
+    any of them, whether or not this function anticipated the shape. Redaction
+    remains defence in depth (`assert_no_credentials`), not the boundary.
+
+    Unrecognised input yields `form: "unknown"` with empty fields — declining to
+    describe a remote is always safe, whereas guessing at one is not.
+    """
+    identity = {"remote": remote, "form": "unknown", "host": None, "owner": None, "name": None}
+    if not url:
+        return identity
+
+    def strip_repo(name: str) -> str:
+        return name[:-4] if name.endswith(".git") else name
+
+    def split_owner_repo(path: str, identity: dict) -> None:
+        # Query and fragment are never identity, and either can carry a token.
+        path = path.split("?", 1)[0].split("#", 1)[0].strip("/")
+        parts = [p for p in path.split("/") if p]
+        if parts:
+            identity["name"] = strip_repo(parts[-1])
+        if len(parts) > 1:
+            identity["owner"] = "/".join(parts[:-1])
+
+    scheme, sep, rest = url.partition("://")
+    if sep:
+        # scheme://[userinfo@]host[:port]/owner/repo — userinfo is dropped by
+        # taking only what follows the last '@' in the authority.
+        authority, _, path = rest.partition("/")
+        host = authority.rpartition("@")[2]
+        identity["form"] = "url"
+        identity["host"] = host.split(":", 1)[0] or None
+        split_owner_repo(path, identity)
+        return identity
+
+    # scp-style `[user@]host:owner/repo.git`. Distinguished from a local path by
+    # a colon that is not part of a drive letter or an absolute path.
+    if ":" in url and not url.startswith((".", "/", "~")):
+        authority, _, path = url.partition(":")
+        identity["form"] = "scp"
+        identity["host"] = authority.rpartition("@")[2] or None
+        split_owner_repo(path, identity)
+        return identity
+
+    if url.startswith((".", "/", "~")) or "/" in url:
+        identity["form"] = "path"
+        split_owner_repo(url, identity)
+        identity["owner"] = None  # a filesystem path names no namespace
+        return identity
+
+    return identity
+
+
+# Shapes that must never appear in a checkpoint, checked as defence in depth
+# after the allowlist above has already decided what gets written.
+_CREDENTIAL_SHAPES = (
+    re.compile(r"https?://[^/\s:@]+:[^/\s@]+@"),
+    re.compile(r"gh[pousr]_[A-Za-z0-9]{20,}"),
+    re.compile(r"github_pat_[A-Za-z0-9_]{20,}"),
+    re.compile(r"-----BEGIN [A-Z ]*PRIVATE KEY-----"),
+    re.compile(r"xox[baprs]-[A-Za-z0-9-]{10,}"),
+    re.compile(r"[Aa]uthorization:\s*Bearer\s+\S{12,}"),
+)
+
+
+def assert_no_credentials(manifest: dict) -> None:
+    """Refuse to write a manifest carrying credential-shaped text.
+
+    The allowlist in `repository_identity` and `observe` is the security
+    boundary; this is the tripwire behind it. If a future field ever starts
+    carrying something secret-shaped, the export fails loudly here rather than
+    producing a portable artifact nobody thought to re-inspect.
+    """
+    serialized = json.dumps(manifest)
+    for shape in _CREDENTIAL_SHAPES:
+        if shape.search(serialized):
+            sys.exit(
+                "icn-session-checkpoint: refusing to write a manifest containing "
+                "credential-shaped text. This is a bug in what the exporter "
+                "collects; the value is deliberately not printed."
+            )
+
+
 def resolve_root(start: Path) -> Path:
     root = run(["git", "rev-parse", "--show-toplevel"], cwd=start)
     if not root:
@@ -117,16 +220,46 @@ def observe(root: Path) -> dict:
     head = git(root, "rev-parse", "HEAD")
     upstream = git(root, "rev-parse", "--abbrev-ref", "--symbolic-full-name", "@{u}")
 
-    # The comparison base is the merge-base with the upstream default, because
-    # "how far ahead" is only meaningful against a named base.
-    base_ref = "origin/main"
-    merge_base = git(root, "merge-base", "HEAD", base_ref)
+    # The comparison base is the remote's own default branch, because "how far
+    # ahead" is only meaningful against a named base — and a repository whose
+    # default is not `main` would otherwise be measured against a ref that does
+    # not exist. `origin/HEAD` is absent in plenty of clones, so it falls back.
+    # The base is the remote's DEFAULT branch, not the branch's own upstream.
+    # A feature branch's upstream is its own pushed copy, against which
+    # ahead/behind is 0/0 by construction — true, and useless to a reader asking
+    # how far this work sits from the integration target. The upstream ref is
+    # recorded separately above for anyone who wants it.
+    #
+    # When nothing names a default — a fresh repository, a clone with no
+    # origin/HEAD — the base and every field derived from it are null. A guessed
+    # base produces ahead/behind numbers that look authoritative while being
+    # measured against a ref that may not exist.
+    #
+    # `origin/HEAD` states the default explicitly, but it is unset in plenty of
+    # clones and in most linked worktrees, so the conventional names are tried
+    # after it — and each candidate is only accepted once `rev-parse --verify`
+    # confirms the ref actually exists. Resolving against a ref that is really
+    # there is not the same as guessing at one that might not be, and
+    # `base_ref_source` records which of the two happened.
+    declared = git(root, "symbolic-ref", "--quiet", "--short", "refs/remotes/origin/HEAD")
+    base_ref = None
+    base_ref_source = None
+    for candidate, source in (
+        (declared, "origin/HEAD"),
+        ("origin/main", "conventional default"),
+        ("origin/master", "conventional default"),
+    ):
+        if candidate and git(root, "rev-parse", "--verify", "--quiet", f"{candidate}^{{commit}}"):
+            base_ref, base_ref_source = candidate, source
+            break
 
-    ahead = behind = None
-    counts = git(root, "rev-list", "--left-right", "--count", f"{base_ref}...HEAD")
-    if counts and len(counts.split()) == 2:
-        behind_s, ahead_s = counts.split()
-        behind, ahead = int(behind_s), int(ahead_s)
+    merge_base = ahead = behind = None
+    if base_ref:
+        merge_base = git(root, "merge-base", "HEAD", base_ref)
+        counts = git(root, "rev-list", "--left-right", "--count", f"{base_ref}...HEAD")
+        if counts and len(counts.split()) == 2:
+            behind_s, ahead_s = counts.split()
+            behind, ahead = int(behind_s), int(ahead_s)
 
     porcelain = run(["git", "status", "--porcelain"], cwd=root, raw=True) or ""
     changed = [line[3:] for line in porcelain.splitlines() if len(line) > 3]
@@ -134,7 +267,7 @@ def observe(root: Path) -> dict:
     return {
         "repository": {
             "root": str(root),
-            "remote_origin": git(root, "remote", "get-url", "origin"),
+            "origin": repository_identity(git(root, "remote", "get-url", "origin")),
         },
         "worktree": {
             "path": str(root),
@@ -146,6 +279,7 @@ def observe(root: Path) -> dict:
             "head": head,
             "upstream": upstream,
             "base_ref": base_ref,
+            "base_ref_source": base_ref_source,
             "merge_base": merge_base,
             "commits_ahead_of_base": ahead,
             "commits_behind_base": behind,
@@ -173,8 +307,7 @@ def capture_pull_request(root: Path, branch: str | None) -> dict:
     raw = run(
         [
             "gh", "pr", "list", "--head", branch, "--state", "all", "--limit", "10",
-            "--json", "number,title,state,url,headRefOid,isDraft,mergeable,"
-                      "mergeStateStatus,reviewDecision",
+            "--json", PR_JSON_FIELDS,
         ],
         cwd=root,
     )
@@ -246,21 +379,34 @@ def adopt_artifact(out: Path, source: Path, role: str, extra: dict) -> dict:
 
     Copied rather than referenced: a checkpoint that points at a path inside a
     harness's private directory is exactly the dependency this tool removes.
+    For the same reason the record carries no absolute source path — the one
+    supplied here is typically inside the vendor's own directory, and writing
+    it down would put that dependency back in the manifest as a string.
+
+    Files land under `artifacts/<role>/`, so two artifacts that happen to share
+    a basename cannot overwrite each other. A second artifact for one role is
+    refused rather than silently replacing the first: a checkpoint that quietly
+    dropped an artifact would still verify, which is the worst available
+    outcome for a format whose job is to be trustworthy after copying.
     """
     if not source.is_file():
         sys.exit(f"icn-session-checkpoint: {role} file not found: {source}")
 
-    artifacts = out / ARTIFACT_DIR
-    artifacts.mkdir(parents=True, exist_ok=True)
-    dest = artifacts / source.name
+    role_dir = out / ARTIFACT_DIR / role
+    role_dir.mkdir(parents=True, exist_ok=True)
+    dest = role_dir / source.name
+    if dest.exists():
+        sys.exit(
+            f"icn-session-checkpoint: refusing to overwrite an existing "
+            f"{role} artifact at {dest}"
+        )
     shutil.copyfile(source, dest)
 
     record = {
-        "path": f"{ARTIFACT_DIR}/{dest.name}",
+        "path": f"{ARTIFACT_DIR}/{role}/{dest.name}",
         "role": role,
         "bytes": dest.stat().st_size,
         "sha256": sha256_of(dest),
-        "source_path": str(source),
     }
     record.update(extra)
     return record
@@ -350,6 +496,8 @@ def cmd_create(args: argparse.Namespace) -> int:
         },
     }
 
+    assert_no_credentials(manifest)
+
     (out / MANIFEST_NAME).write_text(
         json.dumps(manifest, indent=2, sort_keys=False) + "\n", encoding="utf-8"
     )
@@ -385,21 +533,63 @@ def cmd_verify(args: argparse.Namespace) -> int:
         print(f"verify: unknown schema {schema!r} (this tool writes {SCHEMA})", file=sys.stderr)
         return 1
 
+    # A tampered manifest is the case this command exists for, so every field
+    # it reads is checked before it is used. Raising a KeyError here would turn
+    # a detected tamper into a crash, and a crash is not a verdict.
+    artifacts = manifest.get("artifacts")
+    if artifacts is None:
+        artifacts = []
+    if not isinstance(artifacts, list):
+        print("verify: MALFORMED artifacts (not a list)", file=sys.stderr)
+        return 1
+
     failures = 0
-    for artifact in manifest.get("artifacts", []):
-        path = out / artifact["path"]
-        if not path.is_file():
-            print(f"verify: MISSING {artifact['path']}", file=sys.stderr)
+    for index, artifact in enumerate(artifacts):
+        if (
+            not isinstance(artifact, dict)
+            or not isinstance(artifact.get("path"), str)
+            or not isinstance(artifact.get("sha256"), str)
+        ):
+            print(f"verify: MALFORMED artifact record at index {index}", file=sys.stderr)
             failures += 1
             continue
-        actual = sha256_of(path)
-        if actual != artifact.get("sha256"):
-            print(f"verify: HASH MISMATCH {artifact['path']}", file=sys.stderr)
+
+        relative = artifact["path"]
+        # The manifest is untrusted input the moment a checkpoint is copied from
+        # another machine. An absolute path would make `out / relative` discard
+        # `out` entirely, and `..` segments climb out of it, either of which
+        # would let a manifest "verify" by hashing an unrelated local file — the
+        # exact opposite of a self-contained artifact.
+        candidate = PurePosixPath(relative)
+        if (
+            candidate.is_absolute()
+            or ".." in candidate.parts
+            or not relative.startswith(f"{ARTIFACT_DIR}/")
+        ):
+            print(f"verify: PATH NOT INSIDE {ARTIFACT_DIR}/ -- {relative}", file=sys.stderr)
+            failures += 1
+            continue
+
+        path = out / relative
+        try:
+            path.resolve().relative_to(out.resolve())
+        except ValueError:
+            print(f"verify: PATH ESCAPES CHECKPOINT {relative}", file=sys.stderr)
+            failures += 1
+            continue
+
+        if not path.is_file():
+            print(f"verify: MISSING {relative}", file=sys.stderr)
+            failures += 1
+            continue
+
+        if sha256_of(path) != artifact["sha256"]:
+            print(f"verify: HASH MISMATCH {relative}", file=sys.stderr)
             failures += 1
         else:
-            print(f"verify: ok {artifact['path']} ({artifact['bytes']} bytes)")
+            print(f"verify: ok {relative} ({path.stat().st_size} bytes)")
 
-    print(f"verify: schema ok, {len(manifest.get('artifacts', []))} artifact(s), {failures} failure(s)")
+    print(f"verify: schema ok, {len(artifacts)} artifact(s), {failures} failure(s)")
     return 1 if failures else 0
 
 

--- a/scripts/tests/test_session_checkpoint.py
+++ b/scripts/tests/test_session_checkpoint.py
@@ -174,6 +174,130 @@ def main() -> int:
         check("verify names the tampered file",
               "handoff.md" in (result.stdout + result.stderr))
 
+        # --- review findings from PR #2702, pinned so they cannot return -----
+        print("credentials and machine-local paths stay out of the manifest")
+        check("no absolute source path is recorded for an artefact",
+              all("source_path" not in a for a in m2["artifacts"]))
+
+        # The portable artifact must carry repository IDENTITY, never the remote
+        # string. Each shape below is exported and then the whole checkpoint
+        # tree is searched, byte-wise, for the sentinel secret.
+        SENTINEL = "s3cr3t-sentinel-not-a-real-token-9eec9e"
+        shapes = [
+            ("plain https", f"https://github.com/org/repo.git",
+             {"form": "url", "host": "github.com", "owner": "org", "name": "repo"}),
+            ("https with token userinfo",
+             f"https://x-access-token:{SENTINEL}@github.com/org/repo.git",
+             {"form": "url", "host": "github.com", "owner": "org", "name": "repo"}),
+            ("https with user:password",
+             f"https://alice:{SENTINEL}@example.com/team/sub/repo.git",
+             {"form": "url", "host": "example.com", "owner": "team/sub", "name": "repo"}),
+            ("ssh:// url", "ssh://git@github.com:22/org/repo.git",
+             {"form": "url", "host": "github.com", "owner": "org", "name": "repo"}),
+            ("scp-like", "git@github.com:org/repo.git",
+             {"form": "scp", "host": "github.com", "owner": "org", "name": "repo"}),
+            ("query and fragment",
+             f"https://github.com/org/repo.git?access_token={SENTINEL}#frag",
+             {"form": "url", "host": "github.com", "owner": "org", "name": "repo"}),
+            ("local path", "/srv/git/repo.git",
+             {"form": "path", "host": None, "owner": None, "name": "repo"}),
+            ("malformed", "not a url at all",
+             {"form": "unknown", "host": None, "owner": None, "name": None}),
+        ]
+
+        for label, remote_url, expected in shapes:
+            git(repo, "remote", "add", "origin", remote_url)
+            out_r = tmp / f"ckpt-remote-{abs(hash(label))}"
+            run = create(out_r, repo)
+            git(repo, "remote", "remove", "origin")
+
+            check(f"[{label}] create succeeds", run.returncode == 0)
+            if run.returncode != 0:
+                continue
+            mr = json.loads((out_r / "manifest.json").read_text(encoding="utf-8"))
+            origin = mr["observed"]["repository"]["origin"]
+            check(f"[{label}] identity parsed as expected",
+                  all(origin.get(k) == v for k, v in expected.items()))
+            check(f"[{label}] no raw remote URL field is emitted",
+                  "remote_origin" not in mr["observed"]["repository"])
+
+            # The real assertion: the sentinel appears NOWHERE in the artifact.
+            polluted = [
+                str(f.relative_to(out_r))
+                for f in out_r.rglob("*") if f.is_file()
+                and SENTINEL.encode() in f.read_bytes()
+            ]
+            check(f"[{label}] sentinel absent from the whole checkpoint tree",
+                  polluted == [])
+
+        # And the tripwire behind the allowlist must actually fire.
+        print("the credential tripwire fires")
+        import subprocess as _sp
+        probe = _sp.run(
+            [sys.executable, "-c",
+             "import importlib.util,sys;"
+             f"spec=importlib.util.spec_from_loader('t',importlib.machinery.SourceFileLoader('t',{str(TOOL)!r}));"
+             "m=importlib.util.module_from_spec(spec);"
+             "import importlib.machinery;"
+             "spec.loader.exec_module(m);"
+             "m.assert_no_credentials({'x':'https://u:p@h/'})"],
+            capture_output=True, text=True)
+        check("assert_no_credentials rejects a userinfo URL", probe.returncode != 0)
+        check("the tripwire does not print the offending value",
+              "u:p@h" not in (probe.stdout + probe.stderr))
+
+        print("artefacts cannot collide")
+        # Two artefacts sharing a basename must not overwrite one another.
+        collide_dir = tmp / "collide"
+        collide_dir.mkdir()
+        same_a = collide_dir / "a"
+        same_a.mkdir()
+        same_b = collide_dir / "b"
+        same_b.mkdir()
+        (same_a / "notes.md").write_text("handoff text\n", encoding="utf-8")
+        (same_b / "notes.md").write_text("transcript text\n", encoding="utf-8")
+        out_col = tmp / "ckpt-collide"
+        run = create(out_col, repo,
+                     "--handoff", str(same_a / "notes.md"),
+                     "--transcript", str(same_b / "notes.md"))
+        check("create succeeds with two same-named artefacts", run.returncode == 0)
+        mcol = json.loads((out_col / "manifest.json").read_text(encoding="utf-8"))
+        paths = {a["path"] for a in mcol["artifacts"]}
+        check("the two artefacts get distinct paths", len(paths) == 2)
+        bodies = {(out_col / p).read_text(encoding="utf-8") for p in paths}
+        check("neither artefact overwrote the other",
+              bodies == {"handoff text\n", "transcript text\n"})
+        check("verify passes on the collided-basename checkpoint",
+              verify(out_col).returncode == 0)
+
+        print("verify survives a malformed manifest")
+        for label, artifacts in (
+            ("artifact record is not a dict", ["just a string"]),
+            ("artifact record has no path", [{"sha256": "0" * 64}]),
+            ("artifact record has no sha256",
+             [{"path": "artifacts/handoff/notes.md"}]),
+            ("artifacts is not a list", {"nope": True}),
+            ("path escapes the checkpoint",
+             [{"path": "../../etc/passwd", "sha256": "0" * 64}]),
+            ("path is absolute",
+             [{"path": "/etc/passwd", "sha256": "0" * 64}]),
+            ("path is outside artifacts/",
+             [{"path": "manifest.json", "sha256": "0" * 64}]),
+        ):
+            out_bad = tmp / f"ckpt-bad-{abs(hash(label))}"
+            out_bad.mkdir()
+            # A real file at the referenced path, so a record missing `sha256`
+            # reaches the hash comparison instead of stopping at "MISSING".
+            real = out_bad / "artifacts" / "handoff"
+            real.mkdir(parents=True)
+            (real / "notes.md").write_text("x\n", encoding="utf-8")
+            bad = dict(m)
+            bad["artifacts"] = artifacts
+            (out_bad / "manifest.json").write_text(json.dumps(bad), encoding="utf-8")
+            result = verify(out_bad)
+            check(f"verify fails cleanly when {label}",
+                  result.returncode != 0 and "Traceback" not in result.stderr)
+
         # --- an unknown schema is refused, not half-understood ---------------
         print("schema discipline")
         out3 = tmp / "ckpt-future"

--- a/scripts/tests/test_session_checkpoint.py
+++ b/scripts/tests/test_session_checkpoint.py
@@ -1,0 +1,209 @@
+#!/usr/bin/env python3
+"""Controls for ops/scripts/icn-session-checkpoint.
+
+The point of the checkpoint format is that state survives WITHOUT the harness
+that produced it, so these tests run the tool against throwaway git repositories
+and read only the files it wrote. Nothing here imports a Claude API, reads a
+provider directory, or assumes a transcript exists.
+
+The properties under test are the ones that make a checkpoint trustworthy:
+
+* it works with no provider transcript at all (portability);
+* a transcript, when supplied, is copied and hashed rather than referenced or
+  parsed (the vendor artefact is evidence, not a dependency);
+* content hashes actually detect tampering (`verify` must fail, not warn);
+* the manifest keeps observed / captured / generated apart, because a consumer
+  that cannot tell a re-derivable fact from a stale one will act on the stale
+  one;
+* the tool never invents narrative it did not receive.
+
+Run: python3 scripts/tests/test_session_checkpoint.py
+"""
+
+import json
+import pathlib
+import shutil
+import subprocess
+import sys
+import tempfile
+
+ROOT = pathlib.Path(__file__).resolve().parents[2]
+TOOL = ROOT / "ops" / "scripts" / "icn-session-checkpoint"
+
+failures = []
+
+
+def check(desc, cond):
+    print(f"  {'ok  ' if cond else 'FAIL'} {desc}")
+    if not cond:
+        failures.append(desc)
+
+
+def git(repo, *args):
+    subprocess.run(
+        ["git", *args], cwd=repo, check=True, capture_output=True, text=True
+    )
+
+
+def a_repo(tmp: pathlib.Path) -> pathlib.Path:
+    """A minimal git worktree with one commit and one uncommitted change."""
+    repo = tmp / "repo"
+    repo.mkdir()
+    git(repo, "init", "-q", "-b", "main")
+    git(repo, "config", "user.email", "test@example.invalid")
+    git(repo, "config", "user.name", "test")
+    (repo / "tracked.txt").write_text("one\n", encoding="utf-8")
+    git(repo, "add", "tracked.txt")
+    git(repo, "commit", "-q", "-m", "first")
+    # An unstaged modification: `git status --porcelain` puts a space in column
+    # one for these, and a parser that trims it truncates every path.
+    (repo / "tracked.txt").write_text("two\n", encoding="utf-8")
+    return repo
+
+
+def create(out, repo, *extra):
+    return subprocess.run(
+        [sys.executable, str(TOOL), "create", "--out", str(out), "--cwd", str(repo), *extra],
+        capture_output=True,
+        text=True,
+    )
+
+
+def verify(out):
+    return subprocess.run(
+        [sys.executable, str(TOOL), "verify", str(out)], capture_output=True, text=True
+    )
+
+
+def main() -> int:
+    if not TOOL.is_file():
+        print(f"missing tool: {TOOL}")
+        return 1
+
+    with tempfile.TemporaryDirectory() as td:
+        tmp = pathlib.Path(td)
+        repo = a_repo(tmp)
+
+        # --- portability: no transcript, no harness, still a checkpoint ------
+        print("a checkpoint without any provider artefact")
+        out = tmp / "ckpt-bare"
+        run = create(out, repo)
+        check("create succeeds with no transcript and no handoff", run.returncode == 0)
+        manifest_path = out / "manifest.json"
+        check("manifest.json is written", manifest_path.is_file())
+        if not manifest_path.is_file():
+            print(run.stderr)
+            return 1
+        m = json.loads(manifest_path.read_text(encoding="utf-8"))
+        check("schema is declared", m.get("schema") == "icn-session-checkpoint/v1")
+        check("verify passes on a bare checkpoint", verify(out).returncode == 0)
+
+        # --- the three truth classes stay apart ------------------------------
+        print("truth classes")
+        check("observed / captured / generated are separate blocks",
+              all(k in m for k in ("observed", "captured", "generated")))
+        check("each class explains what it is",
+              set(m.get("truth_classes", {})) == {"observed", "captured", "generated"})
+        check("live-state owners are named rather than duplicated",
+              m.get("authority", {}).get("live_state_owners")
+              == "ops/state/truth/sources.json")
+
+        # --- observed state is real, and column-correct ----------------------
+        print("observed git state")
+        g = m["observed"]["git"]
+        check("branch is captured", g.get("branch") == "main")
+        check("HEAD is a full sha", isinstance(g.get("head"), str) and len(g["head"]) == 40)
+        check("dirty is reported", g.get("dirty") is True)
+        check("the changed path is not truncated",
+              g.get("changed_files") == ["tracked.txt"])
+
+        # --- unresolvable facts are reported, not guessed --------------------
+        print("facts this repository cannot supply")
+        check("a missing PR is reported with a reason, not invented",
+              m["captured"]["pull_request"]["resolved"] is None
+              and bool(m["captured"]["pull_request"].get("reason")))
+        check("checks are unresolved when there is no PR",
+              m["captured"]["checks"]["resolved"] is None)
+        check("no narrative is invented", m["generated"]["notes"] == []
+              and m["generated"]["handoff"] is None)
+
+        # --- a supplied transcript is opaque evidence ------------------------
+        print("a checkpoint carrying a provider transcript")
+        transcript = tmp / "session.jsonl"
+        transcript.write_text('{"vendor":"whatever","n":1}\n', encoding="utf-8")
+        handoff = tmp / "handoff.md"
+        handoff.write_text("# Handoff\n\nWhat happened.\n", encoding="utf-8")
+
+        out2 = tmp / "ckpt-full"
+        run = create(
+            out2, repo,
+            "--transcript", str(transcript),
+            "--handoff", str(handoff),
+            "--provider", "some-harness",
+            "--ref", "icn#1",
+            "--note", "a note the tool did not write",
+        )
+        check("create succeeds with artefacts", run.returncode == 0)
+        m2 = json.loads((out2 / "manifest.json").read_text(encoding="utf-8"))
+
+        roles = {a["role"]: a for a in m2["artifacts"]}
+        check("both artefacts are recorded", set(roles) == {"handoff", "provider-transcript"})
+        check("the transcript is marked opaque",
+              roles.get("provider-transcript", {}).get("opaque") is True)
+        check("the transcript is COPIED, not referenced",
+              (out2 / roles["provider-transcript"]["path"]).is_file())
+        check("the copy is byte-identical",
+              (out2 / roles["provider-transcript"]["path"]).read_bytes()
+              == transcript.read_bytes())
+        check("the agent's note is carried through unchanged",
+              m2["generated"]["notes"] == ["a note the tool did not write"])
+        check("a supplied reference is recorded as unqueried",
+              m2["captured"]["references"][0]["ref"] == "icn#1")
+
+        # The whole point: delete the source and the checkpoint still stands.
+        transcript.unlink()
+        handoff.unlink()
+        check("verify passes after the originals are gone", verify(out2).returncode == 0)
+
+        # --- hashes are load-bearing ----------------------------------------
+        print("integrity")
+        tampered = out2 / roles["handoff"]["path"]
+        tampered.write_text("# Handoff\n\nSomething else entirely.\n", encoding="utf-8")
+        result = verify(out2)
+        check("verify FAILS on a tampered artefact", result.returncode != 0)
+        check("verify names the tampered file",
+              "handoff.md" in (result.stdout + result.stderr))
+
+        # --- an unknown schema is refused, not half-understood ---------------
+        print("schema discipline")
+        out3 = tmp / "ckpt-future"
+        out3.mkdir()
+        future = dict(m)
+        future["schema"] = "icn-session-checkpoint/v99"
+        (out3 / "manifest.json").write_text(json.dumps(future), encoding="utf-8")
+        check("verify refuses a schema it does not implement",
+              verify(out3).returncode != 0)
+
+        # --- the tool is discoverable as a capability ------------------------
+        print("capability registration")
+        header = TOOL.read_text(encoding="utf-8").split("\n", 40)[:6]
+        check("declares a #: capability: header for the generated index",
+              any(line.startswith("#: capability:") for line in header))
+        check("is executable, or the capability generator skips it",
+              TOOL.stat().st_mode & 0o111 != 0)
+
+    print()
+    if failures:
+        print(f"icn-session-checkpoint tests: {len(failures)} failure(s)")
+        for f in failures:
+            print(f"  - {f}")
+        return 1
+    print("icn-session-checkpoint tests: clean")
+    return 0
+
+
+if __name__ == "__main__":
+    if shutil.which("git") is None:
+        print("git unavailable; skipping")
+        sys.exit(0)
+    sys.exit(main())

--- a/scripts/tests/test_session_checkpoint.py
+++ b/scripts/tests/test_session_checkpoint.py
@@ -298,6 +298,53 @@ def main() -> int:
             check(f"verify fails cleanly when {label}",
                   result.returncode != 0 and "Traceback" not in result.stderr)
 
+        print("a reused output directory cannot smuggle stale artefacts")
+        reuse = tmp / "ckpt-reuse"
+        t2 = tmp / "second.jsonl"
+        t2.write_text('{"n":2}\n', encoding="utf-8")
+        h2 = tmp / "second.md"
+        h2.write_text("# second\n", encoding="utf-8")
+        run = create(reuse, repo, "--transcript", str(t2), "--handoff", str(h2))
+        check("first create into a fresh directory succeeds", run.returncode == 0)
+        first_files = {str(f.relative_to(reuse)) for f in reuse.rglob("*") if f.is_file()}
+        check("the first checkpoint has its artefacts", len(first_files) == 3)
+
+        run = create(reuse, repo)
+        check("a bare re-create into a non-empty directory is refused without --replace",
+              run.returncode != 0)
+        check("the refusal explains why", "not empty" in (run.stdout + run.stderr))
+
+        run = create(reuse, repo, "--replace")
+        check("--replace succeeds", run.returncode == 0)
+        mre = json.loads((reuse / "manifest.json").read_text(encoding="utf-8"))
+        check("the replacing manifest declares no artefacts", mre["artifacts"] == [])
+        left = {str(f.relative_to(reuse)) for f in reuse.rglob("*") if f.is_file()}
+        check("no stale artefact survived the replacement", left == {"manifest.json"})
+        check("verify passes on the replaced checkpoint", verify(reuse).returncode == 0)
+
+        print("verify catches undeclared and index-stripped manifests")
+        # Undeclared file planted beside a valid manifest.
+        planted = out2 / "artifacts" / "handoff" / "extra.md"
+        planted.parent.mkdir(parents=True, exist_ok=True)
+        planted.write_text("not in the manifest\n", encoding="utf-8")
+        result = verify(out2)
+        check("verify FAILS on an undeclared artefact", result.returncode != 0)
+        check("verify names the undeclared file", "extra.md" in (result.stdout + result.stderr))
+        planted.unlink()
+
+        for label, mutate in (
+            ("the artifacts index is removed", lambda d: d.pop("artifacts", None)),
+            ("the artifacts index is null", lambda d: d.update(artifacts=None)),
+        ):
+            out_ix = tmp / f"ckpt-ix-{abs(hash(label))}"
+            out_ix.mkdir()
+            (out_ix / "artifacts").mkdir()
+            (out_ix / "artifacts" / "orphan.bin").write_text("x", encoding="utf-8")
+            stripped = dict(m)
+            mutate(stripped)
+            (out_ix / "manifest.json").write_text(json.dumps(stripped), encoding="utf-8")
+            check(f"verify FAILS when {label}", verify(out_ix).returncode != 0)
+
         # --- an unknown schema is refused, not half-understood ---------------
         print("schema discipline")
         out3 = tmp / "ckpt-future"


### PR DESCRIPTION
## Delivery

- **Delivery lane**: STANDARD
- **Acceptance contract**: a development session's durable state has a representation ICN can read and verify without the harness that produced it.
- **Explicit non-goals**: not an agent orchestrator, not a model router, not a UI, no MCP change, no replacement for Claude Code or Codex, and no claim that ICN is harness-independent.

<!-- ICN-DELIVERY-LIFECYCLE:BEGIN -->
```
ICN DELIVERY LIFECYCLE
State:                REVIEWING
Lane:                 STANDARD
Acceptance contract:  A portable session checkpoint that works with no provider transcript and verifies after being copied.
Review generation:    1 of 1 (STANDARD) — OPEN, requested 2026-09-02; awaiting human reviewer
Freeze head:          - (not frozen; head under review is 0b2b630de4dc)
Known blockers:       0
Follow-up ledger:     -
```
<!-- ICN-DELIVERY-LIFECYCLE:END -->

## Summary

A session finished successfully and its harness's own export malfunctioned. Recovery meant locating that vendor's private transcript file by hand and rebuilding a handoff separately. Nothing was lost, but the incident named a real property of the current arrangement: **a session's reconstructable state existed only inside one vendor's tooling**, in a format that vendor owns, reachable only through a command that vendor implements.

That is a portability failure rather than a harness defect. It would look the same in any other agent product.

`ops/scripts/icn-session-checkpoint` is the smallest correction:

```
icn-session-checkpoint create --out DIR [--handoff F] [--transcript F]
                              [--provider NAME] [--ref R]... [--note TEXT]...
icn-session-checkpoint verify DIR
```

It writes `manifest.json` plus a hashed `artifacts/` directory. It is a helper capability like any other — a `#: capability:` header, discovered by the generator described in AGENT_RUNTIME §7 — so no launcher, provider adapter or prompt is edited to make it reachable.

## The design decisions worth reviewing

**The manifest keeps three kinds of fact apart**, because a consumer that cannot tell a re-derivable fact from a stale one will act on the stale one:

| Block | Holds | Treat as |
|---|---|---|
| `observed` | repo, worktree, branch, HEAD, base, ahead/behind, dirty state, changed files, recent commits — derived here from Git | re-derivable |
| `captured` | the branch's PR and its check buckets, as GitHub reported them at `created_at` | historical; requery before acting |
| `generated` | handoff and notes supplied by a person or agent | not derived, not verified |

This is the §2.5 field classification applied to a different artefact, for the same reason: the runtime stores the **reference**, never the state.

**A provider transcript is optional, copied, and never parsed.** The format is complete without one, which is what lets a Codex or local-model adapter attach its own stream on identical terms. Artifacts are copied rather than referenced, because a checkpoint pointing into a harness's private directory would reproduce exactly the dependency this removes.

**It invents nothing.** No PR for the branch, several PRs for one branch, `gh` absent — each records `resolved: null` with the reason. Narrative is carried through from `--handoff`/`--note`, never synthesised.

**Content hashes only, no signing.** ICN has signing primitives, and reaching for them here would produce ceremony rather than a guarantee: the signer would be an agent process with no standing to attest anything. `verify` re-hashes every artifact and **fails** on mismatch or unknown schema.

## What changed

- `ops/scripts/icn-session-checkpoint` — new, executable, `#: capability:` header.
- `scripts/tests/test_session_checkpoint.py` — 27 controls; runs the exporter against throwaway git repositories and reads only the files it wrote.
- `.github/workflows/agent-drift-check.yml` — runs those controls, and watches the test path.
- `docs/architecture/AGENT_RUNTIME.md` §10 — the mechanism, the harness-sovereignty principle, and what was deliberately not built.
- `docs/reference/project-index/generated/agent-capabilities.json` — regenerated (4 helpers, was 3).

## What did not change

- No MCP tool, no `ops/mcp/src/**` change, no session-registry schema change, so no conflict with the frozen agent-runtime surfaces in #2690 / #2692.
- Vendor-specific adapters stay vendor-specific. Nothing under `.claude/` becomes canonical.
- No claim that ICN is harness-independent. §10.2 states the principle as a **direction**, and §7 already records how narrow the non-Claude surface actually is.

## Related

- Issues: Refs #2689
- Specs: `docs/architecture/AGENT_RUNTIME.md` §7 (capability discovery), §2.5 (field classification), `.agents/skills/handoff`
- Independent of #2701 and #2700 — based on `main`, disjoint files.

## Risk

Low blast radius: one new executable, one new test, one workflow step, one appended doc section, one regenerated manifest. Nothing existing calls it. The main review question is not safety but **whether the format's three truth classes are the right ones**, because that is the part future adapters will be built against.

## Documentation control
- [x] `docs/architecture/AGENT_RUNTIME.md` is an existing doc; no new doc added, no registry row needed
- [x] Ran `python3 docs/scripts/doc_control_check.py --repo . --registry docs/registry.toml` — passes
- [x] No control-plane canonical path changed

## Type of change
- [x] New feature (tooling)

## Verification

```
python3 scripts/tests/test_session_checkpoint.py           27 controls, clean
python3 scripts/check-agent-capabilities.py                manifest is true
python3 scripts/check-truth-spine.py                       clean
python3 docs/scripts/doc_control_check.py                  OK
bash ops/scripts/drift-check.sh                            PASS
```

Dogfooded: this session's own checkpoint was produced with the tool and re-verified after the source files were removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


