### PR TITLE
fix(ci): repair the benchmark regression count; docs(identity): correct a §7.5 claim I7 made false

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -145,7 +145,7 @@ jobs:
 
           # Count only Criterion's explicit regression verdict. Do not match confidence-interval
           # lines like `change: [-0.5% -0.2% +0.03%]` — the positive upper bound is not a regression.
-          REGRESSION_COUNT=$(grep -ciF "Performance has regressed" bench_output.txt || echo "0")
+          REGRESSION_COUNT=$(grep -ciF "Performance has regressed" bench_output.txt || true)
 
           if [ "$REGRESSION_COUNT" -gt 0 ]; then
             echo "has_regressions=true" >> $GITHUB_OUTPUT

--- a/docs/architecture/IDENTITY_SEMANTICS.md
+++ b/docs/architecture/IDENTITY_SEMANTICS.md
@@ -1,7 +1,7 @@
 ---
 Status: normative
 Canonical: yes
-Last Reviewed: 2026-08-18
+Last Reviewed: 2026-09-06
 ---
 
 # Identity Semantics — the N2 semantic contract
@@ -499,9 +499,21 @@ them all at once.
 
 The other three prerequisites — migration ordering, alias/transition
 recognition, final cutover — remain undesigned, and **no persisted vote or
-membership key has been re-keyed**. Membership lists are still compared by DID
-spelling; under a static list an alias spelling is refused at the membership
-gate, which is fail-closed but is not yet alias recognition.
+membership key has been re-keyed**.
+
+In-memory membership *comparison* is a separate matter from the persisted
+*keys* this gate governs, and it has moved. Since I7 landed (#2686), `Did`
+equality is principal equality, so a static membership list — a `Vec<Did>`
+tested with `contains` — now admits **any** accepted spelling of a listed
+member. A previous revision of this section stated that an alias spelling is
+refused at the membership gate and called that fail-closed; that described
+pre-I7 behaviour and is no longer true.
+
+This does not narrow the gate. Admitting an alias of a genuine member is the
+correct reading of principal equality, and it is why the three remaining
+prerequisites still matter: recognition at the comparison boundary is not
+migration of the persisted keyspace, and nothing above re-keys a stored
+membership or vote row.
 
 ---
 


### PR DESCRIPTION
Two unrelated, independently-verified truth repairs found during a repository reconciliation pass. Both are isolated and neither touches the protected N2-A M4d lane (#2716 — `icnctl`, `icn-store`, `n2-a-migration-gate.md`).

## 1. `fix(ci)` — benchmark regression count evaluated a two-line string

`grep -c` prints `0` on no match **and** exits 1, so `|| echo "0"` fired *on top of* grep's own output and `REGRESSION_COUNT` became `"0\n0"`. The following `[ "$REGRESSION_COUNT" -gt 0 ]` then failed with `integer expression expected` instead of comparing, and the `if` fell through to the no-regression branch.

Clean runs reached the correct verdict **by way of a shell error rather than a comparison**, logging a spurious error each time. Two-or-more regressions still compared correctly — so the reporting worked in the case that mattered and hid the defect in the case that did not.

**Verified both branches directly** before and after:

```
before:  no match -> "0\n0"  -> `[: integer expression expected`
after:   no match -> "0"     -> else branch, no error
after:   2 matches -> "2"    -> regression branch
```

Workflow-only. No benchmark, threshold, or Rust change.

## 2. `docs(identity)` — a §7.5 claim that I7 made false

`docs/architecture/IDENTITY_SEMANTICS.md` is the registered owner of the `identity_semantics` domain and is marked `Status: normative` / `Canonical: yes`.

§7.5 closed by asserting that membership lists are compared by DID spelling and that *"under a static list an alias spelling is refused at the membership gate, which is fail-closed"*. That described pre-I7 behaviour.

Since **#2686** (`0defbde51`), `Did::PartialEq` compares decoded identifier bytes, so `MembershipSource::contains_static` — a `Vec<Did>` tested with `contains` (`icn/crates/icn-governance/src/membership.rs:46`) — now **admits** any accepted spelling of a listed member. **The document claimed a fail-closed refusal where the code admits**, which is the unsafe direction for a reader reasoning about the gate's posture.

The replacement text separates the two things §7.5 was conflating: in-memory membership *comparison* (which moved with I7) and the persisted membership/vote *keys* this gate governs (which have **not** been re-keyed).

**This is synchronization with landed code, not a semantic or governance change.** The gate itself, its four prerequisites, and the *"no persisted vote or membership key has been re-keyed"* statement are all unchanged. Surfaced while revalidating #2678.

## Verification

- `python3 docs/scripts/doc_control_check.py` → **passes** (971 markdown files; the 64 enforcement warnings are pre-existing and name other documents).
- `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/benchmark.yml'))"` → valid.
- Both `grep` branches exercised directly (output above).
- No Rust source changed, so no `cargo` gate is in scope for this diff.

## Non-claims

- Neither change fixes any advisory, benchmark regression, or migration.
- The §7.5 correction advances **nothing** in N2-A. It makes an existing document true; #2627 stays open and §7.5 remains a separate hard gate.

Refs #2627 #2678 #2686.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
