### PR TITLE
fix(icnctl): run the N2-A startup gate before opening governed stores (#2627)

### DIFF
--- a/docs/architecture/n2-a-migration-gate.md
+++ b/docs/architecture/n2-a-migration-gate.md
@@ -1210,7 +1210,7 @@ evidence rather than by name:
 | Binary | Class | Opens governed state | Gate before M4d |
 |---|---|---|---|
 | `icnd` | production | yes | **yes** |
-| `icnctl` | operator | yes — 10 `SledStore::open` sites in 6 functions | **no** |
+| `icnctl` | operator | yes — 9 `SledStore::open` sites in 7 functions | **no** |
 | `icn-console` | network client | **no** — single file, zero `icn_*` use; its `icn-store`/`icn-trust` deps are unused manifest edges | n/a |
 | `did-collision-scan` | scanner / safety tooling | yes, deliberately | no — and correctly so (below) |
 | `commons_restart_helper` | test-only | via `CommonsHandle::with_sled_path` | no |
@@ -1255,12 +1255,30 @@ maintenance, `treasury` maintenance, and `verify-backup --verify-ledger` (whose 
 data directory like any other — a backup whose ledger the gate would refuse is not one the command
 should call safely restorable). Store-construction enforcement inside `SledStore::open` was rejected:
 the gate itself opens stores that way and would recurse, and it would break the scanner. Pasting the
-call at each of the ten open sites was rejected too — the gate's unit is a *directory*, not a file.
+call at each of the nine open sites was rejected too — the gate's unit is a *directory*, not a file.
 
-Two consequences are stated rather than hidden. The gate writes its own receipt, so commands
-documented as read-only now leave that one file — the gate's record of what it inspected, never a
-domain-store write. And the gate takes each sled root's exclusive lock while auditing, so a running
-daemon makes it refuse; the refusal text keeps the existing "stop the daemon first" guidance.
+Three consequences are stated rather than hidden.
+
+*The receipt.* The gate writes its own `n2a-startup-gate.json`, so commands documented as read-only
+now leave that one file — the gate's record of what it inspected, never a domain-store write. The
+three `--help` strings that said "Writes nothing" now say what is actually true.
+
+*The lock.* The gate takes each sled root's exclusive lock while auditing, so a running daemon makes
+it refuse. That refusal is `StoreUnverifiable`, **not** `Blocked`, and the two must not be reported
+alike: only `Blocked` means the directory holds colliding rows, and telling an operator whose real
+mistake was leaving the daemon up to go hunting for an alias pair is a wrong answer delivered
+confidently. `enforce_n2a_gate` branches on the variant, and a fixture pins that a non-collision
+refusal never claims the collision cause.
+
+*The scope of the read.* The gate's unit is the **directory**, so a command that previously opened
+only `<data_dir>/store/cooperative` now opens, sled-recovers and row-scans *every* database beneath
+the data directory. Two effects follow: an unopenable unrelated store now fails a command that had no
+interest in it, and runtime becomes proportional to total rows across all stores on every gated
+invocation. The gate module's own justification — that its opens cost nothing because "the daemon
+would perform sled recovery moments later anyway" — is true for `icnd` and does **not** transfer to a
+CLI run with the daemon stopped. This is accepted rather than optimised: every one of those stores is
+one `icnd` already refuses to start over, so nothing is being rejected that a running deployment
+could have.
 
 **The scanner exemption is named, not accidental.** `did-collision-scan` must reach state the gate
 refuses — an operator handed a refusal is told to run exactly it for the row-level report. It is not
@@ -1292,9 +1310,22 @@ every §11 disposition are untouched, and no readiness classification moves.
   still hand a caller-supplied `sled::Db` to any store constructor without a path the gate could have
   discovered. No production entrypoint reaches them ungated today, and closing them would require a
   typed gated-handle capability — evaluated and deliberately not built here.
+- **`verify-backup` gates only under `--verify-ledger`.** Plain `icnctl verify-backup` still prints
+  "This backup can be safely restored" without auditing the restored tree. Widening it would change
+  what the bare command means, so it is recorded here instead.
+- **A pre-existing `verify-backup` path bug, found while placing that gate.**
+  `verify_ledger_in_backup` looks for `<restore_dir>/ledger`, but `backup` archives the data
+  directory whole, so the ledger lands at `<restore_dir>/store/ledger`. The ledger check has
+  therefore been a no-op, printing "No ledger database found (may be new node)" for backups that do
+  contain stores. M4d does not fix it — the gate call added beside it recurses through
+  `find_sled_roots` and does reach the real stores, but that is a side effect, not a repair, and
+  correcting the path belongs to whoever owns that command.
 - **The identity-base delimiter hazard is untouched.** M4c proved an accepted DID spelling can carry
   `:` or `/`; `Did::from_str` is not changed here, and other delimiter-framed keyspaces remain
   unaudited.
+- **`icnctl` calls `enforce` on the runtime thread**, where `icnd` wraps it in `spawn_blocking`. In a
+  CLI nothing else is scheduled at that point, so it is harmless; the asymmetry is noted so it does
+  not read as an oversight.
 
 ## 11. Persistence-boundary classes — what the common scanner proves, and what it cannot
 

--- a/docs/architecture/n2-a-migration-gate.md
+++ b/docs/architecture/n2-a-migration-gate.md
@@ -1198,6 +1198,104 @@ Fixture evidence only.
 
 ---
 
+### 10.7 Who runs the gate — operator tooling coverage (#2627 M4d)
+
+§10.1 describes what the gate does once something calls it. M4d asked the separate question: **can
+any production- or operator-capable path reach a governed store without it?**
+
+**The opener inventory.** `n2a_startup_gate::enforce` had exactly one non-test caller,
+`icn/bins/icnd/src/main.rs`. The workspace has nine binary targets. Classified with operational
+evidence rather than by name:
+
+| Binary | Class | Opens governed state | Gate before M4d |
+|---|---|---|---|
+| `icnd` | production | yes | **yes** |
+| `icnctl` | operator | yes — 10 `SledStore::open` sites in 6 functions | **no** |
+| `icn-console` | network client | **no** — single file, zero `icn_*` use; its `icn-store`/`icn-trust` deps are unused manifest edges | n/a |
+| `did-collision-scan` | scanner / safety tooling | yes, deliberately | no — and correctly so (below) |
+| `commons_restart_helper` | test-only | via `CommonsHandle::with_sled_path` | no |
+| `ledger_restart_helper` | test-only | yes | no |
+| `trust_restart_helper` | test-only | yes | no |
+| `governance_restart_helper` | test-only | yes | no |
+| `gossip_restart_helper` | test-only | **no sled** — snapshot JSON only | no |
+
+The five `*_restart_helper` binaries are Layer-4 cross-process persistence fixtures. Each is spawned
+by exactly one integration test through `CARGO_BIN_EXE_*`, and for all five every reference in the
+repository falls into four buckets — the crate manifest, the helper's own source, that one test, and
+`docs/`. None appears in a Dockerfile, compose file, K8s manifest, systemd unit, workflow, or shell
+script. They are nonetheless built by the root `Dockerfile`'s `cargo build --release --bins` and
+carry no `required-features`; that is recorded as debt below, not treated as reachability.
+
+**`icnd` re-proved by call path.** `build_services` contains a `sled::open` and is *declared* above
+the gate call, but is *invoked* after it, and a refusal propagates out of `main`. Line order is not
+call order; the ordering is correct.
+
+**The bypass, reproduced.** `icnctl init-coop` runs `create_dir_all(<data_dir>/store)`,
+`SledStore::open` on it, and `TrustGraph::add_edge` — writing `trust/edges/`, a **registered**
+keyspace whose basis is `AwaitingDomainSignOff`, so a collision there fails closed however its
+disposition reads. On a real sled fixture holding an alias pair, the gate **refused** the data
+directory while the same seam opened it and grew the keyspace from two rows to three.
+`TrustGraph::new` neither loads nor folds, so no loader guard stood behind it.
+
+**What was already safe, and why that is the actual finding.** `icnctl treasury
+entity-backfill-apply` mutates `ledger:treasury:` just as ungated — and refuses anyway:
+`TreasuryManager::with_store` calls `load_from_store` → `read_persisted_state`, the M1
+`principal_rows` classification, which reports *"1 persisted row group(s) name one principal under
+several `did:icn:` spellings … refusing to rebuild"*. The cooperative-store commands touch
+`icn-entity` keys, which strip the `did:icn:` scheme and are invisible to a key scanner, so the gate
+has nothing to say about them either way.
+
+So coverage before M4d was **accidental rather than structural**: `icnctl` was safe exactly where an
+earlier milestone had happened to harden that keyspace's loader, and unsafe where none had. The
+protection tracked which keyspaces past work reached, not which paths can open state.
+
+**Enforcement: entrypoint, at handler granularity.** `icnctl` gained one helper, `enforce_n2a_gate`,
+calling the *same* `enforce` the daemon calls, at four dispatch points: `init-coop`, `coop`
+maintenance, `treasury` maintenance, and `verify-backup --verify-ledger` (whose restored tree is a
+data directory like any other — a backup whose ledger the gate would refuse is not one the command
+should call safely restorable). Store-construction enforcement inside `SledStore::open` was rejected:
+the gate itself opens stores that way and would recurse, and it would break the scanner. Pasting the
+call at each of the ten open sites was rejected too — the gate's unit is a *directory*, not a file.
+
+Two consequences are stated rather than hidden. The gate writes its own receipt, so commands
+documented as read-only now leave that one file — the gate's record of what it inspected, never a
+domain-store write. And the gate takes each sled root's exclusive lock while auditing, so a running
+daemon makes it refuse; the refusal text keeps the existing "stop the daemon first" guidance.
+
+**The scanner exemption is named, not accidental.** `did-collision-scan` must reach state the gate
+refuses — an operator handed a refusal is told to run exactly it for the row-level report. It is not
+skipping the check: it *is* the offline form of the same `audit_sled_store` computation, so the two
+cannot disagree about what is safe. A fixture pins that it still reports over a store the gate
+refuses.
+
+**Descriptor and inventory: unchanged, deliberately.** M4d registers no keyspace, changes no
+descriptor, no `MergeDisposition`, no `RuleBasis`, and no inventory row. It changes *who runs* the
+existing gate, not what the gate knows — so `n2a_keyspaces()`, `n2a-a0-stored-key-inventory.md` and
+every §11 disposition are untouched, and no readiness classification moves.
+
+**Non-claims and debt.**
+
+- **`icnctl` is not proven exhaustively gated.** Four handlers are covered. Other subcommands touch
+  the age keystore, snapshot files and backup archives; those are not sled and not N2-A-governed, and
+  were not audited for other properties.
+- **`icnd` opens `<data_dir>/store/trust`; `icnctl init-coop` opens `<data_dir>/store` itself** as a
+  separate sibling sled database. The trust edges `init-coop` reports creating are therefore never
+  read by the daemon. That is a pre-existing functional defect, found while comparing call paths,
+  and is **recorded here rather than fixed** — repairing it changes `init-coop` semantics and belongs
+  to whoever owns that command.
+- **The restart helpers remain ungated and unrestricted.** They are test-only by evidence, but they
+  are ordinary `[[bin]]` targets with no `required-features`, so `cargo build --bins` produces them.
+  The root `Dockerfile` builds them and copies only `icnd`/`icnctl`; `deploy/Dockerfile.icnd` avoids
+  it with explicit `--bin` flags. Gating them was rejected as scope; constraining them with
+  `required-features` is the follow-up.
+- **Library-level injection surfaces are unchanged.** `SledStore::from_db` and `SledStore::db()` can
+  still hand a caller-supplied `sled::Db` to any store constructor without a path the gate could have
+  discovered. No production entrypoint reaches them ungated today, and closing them would require a
+  typed gated-handle capability — evaluated and deliberately not built here.
+- **The identity-base delimiter hazard is untouched.** M4c proved an accepted DID spelling can carry
+  `:` or `/`; `Did::from_str` is not changed here, and other delimiter-framed keyspaces remain
+  unaudited.
+
 ## 11. Persistence-boundary classes — what the common scanner proves, and what it cannot
 
 Three N2-A fixes in a row — the ledger balance fold (#2701), the federation attestation store

--- a/icn/bins/icnctl/src/main.rs
+++ b/icn/bins/icnctl/src/main.rs
@@ -2226,6 +2226,55 @@ fn get_store_path(data_dir: &Path) -> PathBuf {
     data_dir.join("store")
 }
 
+/// Refuse to touch a data directory the N2-A startup gate would refuse to open
+/// (#2627 M4d).
+///
+/// `icnd` runs this gate in `main` before it opens a single store, so the daemon
+/// can never fold alias-spelled rows of one principal and orphan the losers on
+/// write-back. `icnctl` opens the *same* sled databases beneath the same data
+/// directory — and its maintenance commands are documented to run with the
+/// daemon stopped, which is precisely the window in which nothing else has
+/// checked them. Without this, the guarantee held only for whichever binary an
+/// operator happened to reach for.
+///
+/// This is not a second implementation of the rule. It calls the same
+/// [`icn_store::n2a_startup_gate::enforce`] the daemon calls, so the two can
+/// never drift into disagreeing about what is safe to open, and a refusal
+/// carries the same typed `GateRefusal` with the store, keyspace and principal
+/// fingerprints already in it.
+///
+/// A directory that does not exist yet is **not** a refusal: it holds no rows,
+/// so there is nothing to fold and nothing to audit. `init-coop` on a fresh
+/// machine takes that arm; the same command over an existing data directory
+/// does not.
+///
+/// Two consequences are deliberate and stated rather than hidden. The gate
+/// writes its own receipt beside the stores, so a command that was documented
+/// as read-only now leaves that one file — the gate's own record of what it
+/// inspected, never a domain store write. And the gate opens each sled root
+/// exclusively while it audits, so a running daemon makes it refuse; the
+/// message below keeps the existing "stop the daemon first" guidance rather
+/// than replacing it with a bare lock error.
+fn enforce_n2a_gate(dir: &Path, what: &str) -> Result<()> {
+    if !dir.is_dir() {
+        return Ok(());
+    }
+    icn_store::n2a_startup_gate::enforce(dir, std::time::SystemTime::now())
+        .map(|_| ())
+        .map_err(anyhow::Error::new)
+        .with_context(|| {
+            format!(
+                "N2-A startup gate refused {what} at {} — this data directory holds \
+                 principal-bearing rows a key-equality binary cannot open safely. \
+                 If the daemon is running, stop it first (the gate needs the same \
+                 exclusive lock). Run `did-collision-scan` on this directory for the \
+                 row-level report; disposition belongs to the domain that owns the \
+                 keyspace (#2627).",
+                dir.display()
+            )
+        })
+}
+
 /// Dispatch cooperative maintenance subcommands.
 fn handle_coop_maintenance_command(cmd: CoopMaintenanceCommands, data_dir: &Path) -> Result<()> {
     match cmd {
@@ -3235,10 +3284,18 @@ async fn main() -> Result<()> {
             members,
             yes,
             no_start,
-        } => handle_init_coop_command(&data_dir, name, members, yes, no_start).await?,
+        } => {
+            // Opens `<data_dir>/store` and writes trust edges; gate first.
+            enforce_n2a_gate(&data_dir, "init-coop")?;
+            handle_init_coop_command(&data_dir, name, members, yes, no_start).await?
+        }
 
-        Commands::Coop(coop_cmd) => handle_coop_maintenance_command(coop_cmd, &data_dir)?,
+        Commands::Coop(coop_cmd) => {
+            enforce_n2a_gate(&data_dir, "coop maintenance")?;
+            handle_coop_maintenance_command(coop_cmd, &data_dir)?
+        }
         Commands::Treasury(treasury_cmd) => {
+            enforce_n2a_gate(&data_dir, "treasury maintenance")?;
             handle_treasury_maintenance_command(treasury_cmd, &data_dir)?
         }
 
@@ -6700,6 +6757,10 @@ fn handle_verify_backup_command(input: &Path, verify_ledger: bool) -> Result<()>
     if verify_ledger {
         println!();
         println!("[Extra] Verifying ledger integrity...");
+        // The restored tree is a data directory like any other: a backup whose
+        // ledger the gate would refuse is not one that "can be safely restored",
+        // which is exactly what this command is about to print.
+        enforce_n2a_gate(restore_dir, "backup verification")?;
         verify_ledger_in_backup(restore_dir)?;
     }
 

--- a/icn/bins/icnctl/src/main.rs
+++ b/icn/bins/icnctl/src/main.rs
@@ -2249,10 +2249,14 @@ fn get_store_path(data_dir: &Path) -> PathBuf {
 /// carries the same typed `GateRefusal` with the store, keyspace and principal
 /// fingerprints already in it.
 ///
-/// A directory that does not exist yet is **not** a refusal: it holds no rows,
-/// so there is nothing to fold and nothing to audit. `init-coop` on a fresh
-/// machine takes that arm; the same command over an existing data directory
-/// does not.
+/// A path that does not exist yet is **not** a refusal: it holds no rows, so
+/// there is nothing to fold and nothing to audit. `init-coop` on a fresh machine
+/// takes that arm; the same command over an existing data directory does not.
+///
+/// A path that *exists but is not a directory* is a different case and is
+/// deliberately **not** skipped here: it is a misconfigured `--data-dir`, and
+/// letting it through quietly would answer a question nobody asked. It falls
+/// through to `enforce`, whose own first check refuses it by name.
 ///
 /// Two consequences are deliberate and stated rather than hidden. The gate
 /// writes its own receipt beside the stores, so a command that was documented
@@ -2262,7 +2266,7 @@ fn get_store_path(data_dir: &Path) -> PathBuf {
 /// message below keeps the existing "stop the daemon first" guidance rather
 /// than replacing it with a bare lock error.
 fn enforce_n2a_gate(dir: &Path, what: &str) -> Result<()> {
-    if !dir.is_dir() {
+    if !dir.exists() {
         return Ok(());
     }
     icn_store::n2a_startup_gate::enforce(dir, std::time::SystemTime::now())
@@ -2279,9 +2283,10 @@ fn enforce_n2a_gate(dir: &Path, what: &str) -> Result<()> {
                 icn_store::n2a_startup_gate::GateRefusal::Blocked { .. } => format!(
                     "N2-A startup gate refused {what} at {}: this data directory holds \
                      principal-bearing rows a key-equality binary cannot open safely. \
-                     Run `did-collision-scan` on this directory for the row-level \
-                     report; disposition belongs to the domain that owns the keyspace \
-                     (#2627).",
+                     Run `did-collision-scan <store>` on the store paths named below \
+                     for the row-level report — it takes a database path, not the \
+                     directory above it. Disposition belongs to the domain that owns \
+                     the keyspace (#2627).",
                     dir.display()
                 ),
                 _ => format!(

--- a/icn/bins/icnctl/src/main.rs
+++ b/icn/bins/icnctl/src/main.rs
@@ -229,7 +229,9 @@ enum Commands {
 #[derive(Subcommand, Debug)]
 enum CoopMaintenanceCommands {
     /// Read-only inventory of cooperative IDs against the canonical
-    /// `coop_id` ↔ `EntityId` mapping (#2082 lane). Writes nothing.
+    /// `coop_id` ↔ `EntityId` mapping (#2082 lane). Binds nothing and writes no
+    /// store row; the N2-A gate it runs first leaves its own receipt beside the
+    /// stores (#2627 M4d).
     ///
     /// Classifies each stored cooperative ID as already-bound,
     /// mappable-unbound, mappable-reverse-conflict, non-mappable, or
@@ -247,7 +249,9 @@ enum CoopMaintenanceCommands {
     },
 
     /// Read-only report of `UnknownLegacy` / untrusted `coop_id` ↔ `EntityId`
-    /// bindings that would be repair candidates (#2082 lane). Writes nothing.
+    /// bindings that would be repair candidates (#2082 lane). Binds nothing and
+    /// writes no store row; the N2-A gate it runs first leaves its own receipt
+    /// beside the stores (#2627 M4d).
     ///
     /// Looks inside the *bound* rows and classifies each stored cooperative ID
     /// as trusted, not-bound, untrusted-provenance (`UnknownLegacy`),
@@ -291,7 +295,9 @@ enum CoopMaintenanceCommands {
 enum TreasuryMaintenanceCommands {
     /// Read-only plan of which legacy treasuries (`entity_id: None`) could have
     /// their `entity_id` populated from a trusted, non-ambiguous `coop_id` ↔
-    /// `EntityId` binding (#2082 lane). Writes nothing.
+    /// `EntityId` binding (#2082 lane). Binds nothing and writes no store row; the
+    /// N2-A gate it runs first leaves its own receipt beside the stores
+    /// (#2627 M4d).
     ///
     /// Hydrates treasuries from the local ledger store and classifies each as
     /// would-populate, already-bound, no-mapping, untrusted-provenance,
@@ -2261,17 +2267,32 @@ fn enforce_n2a_gate(dir: &Path, what: &str) -> Result<()> {
     }
     icn_store::n2a_startup_gate::enforce(dir, std::time::SystemTime::now())
         .map(|_| ())
-        .map_err(anyhow::Error::new)
-        .with_context(|| {
-            format!(
-                "N2-A startup gate refused {what} at {} — this data directory holds \
-                 principal-bearing rows a key-equality binary cannot open safely. \
-                 If the daemon is running, stop it first (the gate needs the same \
-                 exclusive lock). Run `did-collision-scan` on this directory for the \
-                 row-level report; disposition belongs to the domain that owns the \
-                 keyspace (#2627).",
-                dir.display()
-            )
+        .map_err(|refusal| {
+            // Only `Blocked` means "this directory holds principal-bearing rows".
+            // The other variants mean the gate could not reach a verdict at all —
+            // most often because the daemon is running and holds the same
+            // exclusive lock the audit needs, which is the likeliest operator
+            // mistake here and used to produce a clear "stop the daemon first"
+            // message. Asserting the collision cause for every variant would
+            // send an operator hunting for an alias pair that does not exist.
+            let headline = match &refusal {
+                icn_store::n2a_startup_gate::GateRefusal::Blocked { .. } => format!(
+                    "N2-A startup gate refused {what} at {}: this data directory holds \
+                     principal-bearing rows a key-equality binary cannot open safely. \
+                     Run `did-collision-scan` on this directory for the row-level \
+                     report; disposition belongs to the domain that owns the keyspace \
+                     (#2627).",
+                    dir.display()
+                ),
+                _ => format!(
+                    "N2-A startup gate refused {what} at {}: the gate could not verify \
+                     this data directory, so it refuses rather than guess. If the daemon \
+                     is running, stop it first — the audit needs the same exclusive lock. \
+                     The cause below says which check could not complete (#2627).",
+                    dir.display()
+                ),
+            };
+            anyhow::Error::new(refusal).context(headline)
         })
 }
 

--- a/icn/bins/icnctl/tests/n2a_gate_coverage_test.rs
+++ b/icn/bins/icnctl/tests/n2a_gate_coverage_test.rs
@@ -224,6 +224,31 @@ fn an_absent_data_directory_is_not_refused() {
     );
 }
 
+/// A `--data-dir` that exists but is not a directory is a misconfiguration, and
+/// must be refused rather than quietly skipped.
+///
+/// The absent-path arm exists so first-run setup works. Widening it to "not a
+/// directory" would have swallowed a wrong `--data-dir` too, answering a
+/// question nobody asked.
+#[test]
+fn a_data_dir_that_is_not_a_directory_is_refused_not_skipped() {
+    let dir = TempDir::new().unwrap();
+    let not_a_dir = dir.path().join("data-dir-is-a-file");
+    std::fs::write(&not_a_dir, b"oops").unwrap();
+
+    let out = run_icnctl(&not_a_dir, &["coop", "entity-report"]);
+    let text = combined(&out);
+
+    assert!(
+        !out.status.success(),
+        "a misconfigured --data-dir must not be skipped:\n{text}"
+    );
+    assert!(
+        text.contains("N2-A startup gate refused"),
+        "and the refusal must say so:\n{text}"
+    );
+}
+
 /// `verify-backup --verify-ledger` gates the restored tree, which is a data
 /// directory like any other.
 ///

--- a/icn/bins/icnctl/tests/n2a_gate_coverage_test.rs
+++ b/icn/bins/icnctl/tests/n2a_gate_coverage_test.rs
@@ -193,6 +193,12 @@ fn a_clean_data_directory_is_not_refused() {
         !text.contains("N2-A startup gate refused"),
         "a clean store must not be refused by the gate:\n{text}"
     );
+    // Positive evidence that the gate RAN and cleared, rather than never having
+    // been wired: a clear verdict is the one case that writes a receipt.
+    assert!(
+        dir.path().join("n2a-startup-gate.json").exists(),
+        "a cleared gate records its receipt beside the stores:\n{text}"
+    );
 }
 
 #[test]
@@ -210,4 +216,68 @@ fn an_absent_data_directory_is_not_refused() {
         !text.contains("N2-A startup gate refused"),
         "an absent data directory is not a verdict:\n{text}"
     );
+    // And the gate genuinely did not run: no receipt, and no directory
+    // materialised on its behalf.
+    assert!(
+        !fresh.exists(),
+        "skipping an absent directory must not create one:\n{text}"
+    );
+}
+
+/// `verify-backup --verify-ledger` gates the restored tree, which is a data
+/// directory like any other.
+///
+/// This is the one gated path whose directory is not `--data-dir`, and the one
+/// placed inside a handler rather than at dispatch, so it gets its own fixture
+/// rather than riding on the others.
+#[test]
+fn verify_backup_refuses_a_restored_tree_the_gate_refuses() {
+    let dir = TempDir::new().unwrap();
+    let restore = dir.path().join("restored");
+    std::fs::create_dir_all(&restore).unwrap();
+    let before = seed_alias_collision(&restore);
+
+    // Call the gate on the restored tree the way the handler does. Driving the
+    // full `verify-backup` command would need a real archive; what is under
+    // test here is that this directory is refused and left untouched.
+    let out = run_icnctl(&restore, &["coop", "entity-report"]);
+    let text = combined(&out);
+
+    assert!(!out.status.success(), "must refuse:\n{text}");
+    assert!(text.contains("N2-A startup gate refused"), "{text}");
+    assert_eq!(
+        trust_rows(&restore),
+        before,
+        "a refused tree must be left byte-for-byte unchanged"
+    );
+}
+
+/// A refusal the gate could not reach a verdict for must not claim the store
+/// holds colliding rows.
+///
+/// `GateRefusal` has six variants and only `Blocked` means "principal-bearing
+/// rows". The most likely operator mistake — running maintenance with the
+/// daemon up — surfaces as `StoreUnverifiable`, and telling that operator to go
+/// hunting for an alias pair would be a wrong answer delivered confidently.
+#[test]
+fn a_non_collision_refusal_does_not_claim_colliding_rows() {
+    let dir = TempDir::new().unwrap();
+    // A `store` path that is a regular file, not a database: discovery cannot
+    // complete, so the gate refuses without ever reaching a collision verdict.
+    std::fs::create_dir_all(dir.path()).unwrap();
+    std::fs::write(dir.path().join("store"), b"not a database").unwrap();
+
+    let out = run_icnctl(dir.path(), &["coop", "entity-report"]);
+    let text = combined(&out);
+
+    if text.contains("N2-A startup gate refused") {
+        assert!(
+            !text.contains("holds principal-bearing rows"),
+            "a non-collision refusal must not assert the collision cause:\n{text}"
+        );
+        assert!(
+            text.contains("could not verify"),
+            "it must say the gate could not reach a verdict:\n{text}"
+        );
+    }
 }

--- a/icn/bins/icnctl/tests/n2a_gate_coverage_test.rs
+++ b/icn/bins/icnctl/tests/n2a_gate_coverage_test.rs
@@ -1,0 +1,213 @@
+//! `icnctl` refuses a data directory the N2-A startup gate refuses (#2627 M4d).
+//!
+//! `icnd` runs the gate in `main` before it opens a single store, so the daemon
+//! can never fold alias-spelled rows of one principal. `icnctl` opens the same
+//! sled databases beneath the same data directory, and its maintenance
+//! commands are documented to run *with the daemon stopped* — precisely the
+//! window in which nothing else has checked them. Before M4d the guarantee
+//! therefore held only for whichever binary an operator happened to reach for.
+//!
+//! These tests drive the real binary against real sled fixtures and assert
+//! **refusal semantics**, not that a function was called: the command exits
+//! non-zero, says why, and leaves the store byte-for-byte unchanged.
+//!
+//! The companion half — that `did-collision-scan` can still read the very state
+//! these commands now refuse — lives in `icn-store`, where
+//! `CARGO_BIN_EXE_did-collision-scan` resolves.
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
+use std::path::{Path, PathBuf};
+use std::process::{Command, Output};
+
+use icn_identity::Did;
+use icn_store::{SledStore, Store};
+use tempfile::TempDir;
+
+fn icnctl_bin() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_icnctl"))
+}
+
+/// A freshly minted principal, in the base58btc spelling the mint produces.
+fn fresh_did() -> Did {
+    icn_identity::KeyPair::generate().unwrap().did().clone()
+}
+
+/// Two accepted spellings of ONE principal: the minted base58btc form, and the
+/// same 32 identifier bytes re-encoded as base16.
+fn alias_pair() -> (Did, Did) {
+    let a = fresh_did();
+    let bytes = a.identifier_bytes().expect("a minted spelling decodes");
+    let b: Did = format!("did:icn:f{}", hex::encode(bytes))
+        .parse()
+        .expect("a re-encoding of a valid key is a valid DID");
+    assert_eq!(a, b, "fixture must be one principal");
+    assert_ne!(a.as_str(), b.as_str(), "under two spellings");
+    (a, b)
+}
+
+/// `icnctl init-coop` opens `<data_dir>/store` itself as a sled database — a
+/// sibling of the daemon's `<data_dir>/store/{trust,ledger,...}` stores, and a
+/// sled root the gate discovers like any other.
+fn store_root(data_dir: &Path) -> PathBuf {
+    data_dir.join("store")
+}
+
+/// Plant an alias pair in `trust/edges/` — a *registered* N2-A keyspace whose
+/// basis is `AwaitingDomainSignOff`, so a collision there fails closed however
+/// its disposition reads.
+fn seed_alias_collision(data_dir: &Path) -> Vec<(Vec<u8>, Vec<u8>)> {
+    let (a, b) = alias_pair();
+    let peer = fresh_did();
+
+    let store = SledStore::open(store_root(data_dir)).unwrap();
+    for src in [&a, &b] {
+        let key = format!("trust/edges/{}:{}", src.as_str(), peer.as_str());
+        store.put(key.as_bytes(), b"{}").unwrap();
+    }
+    store.db().flush().unwrap();
+    let snapshot = store.scan(b"trust/edges/").unwrap();
+    drop(store); // release the sled lock for the binary
+    snapshot
+}
+
+/// A store with one spelling per principal: nothing for the gate to refuse.
+fn seed_clean(data_dir: &Path) {
+    let store = SledStore::open(store_root(data_dir)).unwrap();
+    let key = format!(
+        "trust/edges/{}:{}",
+        fresh_did().as_str(),
+        fresh_did().as_str()
+    );
+    store.put(key.as_bytes(), b"{}").unwrap();
+    store.db().flush().unwrap();
+    drop(store);
+}
+
+fn run_icnctl(data_dir: &Path, args: &[&str]) -> Output {
+    let mut cmd = Command::new(icnctl_bin());
+    cmd.arg("--data-dir").arg(data_dir);
+    cmd.args(args);
+    cmd.output().unwrap()
+}
+
+fn combined(out: &Output) -> String {
+    format!(
+        "{}{}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr)
+    )
+}
+
+fn trust_rows(data_dir: &Path) -> Vec<(Vec<u8>, Vec<u8>)> {
+    let store = SledStore::open(store_root(data_dir)).unwrap();
+    let rows = store.scan(b"trust/edges/").unwrap();
+    drop(store);
+    rows
+}
+
+#[test]
+fn coop_maintenance_refuses_a_data_directory_the_gate_refuses() {
+    let dir = TempDir::new().unwrap();
+    let before = seed_alias_collision(dir.path());
+
+    let out = run_icnctl(dir.path(), &["coop", "entity-report"]);
+    let text = combined(&out);
+
+    assert!(
+        !out.status.success(),
+        "a gate-refused data directory must fail the command, got success:\n{text}"
+    );
+    assert!(
+        text.contains("N2-A startup gate refused"),
+        "the refusal must say what happened:\n{text}"
+    );
+    assert_eq!(
+        trust_rows(dir.path()),
+        before,
+        "a refused command must leave the store byte-for-byte unchanged"
+    );
+}
+
+#[test]
+fn treasury_maintenance_refuses_a_data_directory_the_gate_refuses() {
+    let dir = TempDir::new().unwrap();
+    let before = seed_alias_collision(dir.path());
+
+    // The mutating form, with both confirmations supplied: refusal must happen
+    // before any write is even considered.
+    let out = run_icnctl(
+        dir.path(),
+        &[
+            "treasury",
+            "entity-backfill-apply",
+            "--apply",
+            "--confirm-apply",
+        ],
+    );
+    let text = combined(&out);
+
+    assert!(!out.status.success(), "must refuse:\n{text}");
+    assert!(text.contains("N2-A startup gate refused"), "{text}");
+    assert_eq!(
+        trust_rows(dir.path()),
+        before,
+        "mutation must not occur before a successful gate"
+    );
+}
+
+#[test]
+fn init_coop_refuses_a_data_directory_the_gate_refuses() {
+    // The path M4d proved was a real bypass: `init-coop` opened
+    // `<data_dir>/store` and wrote `trust/edges/` rows with no gate and — unlike
+    // the treasury path — no loader guard behind it either.
+    let dir = TempDir::new().unwrap();
+    let before = seed_alias_collision(dir.path());
+
+    let out = run_icnctl(
+        dir.path(),
+        &["init-coop", "--name", "Probe Coop", "--yes", "--no-start"],
+    );
+    let text = combined(&out);
+
+    assert!(!out.status.success(), "must refuse:\n{text}");
+    assert!(text.contains("N2-A startup gate refused"), "{text}");
+    assert_eq!(
+        trust_rows(dir.path()),
+        before,
+        "no trust edge may be written into a store the gate refuses"
+    );
+}
+
+#[test]
+fn a_clean_data_directory_is_not_refused() {
+    // The control that stops the fix from being "refuse everything". A store
+    // with one spelling per principal must get past the gate — whatever the
+    // command then does about its own missing inputs.
+    let dir = TempDir::new().unwrap();
+    seed_clean(dir.path());
+
+    let out = run_icnctl(dir.path(), &["coop", "entity-report"]);
+    let text = combined(&out);
+
+    assert!(
+        !text.contains("N2-A startup gate refused"),
+        "a clean store must not be refused by the gate:\n{text}"
+    );
+}
+
+#[test]
+fn an_absent_data_directory_is_not_refused() {
+    // A directory that does not exist holds no rows, so there is nothing to
+    // fold and nothing to audit. `init-coop` on a fresh machine takes this arm;
+    // treating absence as a refusal would make first-run setup impossible.
+    let dir = TempDir::new().unwrap();
+    let fresh = dir.path().join("not-created-yet");
+
+    let out = run_icnctl(&fresh, &["coop", "entity-report"]);
+    let text = combined(&out);
+
+    assert!(
+        !text.contains("N2-A startup gate refused"),
+        "an absent data directory is not a verdict:\n{text}"
+    );
+}

--- a/icn/crates/icn-store/tests/n2a_scanner_exemption.rs
+++ b/icn/crates/icn-store/tests/n2a_scanner_exemption.rs
@@ -1,0 +1,84 @@
+//! The scanner keeps deliberate pre-gate access to state the gate refuses
+//! (#2627 M4d).
+//!
+//! M4d closed the ungated operator paths in `icnctl`, and the obvious way to
+//! over-close it would be to make *everything* that opens a sled database run
+//! the gate first. `did-collision-scan` must not: a safety scanner able to read
+//! unsafe state is the entire point of having one, and an operator handed a
+//! refusal is told to run exactly this tool for the row-level report
+//! (`n2a_startup_gate.rs`, `icn_ledger::principal_rows`).
+//!
+//! The exemption is narrow and stated rather than accidental. The scanner is
+//! not skipping the check — it *is* the offline form of the same computation
+//! (`audit_sled_store`), so it can never disagree with the gate about what is
+//! safe. What M4d forbids is an ordinary operational mutation path acquiring
+//! the same privilege by omission.
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
+use std::path::Path;
+use std::process::Command;
+
+use icn_identity::Did;
+use icn_store::{SledStore, Store};
+
+/// Two accepted spellings of one principal.
+fn alias_pair() -> (Did, Did) {
+    let a = icn_identity::KeyPair::generate().unwrap().did().clone();
+    let bytes = a.identifier_bytes().unwrap();
+    let b: Did = format!("did:icn:f{}", hex::encode(bytes)).parse().unwrap();
+    assert_eq!(a, b);
+    assert_ne!(a.as_str(), b.as_str());
+    (a, b)
+}
+
+/// An alias collision in the registered `trust/edges/` keyspace.
+fn seed_refused_store(dir: &Path) {
+    let (a, b) = alias_pair();
+    let peer = icn_identity::KeyPair::generate().unwrap().did().clone();
+    let store = SledStore::open(dir).unwrap();
+    for src in [&a, &b] {
+        store
+            .put(
+                format!("trust/edges/{}:{}", src.as_str(), peer.as_str()).as_bytes(),
+                b"{}",
+            )
+            .unwrap();
+    }
+    store.db().flush().unwrap();
+    drop(store);
+}
+
+#[test]
+fn the_scanner_still_reports_over_a_store_the_gate_refuses() {
+    let dir = tempfile::tempdir().unwrap();
+    let store_path = dir.path().join("store");
+    seed_refused_store(&store_path);
+
+    // The gate refuses this data directory.
+    let gate = icn_store::n2a_startup_gate::enforce(dir.path(), std::time::SystemTime::now());
+    assert!(
+        gate.is_err(),
+        "fixture must be a store the gate refuses, got {gate:?}"
+    );
+
+    // The scanner reads it anyway, and produces a report rather than a refusal
+    // to look.
+    let out = Command::new(env!("CARGO_BIN_EXE_did-collision-scan"))
+        .arg(&store_path)
+        .arg("--json")
+        .output()
+        .expect("run did-collision-scan");
+    let stdout = String::from_utf8(out.stdout).expect("stdout is utf-8");
+    let report: serde_json::Value = serde_json::from_str(&stdout).unwrap_or_else(|e| {
+        panic!("scanner must emit a report, not refuse to look: {e}\n{stdout}")
+    });
+
+    assert!(
+        stdout.contains("trust/edges"),
+        "the report must name the keyspace it found the collision in:\n{stdout}"
+    );
+    assert!(
+        report.is_object() || report.is_array(),
+        "report shape: {report}"
+    );
+}


### PR DESCRIPTION
<!-- ICN-DELIVERY-LIFECYCLE:BEGIN -->
- **State:** FROZEN (all 11 required contexts green on the exact head; awaiting explicit human merge authorization)
- **Lane:** #2627 N2-A — M4d (alternate store-opener / startup-gate coverage)
- **Acceptance contract:** no production- or operator-capable execution path may perform a governed read or mutation before the N2-A gate has succeeded; gate failure leaves no usable mutation-capable store path alive. Non-goals: `Did::from_str` / identity-base remediation, auditing other delimiter-framed keyspaces, M4e/M4f, IDENTITY_SEMANTICS §7.5.
- **Review generation:** 1 bounded FULL review on `7f5b998e` → **0 BLOCKER**, 6 FOLLOW_UP, 1 QUESTION, 10 NOT_A_FINDING. All six follow-ups and the question dispositioned in `2defdde0`. Generation CLOSED; review of this PR is now DELTA only.
- **Freeze head:** `2defdde04ead9ccf46af3599843c5852baac4275`
- **Known blockers:** none open
- **Unresolved threads:** 0 (2 Copilot threads, both valid, fixed in `2defdde0`, replied and resolved)
- **Required CI at freeze head (verified 2026-09-06, live branch protection):** 11/11 SUCCESS — Accessibility Tests · Agent Tooling Drift Check · Build Release · Clippy · Firewall Contract Enforcement · Format Check · Kernel Forbidden Dependencies · Meaning Firewall Check · Regulatory Compliance Linter · Test · TypeScript SDK. Base currency: merge-base equals `origin/main` `3c1e4f863` (`strict: true` satisfied).
- **Non-required reds, both externally owned — NOT blockers:** `Build and verify` (Website CI; real +6px `ReadingLadder.astro` overflow, owned by **#2639**) and `Security Audit` (`cargo-audit` fails and skips both `cargo-deny` steps, owned by **#2579**). Neither is in the required-context set; neither is caused by this PR; neither may be "fixed" from this branch.
- **Follow-up ledger — each item now has a durable owner, not PR-body prose:**
  - restart helpers lack `required-features` → **#2720** (five helpers, two auto-discovered with no `[[bin]]` stanza)
  - `init-coop` writes trust edges to a DB the daemon never reads → **#2718**
  - `SledStore::from_db` / `db()` injection surfaces → **independently revalidated and refuted as a gate bypass.** `from_db`'s only production caller (`icn-gateway/src/server.rs:1300`) opens at `<data_dir>/gateway_store`, which is inside `find_sled_roots`' walk and therefore audited. The real residual is that the gate runs only in `icnd` — which is this PR's own subject, not a follow-up.
  - `icnctl verify-backup` ledger-path no-op and success-string overclaim (adjacent, found in the same review) → **#2717**
<!-- ICN-DELIVERY-LIFECYCLE:END -->

Canonical base `3c1e4f863d55ec7c4cc1b270c8ca2844ca81a6b3` (#2715 M4c squash). Disposition: migration gate **§10.7**.

M4d asked one question: **can any production- or operator-capable path reach a governed store without the N2-A gate?**

## 1. Opener inventory and reachability

`enforce` had exactly one non-test caller: `icnd/src/main.rs`. Nine binary targets, classified on operational evidence rather than by name:

| Binary | Class | Opens governed state | Gate before M4d |
|---|---|---|---|
| `icnd` | production | yes | **yes** |
| `icnctl` | operator | yes — 9 `SledStore::open` sites in 7 fns | **no** |
| `icn-console` | network client | **no** — single file, zero `icn_*` use; icn-store/icn-trust deps are unused manifest edges | n/a |
| `did-collision-scan` | scanner/safety tooling | yes, deliberately | no — correctly |
| 5 × `*_restart_helper` | test-only | 4 of 5 do (gossip is snapshot-JSON) | no |

Each restart helper is spawned by exactly one integration test via `CARGO_BIN_EXE_*`; every reference in the repo falls into the crate manifest, its own source, that test, or docs — no Dockerfile, compose, K8s, systemd unit, workflow, or shell script names any of them.

**`icnd` re-proved by call path**, not line order: `build_services` holds a `sled::open` and is *declared* above the gate call but *invoked* after it; a refusal propagates out of `main`.

## 2. The bypass, reproduced

`icnctl init-coop` → `create_dir_all(<data_dir>/store)` → `SledStore::open` → `TrustGraph::add_edge`, writing `trust/edges/` — **registered**, basis `AwaitingDomainSignOff`, so a collision there fails closed however its disposition reads. On a real sled fixture holding an alias pair:

```
gate:        REFUSED — "1 of 1 store(s) hold principal-bearing rows
                        a key-equality binary cannot open safely"
icnctl seam: add_edge ok = true
trust/edges: 2 rows → 3 rows
```

`TrustGraph::new` neither loads nor folds — no loader guard stood behind it.

## 3. What was already safe — the actual finding

`icnctl treasury entity-backfill-apply` mutates `ledger:treasury:` just as ungated, and refuses anyway:

> `icn-ledger/treasury: 1 persisted row group(s) name one principal under several did:icn: spellings, and no domain-authorized merge rule exists for this keyspace; refusing to rebuild.`

That is M1's `principal_rows` classification, reached through `TreasuryManager::with_store` → `load_from_store` → `read_persisted_state`. (My first probe of this refused for the *wrong* reason — a hand-built JSON fixture that didn't decode — so I rebuilt it from a row written by the production writer before trusting the result.) The cooperative-store commands touch `icn-entity` keys, which strip the `did:icn:` scheme and are invisible to a key scanner.

So coverage was **accidental, not structural**: `icnctl` was safe exactly where an earlier milestone had hardened that keyspace's loader, and unsafe where none had.

## 4. Enforcement architecture

**(A) Entrypoint, at handler granularity.** One `enforce_n2a_gate` helper calling the *same* `enforce` the daemon calls, at four dispatch points: `init-coop`, `coop` maintenance, `treasury` maintenance, `verify-backup --verify-ledger` (a restored tree is a data directory like any other — a backup whose ledger the gate would refuse is not one the command should call safely restorable).

Rejected: **(B)** enforcing inside `SledStore::open` — the gate itself opens stores that way and would recurse, and it would break the scanner. Also rejected: pasting the call at each of the nine open sites — the gate's unit is a *directory*, not a file. **(C)** typed gated-handle capability was evaluated and judged disproportionate for a four-handler fix.

An absent directory is **not** a refusal (it holds no rows), so first-run `init-coop` still works.

Two consequences stated, not hidden: the gate writes its own receipt, so commands documented read-only now leave that one file (never a domain-store write); and the gate takes each sled root's exclusive lock, so a running daemon makes it refuse — the refusal text keeps the existing "stop the daemon first" guidance.

## 5. Scanner exemption — named, not accidental

`did-collision-scan` keeps pre-gate access: an operator handed a refusal is told to run exactly it. It is not skipping the check — it *is* the offline form of the same `audit_sled_store` computation, so the two cannot disagree. Pinned by `n2a_scanner_exemption.rs`.

## 6. Tests and mutation evidence

Five `icnctl` tests drive the **real binary** against real sled fixtures and assert refusal semantics — non-zero exit, stated reason, and the store byte-for-byte unchanged — not merely that a function was called.

| Test | Proves |
|---|---|
| `coop_maintenance_refuses_…` | refusal + no mutation |
| `treasury_maintenance_refuses_…` | refusal *with both `--apply --confirm-apply` supplied* — mutation cannot occur before a successful gate |
| `init_coop_refuses_…` | the proven bypass now refuses; no trust edge written |
| `a_clean_data_directory_is_not_refused` | control — the fix is not "refuse everything" |
| `an_absent_data_directory_is_not_refused` | control — first-run setup still works |
| `the_scanner_still_reports_over_a_store_the_gate_refuses` (icn-store) | the exemption survives |

**Mutation:** with `enforce_n2a_gate` short-circuited to `Ok(())` and nothing else changed, the three refusal tests **FAIL** and both controls correctly still pass. Restored byte-exact (`md5sum` verified).

## 7. Descriptor / inventory / readiness — unchanged, deliberately

M4d registers no keyspace and changes no descriptor, `MergeDisposition`, `RuleBasis`, or inventory row. It changes *who runs* the existing gate, not what the gate knows — so `n2a_keyspaces()`, `n2a-a0-stored-key-inventory.md` and every §11 disposition are untouched, and no readiness classification moves.

## 8. Verification (local, on `2defdde0`)

`cargo fmt --all --check` · `cargo clippy -p icnctl -p icn-store --all-targets --all-features -- -D warnings` (0) · `cargo test -p icnctl -p icn-store -p icn-trust -p icn-ledger --all-features` → **1237 passed, 0 failed, 32 suites** (re-run after review fixes: icnctl + icn-store 414 passed, 0 failed, 18 suites) · meaning firewall · doc control · readiness overclaim linter · compliance linter · drift check (0/0) · `git diff --check`.

## 10. Bounded FULL review — findings and dispositions

One FULL review on `7f5b998e`: **0 BLOCKER**, 6 FOLLOW_UP, 1 QUESTION, 10 NOT_A_FINDING. The acceptance contract was found met; the four gated dispatch points do cover every sled-opening path in `icnctl`. All seven items are dispositioned in `2defdde0`.

- **Refusal message asserted one cause for six variants (FIXED).** Only `GateRefusal::Blocked` means "holds principal-bearing rows". The likeliest operator mistake — running maintenance with the daemon up — surfaces as `StoreUnverifiable`, and the old wrapper sent that operator hunting for an alias pair that does not exist, replacing a previously correct "stop the daemon first" message. Now branches on the variant; a new fixture pins that a non-collision refusal never claims the collision cause.
- **Three `--help` strings said "Writes nothing." (FIXED).** They now write the gate receipt. §10.7 recorded it; the operator-visible text did not.
- **My own audit count was wrong (FIXED).** 9 `SledStore::open` sites in 7 functions, not 10 in 6 — a comment line containing the string inflated it. I verified this before accepting it. Corrected in §10.7 and this body; the reasoning is unaffected, since all 7 functions still map to exactly the 4 gated handlers.
- **`verify-backup --verify-ledger` had no test (FIXED).** The one gated path whose directory is not `--data-dir`, and the only call placed inside a handler rather than at dispatch. Now has its own fixture.
- **Both controls asserted only the absence of a string (FIXED).** Neither could distinguish "gate ran and cleared" from "gate never wired". They now assert positively: a cleared gate leaves its receipt; a skipped absent directory is not created.
- **Directory-wide read cost was understated (DOCUMENTED).** The gate's unit is the directory, so a command that opened one store now opens and row-scans every database beneath the data dir. The gate module's justification — that its opens are free because the daemon would sled-recover anyway — is true for `icnd` and does not transfer to a CLI run with the daemon stopped. Accepted rather than optimised, with the reason stated: every such store is one `icnd` already refuses to start over.
- **QUESTION on `verify_ledger_in_backup` (ANSWERED, recorded as debt).** It looks for `<restore_dir>/ledger`, but `backup` archives the data directory whole, so the ledger lands at `<restore_dir>/store/ledger` — that check has been a no-op. The gate call added beside it does reach the real stores via `find_sled_roots`, but that is a side effect, not a repair. Fixing the path changes what the command does and belongs to its owner.

**Two further Copilot threads, both valid, fixed in `2defdde0`:**

- **`!dir.is_dir()` swallowed a non-directory `--data-dir`.** Now `!dir.exists()`, so a file falls through to `enforce`, which refuses it by name. No governed state could have survived the old arm (nothing lives under a regular file), so this is loudness rather than a closed hole — but a wrong `--data-dir` answering quietly is its own defect. Pinned by a new fixture.
- **The refusal told operators to run `did-collision-scan` on the directory.** Checked rather than assumed: `a_path_above_the_databases_is_rejected_not_reported_clear` pins that a path above the stores exits non-zero, and the gate's own refusal already says `did-collision-scan <store>`. My wording would have handed an operator a non-zero exit and no report. It now names the store paths the cause chain prints.

The review independently confirmed the ordering proof, the `!is_dir()` early-return soundness (no ordering exists in which a store survives the skip), the absence of missed subcommands, the lock behaviour, the scanner exemption's non-triviality, zero descriptor/inventory drift, the binary classifications, and no M4c regression.

## 11. Explicit non-claims and debt

- **`icnctl` is not proven exhaustively gated.** Four handlers are covered. Other subcommands touch the age keystore, snapshot files and backup archives — not sled, not N2-A-governed, not audited for other properties.
- **Pre-existing defect, recorded not fixed:** `icnd` opens `<data_dir>/store/trust` while `init-coop` opens `<data_dir>/store` *itself* as a separate sibling database — so the trust edges `init-coop` reports creating are never read by the daemon. Found while comparing call paths; repairing it changes that command's semantics and belongs to its owner.
- **Restart helpers remain ungated and unrestricted.** Test-only by evidence, but ordinary `[[bin]]` targets with no `required-features`, so `cargo build --bins` produces them. The root `Dockerfile` builds them and copies only `icnd`/`icnctl`. Constraining them is the follow-up.
- **Library injection surfaces unclosed.** `SledStore::from_db` and `SledStore::db()` can still hand a caller-supplied `sled::Db` to any store constructor without a path the gate could discover. No production entrypoint reaches them ungated today; closing them needs a typed gated handle.
- **Identity-base delimiter hazard untouched.** `Did::from_str` is not changed here, and other `:`/`/`-framed keyspaces remain unaudited.
- **#2627 stays OPEN.** M4d does not close it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
