### PR TITLE
fix(cli): make init-coop seed trust the daemon can actually read (#2718)

### DIFF
--- a/docs/architecture/n2-a-migration-gate.md
+++ b/docs/architecture/n2-a-migration-gate.md
@@ -1296,11 +1296,14 @@ every §11 disposition are untouched, and no readiness classification moves.
 - **`icnctl` is not proven exhaustively gated.** Four handlers are covered. Other subcommands touch
   the age keystore, snapshot files and backup archives; those are not sled and not N2-A-governed, and
   were not audited for other properties.
-- **`icnd` opens `<data_dir>/store/trust`; `icnctl init-coop` opens `<data_dir>/store` itself** as a
-  separate sibling sled database. The trust edges `init-coop` reports creating are therefore never
-  read by the daemon. That is a pre-existing functional defect, found while comparing call paths,
-  and is **recorded here rather than fixed** — repairing it changes `init-coop` semantics and belongs
-  to whoever owns that command.
+- **`icnctl init-coop` wrote trust edges the daemon never read — FIXED in #2724 (#2718).** This
+  section previously recorded, as live debt, that `icnd` opened `<data_dir>/store/trust` while
+  `init-coop` opened `<data_dir>/store` itself as a separate sibling sled database, so the edges
+  the wizard reported creating were never read. That is no longer true: the trust subdirectory now
+  has a single owner (`icn_core::config::TRUST_STORE_SUBDIR` / `Config::trust_store_path`), and both
+  binaries resolve through it. **Historical edges already stranded in `<data_dir>/store` by an
+  earlier `init-coop` are not migrated** — they were never readable by the daemon, so nothing
+  observable regresses, but no recovery is claimed either.
 - **The restart helpers remain ungated and unrestricted.** They are test-only by evidence, but they
   are ordinary `[[bin]]` targets with no `required-features`, so `cargo build --bins` produces them.
   The root `Dockerfile` builds them and copies only `icnd`/`icnctl`; `deploy/Dockerfile.icnd` avoids

--- a/icn/bins/icnctl/src/main.rs
+++ b/icn/bins/icnctl/src/main.rs
@@ -3320,7 +3320,7 @@ async fn main() -> Result<()> {
             yes,
             no_start,
         } => {
-            // Opens `<data_dir>/store` and writes trust edges; gate first.
+            // Opens `<data_dir>/store/trust` and writes trust edges; gate first (#2718).
             enforce_n2a_gate(&data_dir, "init-coop")?;
             handle_init_coop_command(&data_dir, name, members, yes, no_start).await?
         }
@@ -8191,35 +8191,19 @@ async fn handle_init_coop_command(
         println!("Step 1: Creating new identity");
         std::fs::create_dir_all(data_dir).context("Failed to create data directory")?;
 
-        // The identity-reuse branch above already resolves the passphrase through
-        // `read_passphrase`, which honours ICN_KEYSTORE_PASSPHRASE. This branch used
-        // `rpassword` directly, so creating a *new* identity demanded a TTY even under
-        // `--yes` -- the wizard could not run unattended, and its trust-persistence
-        // contract could not be exercised end to end (#2718).
-        let passphrase1 = match passphrase_from_env() {
-            // Confirming an environment variable against itself proves nothing, so the
-            // second prompt is skipped rather than answered twice.
-            Some(from_env) => from_env,
-            None => {
-                print!("Choose a passphrase: ");
-                io::stdout().flush()?;
-                let first = rpassword::read_password()?;
-
-                print!("Confirm passphrase: ");
-                io::stdout().flush()?;
-                let second = rpassword::read_password()?;
-
-                if first != second {
-                    bail!("Passphrases do not match");
-                }
-                first
-            }
-        };
-        if passphrase1.len() < 8 {
+        // Resolve through the shared helper, which honours ICN_KEYSTORE_PASSPHRASE --
+        // the same variable `icnd` reads -- and otherwise prompts and confirms. This
+        // branch previously called `rpassword` directly, so creating a *new* identity
+        // demanded a TTY even under `--yes`: the wizard could not run unattended and its
+        // trust-persistence contract could not be exercised end to end (#2718). The
+        // identity-reuse branch above already went through the same helper family;
+        // spelling the rule a third time here is the drift this change exists to remove.
+        let resolved = confirm_passphrase()?;
+        if resolved.len() < 8 {
             bail!("Passphrase must be at least 8 characters");
         }
 
-        let passphrase = Zeroizing::new(passphrase1.into_bytes());
+        let passphrase = Zeroizing::new(resolved);
 
         // Initialize keystore (generates keypair internally)
         let keystore = AgeKeyStore::init(&keystore_path, &passphrase)?;

--- a/icn/bins/icnctl/src/main.rs
+++ b/icn/bins/icnctl/src/main.rs
@@ -2232,6 +2232,15 @@ fn get_store_path(data_dir: &Path) -> PathBuf {
     data_dir.join("store")
 }
 
+/// The trust store `icnd` opens, resolved through the same owner the daemon uses.
+///
+/// `icn_core::config` owns the subdirectory name; spelling it here a second time
+/// is what let `init-coop` write bootstrap trust into `store/` while the daemon
+/// read `store/trust/` (#2718).
+fn get_trust_store_path(data_dir: &Path) -> PathBuf {
+    get_store_path(data_dir).join(icn_core::config::TRUST_STORE_SUBDIR)
+}
+
 /// Refuse to touch a data directory the N2-A startup gate would refuse to open
 /// (#2627 M4d).
 ///
@@ -8182,17 +8191,30 @@ async fn handle_init_coop_command(
         println!("Step 1: Creating new identity");
         std::fs::create_dir_all(data_dir).context("Failed to create data directory")?;
 
-        print!("Choose a passphrase: ");
-        io::stdout().flush()?;
-        let passphrase1 = rpassword::read_password()?;
+        // The identity-reuse branch above already resolves the passphrase through
+        // `read_passphrase`, which honours ICN_KEYSTORE_PASSPHRASE. This branch used
+        // `rpassword` directly, so creating a *new* identity demanded a TTY even under
+        // `--yes` -- the wizard could not run unattended, and its trust-persistence
+        // contract could not be exercised end to end (#2718).
+        let passphrase1 = match passphrase_from_env() {
+            // Confirming an environment variable against itself proves nothing, so the
+            // second prompt is skipped rather than answered twice.
+            Some(from_env) => from_env,
+            None => {
+                print!("Choose a passphrase: ");
+                io::stdout().flush()?;
+                let first = rpassword::read_password()?;
 
-        print!("Confirm passphrase: ");
-        io::stdout().flush()?;
-        let passphrase2 = rpassword::read_password()?;
+                print!("Confirm passphrase: ");
+                io::stdout().flush()?;
+                let second = rpassword::read_password()?;
 
-        if passphrase1 != passphrase2 {
-            bail!("Passphrases do not match");
-        }
+                if first != second {
+                    bail!("Passphrases do not match");
+                }
+                first
+            }
+        };
         if passphrase1.len() < 8 {
             bail!("Passphrase must be at least 8 characters");
         }
@@ -8433,10 +8455,15 @@ token_expiry_hours = 24
     }
     println!();
 
-    // Step 7: Create trust edges for initial members
-    let store_path = get_store_path(data_dir);
-    std::fs::create_dir_all(&store_path)?;
-    let store = SledStore::open(&store_path).context("Failed to open store")?;
+    // Step 7: Create trust edges for initial members.
+    //
+    // This must be the same sled database `icnd` opens, or the wizard reports
+    // bootstrap trust it then cannot see (#2718). The path is owned by
+    // `icn_core::config`, not spelled here, so the writer cannot drift from the
+    // reader again.
+    let trust_store_path = get_trust_store_path(data_dir);
+    std::fs::create_dir_all(&trust_store_path)?;
+    let store = SledStore::open(&trust_store_path).context("Failed to open trust store")?;
     let store = Arc::new(store);
     let mut trust_graph = TrustGraph::new(store, my_did.clone());
 

--- a/icn/bins/icnctl/tests/init_coop_trust_persistence.rs
+++ b/icn/bins/icnctl/tests/init_coop_trust_persistence.rs
@@ -1,0 +1,200 @@
+//! `icnctl init-coop` must seed trust the daemon can actually read (#2718).
+//!
+//! The wizard printed `✓ Trust edges created for N member(s)` while writing them
+//! into the sled database at `<data_dir>/store`, and `icnd` opened
+//! `<data_dir>/store/trust`. Two different databases, so every bootstrap trust
+//! relationship was invisible to the node it configured — a bootstrap that
+//! reports success is not successful unless the consumer can observe the bytes.
+//!
+//! These tests drive the **real `icnctl` binary** and read back through the
+//! **daemon's own path constructor** (`Config::trust_store_path`). Nothing here
+//! spells a store path itself: a test that recomputed the layout could agree
+//! with a wrong writer and stay green, which is exactly the failure being fixed.
+//!
+//! The pre-fix binary fails `edge_written_by_init_coop_is_visible_at_the_daemon_path`
+//! because `store/trust/` does not exist at all, and fails
+//! `init_coop_does_not_leave_a_sled_database_at_the_store_root` because `store/`
+//! is itself a sled root.
+
+// Integration test: a failed assumption should abort the test loudly, which is what
+// `expect`/`unwrap` do. Same posture as the other `icnctl` integration tests.
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
+use std::path::Path;
+use std::process::Command;
+use std::sync::Arc;
+
+use icn_core::config::Config;
+use icn_identity::Did;
+use icn_store::SledStore;
+use icn_trust::TrustGraph;
+
+/// A second party for the coop. Any valid `did:icn:` identifier works; this one
+/// is a fixed 32-byte key so the test does not depend on generating an identity
+/// twice.
+const MEMBER_DID: &str = "did:icn:z2mc9LnC3ic2berctfjr5xTLU8bibTgYJ3gFB5oTYcu1p";
+
+const PASSPHRASE: &str = "init-coop-trust-test-passphrase";
+
+/// Run the real wizard unattended.
+///
+/// `--yes` covers the confirmation prompt and `ICN_KEYSTORE_PASSPHRASE` covers
+/// the keystore prompt, which is the same variable `icnd` reads.
+fn run_init_coop(data_dir: &Path) -> String {
+    let out = Command::new(env!("CARGO_BIN_EXE_icnctl"))
+        .arg("--data-dir")
+        .arg(data_dir)
+        .args([
+            "init-coop",
+            "--name",
+            "TrustPersistenceCoop",
+            "--members",
+            MEMBER_DID,
+            "--yes",
+            "--no-start",
+        ])
+        .env("ICN_KEYSTORE_PASSPHRASE", PASSPHRASE)
+        .output()
+        .expect("failed to spawn icnctl");
+
+    let stdout = String::from_utf8_lossy(&out.stdout).into_owned();
+    let stderr = String::from_utf8_lossy(&out.stderr).into_owned();
+    assert!(
+        out.status.success(),
+        "init-coop failed (status {:?})\n--- stdout ---\n{stdout}\n--- stderr ---\n{stderr}",
+        out.status.code()
+    );
+    assert!(
+        stdout.contains("Trust edges created"),
+        "init-coop did not report creating trust edges; it may have skipped step 7\n{stdout}"
+    );
+    stdout
+}
+
+/// The DID the wizard generated for this data directory, taken from its own
+/// output rather than recomputed.
+fn own_did_from(stdout: &str) -> Did {
+    let line = stdout
+        .lines()
+        .find_map(|l| l.trim().strip_prefix("Your DID: "))
+        .or_else(|| stdout.lines().find_map(|l| l.trim().strip_prefix("DID: ")))
+        .expect("init-coop did not print the DID it created");
+    line.trim()
+        .parse()
+        .expect("init-coop printed an unparseable DID")
+}
+
+/// The path `icnd` opens. Resolved through the daemon's own constructor so the
+/// test cannot drift from the daemon.
+fn daemon_trust_path(data_dir: &Path) -> std::path::PathBuf {
+    let config = Config {
+        data_dir: data_dir.to_path_buf(),
+        ..Default::default()
+    };
+    config.trust_store_path()
+}
+
+#[test]
+fn edge_written_by_init_coop_is_visible_at_the_daemon_path() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let data_dir = tmp.path();
+
+    // Writer: the real CLI, in its own process. It exits, so every sled handle
+    // it held is closed before anything below opens the database.
+    let stdout = run_init_coop(data_dir);
+    let own_did = own_did_from(&stdout);
+    let member: Did = MEMBER_DID.parse().expect("member DID");
+
+    // Reader: the daemon's path, a fresh process-local handle, no writer state.
+    let trust_path = daemon_trust_path(data_dir);
+    assert!(
+        trust_path.exists(),
+        "the daemon's trust store was never created at {}; init-coop wrote somewhere else",
+        trust_path.display()
+    );
+
+    let store = Arc::new(SledStore::open(&trust_path).expect("open daemon trust store"));
+    let graph = TrustGraph::new(store, own_did.clone());
+
+    let edge = graph
+        .get_edge(&own_did, &member)
+        .expect("trust store read failed")
+        .unwrap_or_else(|| {
+            panic!(
+                "the daemon path holds no edge {own_did} -> {member}; \
+                 init-coop reported success but the daemon sees nothing"
+            )
+        });
+
+    assert_eq!(
+        edge.source, own_did,
+        "edge source is not the wizard's own DID"
+    );
+    assert_eq!(edge.target, member, "edge target is not the member DID");
+    assert!(
+        (edge.score.value() - 0.5).abs() < f64::EPSILON,
+        "bootstrap trust score was not preserved across the reopen: {}",
+        edge.score.value()
+    );
+}
+
+/// MUST-FAIL control for the defect's signature.
+///
+/// Pre-fix, `init-coop` opened `<data_dir>/store` *itself* as a sled database,
+/// leaving sled's `db`/`conf` files at the store root and nesting every other
+/// domain store inside a live database directory. If that reappears, the layout
+/// has regressed even if the test above somehow still passes.
+#[test]
+fn init_coop_does_not_leave_a_sled_database_at_the_store_root() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let data_dir = tmp.path();
+    run_init_coop(data_dir);
+
+    let store_root = data_dir.join("store");
+    for marker in ["db", "conf"] {
+        assert!(
+            !store_root.join(marker).exists(),
+            "sled marker `{marker}` at {} means the store root is itself a database, \
+             which is the #2718 layout defect",
+            store_root.display()
+        );
+    }
+
+    // ...and the trust database is one level down, where the daemon looks.
+    let trust_path = daemon_trust_path(data_dir);
+    assert!(
+        trust_path.join("db").exists() || trust_path.join("conf").exists(),
+        "no sled database at the daemon's trust path {}",
+        trust_path.display()
+    );
+}
+
+/// Pins the canonical trust subdirectory constant.
+///
+/// Unlike the two tests above, this one does **not** discriminate the #2718
+/// writer defect: it observes only the daemon side, so it passed even against
+/// the pre-fix binary during mutation testing. It is here to catch a rename or
+/// re-spelling of the canonical subdirectory, not to prove the writer agrees.
+/// The writer/reader agreement is proven by
+/// `edge_written_by_init_coop_is_visible_at_the_daemon_path`.
+#[test]
+fn the_wizard_and_the_daemon_agree_on_where_trust_lives() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let data_dir = tmp.path();
+    run_init_coop(data_dir);
+
+    let daemon_path = daemon_trust_path(data_dir);
+
+    // The only directory under `store/` that init-coop created for trust must be
+    // the one the daemon opens.
+    assert!(
+        daemon_path.starts_with(data_dir.join("store")),
+        "the daemon trust path escaped the store root: {}",
+        daemon_path.display()
+    );
+    assert_eq!(
+        daemon_path.file_name().and_then(|s| s.to_str()),
+        Some(icn_core::config::TRUST_STORE_SUBDIR),
+        "the daemon's trust subdirectory is not the declared canonical one"
+    );
+}

--- a/icn/bins/icnd/src/main.rs
+++ b/icn/bins/icnd/src/main.rs
@@ -121,7 +121,7 @@ async fn build_services(
     let own_did = bundle.did().clone();
 
     // Open trust store
-    let trust_store_path = config.store_path().join("trust");
+    let trust_store_path = config.trust_store_path();
     std::fs::create_dir_all(&trust_store_path)?;
     let trust_store: Arc<dyn icn_store::Store> =
         Arc::new(icn_store::SledStore::open(&trust_store_path)?);

--- a/icn/crates/icn-core/src/config/mod.rs
+++ b/icn/crates/icn-core/src/config/mod.rs
@@ -164,6 +164,12 @@ impl Default for Config {
     }
 }
 
+/// Subdirectory of [`Config::store_path`] that holds the trust store.
+///
+/// Declared once so a writer and a reader cannot drift apart on the spelling.
+/// Both `icnd` and `icnctl init-coop` resolve the trust store through this.
+pub const TRUST_STORE_SUBDIR: &str = "trust";
+
 impl Config {
     /// Load configuration from a TOML file
     pub fn from_file(path: impl AsRef<std::path::Path>) -> anyhow::Result<Self> {
@@ -204,6 +210,17 @@ impl Config {
     /// Get the ledger store path (sled DB for double-entry ledger)
     pub fn ledger_store_path(&self) -> PathBuf {
         self.store_path().join("ledger")
+    }
+
+    /// Get the trust store path (sled DB for trust attestations and scores).
+    ///
+    /// This is the canonical owner of the trust subdirectory. `icnd` opens the
+    /// trust store here, and any bootstrap writer that seeds trust state must
+    /// resolve the same path or the daemon will not observe what it wrote —
+    /// `icnctl init-coop` previously opened `store/` itself and reported success
+    /// while the daemon read an empty `store/trust/` (#2718).
+    pub fn trust_store_path(&self) -> PathBuf {
+        self.store_path().join(TRUST_STORE_SUBDIR)
     }
 
     /// Validate configuration and return a list of warnings/errors

--- a/icn/crates/icn-store/src/did_collision_scan.rs
+++ b/icn/crates/icn-store/src/did_collision_scan.rs
@@ -2975,9 +2975,9 @@ mod tests {
         let base = tempfile::tempdir().unwrap();
         let data_dir = base.path();
 
-        // `store/` is itself a database (as `icnctl init-coop` leaves it), and
-        // holds a database, a non-database directory, and a database nested
-        // inside a non-database; one more database sits at the data-dir level.
+        // `store/` is itself a database here -- a deliberately hostile shape, not one
+        // any command still produces -- and holds a database, a non-database directory,
+        // and a database nested inside a non-database; one more sits at the data-dir level.
         for rel in [
             "store",
             "store/ledger",


### PR DESCRIPTION
Closes #2718.

<!-- ICN-DELIVERY-LIFECYCLE:BEGIN -->
```
ICN DELIVERY LIFECYCLE
State:                FROZEN  (11/11 required contexts green on the exact head;
                      awaiting explicit human merge authorization)
Lane:                 #2718 -- bootstrap trust persistence
Acceptance contract:  trust state written by the production bootstrap command must be
                      observable by the production daemon after the writer's process exits.
Review generation:    1 bounded FULL review -> 0 BLOCKER, 4 FOLLOW_UP, 0 QUESTION,
                      6 NOT_A_FINDING. Three follow-ups applied in 65a7ef33b; the fourth
                      filed as icn#2725. Generation CLOSED; review is now DELTA only.
Freeze head:          8de72fc8f3c087d34215bf565b1e95c5ad665e88
Base:                 main dd21b2d008963dad91cc9b1c8c485133680115a3 -- merge-base equals
                      origin/main (strict:true satisfied)
Known blockers:       none open
Unresolved threads:   0 (2 Copilot threads, both replied and resolved)
Non-required reds:    Build and verify (icn#2639) and Security Audit (icn#2579) -- both red on
                      main itself, neither caused here, neither fixable from this branch
Follow-up ledger:     (1) icn#2725 -- init-coop reuses an existing icn.toml without honouring
                          its data_dir, so trust can again be seeded where the daemon will not
                          look. Pre-existing; fails `introduced_here`
                      (2) icnctl's get_store_path duplicates Config::store_path; the "ledger"
                          and "cooperative" subdir literals are still spelled in both crates.
                          Centralising the root belongs in one change covering all of them
                      (3) trust edges stranded in <data_dir>/store by an earlier init-coop are
                          NOT migrated -- they were never daemon-readable, so nothing
                          observable regresses, but no recovery is claimed
```
<!-- ICN-DELIVERY-LIFECYCLE:END -->

## The defect

`icnctl init-coop` reported `✓ Trust edges created for N member(s)` while writing into the sled database at `<data_dir>/store`. `icnd` opens `<data_dir>/store/trust`. **A bootstrap operation is not successful because it wrote bytes somewhere — it is successful only if the daemon that depends on those bytes can observe them.**

## Reproduced before changing anything

Running the real binary against `main`:

```
✓ Trust edges created for 1 member(s)

<data_dir>/store/{blobs,conf,db}    <- sled root; the member DID bytes are here
<data_dir>/store/trust              <- DOES NOT EXIST
```

The daemon opens the second path, sled creates it empty, and the node starts with none of its intended bootstrap trust. Trust gates rate limiting, connection admission and federated placement, so this is not cosmetic.

A second, structural symptom: because `store/` was itself a sled database, every other domain store (`store/ledger`, `store/governance`, …) was being created **inside a live sled database directory**.

## Root cause — a missing owner, not a typo

`icn-core` declared `ledger_store_path()` and `protocol_params_path()` but **no trust equivalent**, and the `"trust"` subdirectory was spelled exactly **once** in production code, inside `icnd`. Nothing tied the writer to the reader, so they could drift silently.

Supporting evidence that `store/<domain>/` is the canonical design: `icn-core/src/config/mod.rs` documents the layout, and every *other* `icnctl` consumer already joins a subdirectory (`.join("ledger")`, `.join("cooperative")`). `init-coop` was the lone outlier.

So this is **not** a blind string replacement. The subdirectory now has one owner:

- `icn_core::config::TRUST_STORE_SUBDIR` + `Config::trust_store_path()`
- `icnd` → `config.trust_store_path()`
- `icnctl` → `get_trust_store_path()`, defined in terms of the same constant

**Neither binary spells `"trust"` any more.**

## The passphrase change, and why it is here

The acceptance contract requires proof across the CLI-writer → daemon-reader boundary. That was **unreachable**: `--yes` covers only the confirmation prompt, so creating a new identity demanded a TTY and the wizard could never run unattended.

The file already had an env-aware `read_passphrase` honouring `ICN_KEYSTORE_PASSPHRASE` — the same variable `icnd` reads — and init-coop's **existing-identity branch already used it** while its **new-identity branch called `rpassword` directly**. That inconsistency is now removed. The confirmation prompt is skipped when the value came from the environment, because confirming an environment variable against itself proves nothing.

Without this, the contract cannot be tested at all.

## Tests, and proof they discriminate

Tests drive the **real `icnctl` binary in its own process** (so every writer handle is closed) and read back through **`Config::trust_store_path()` — the daemon's own constructor**. Nothing in the test recomputes the layout; a test that did could agree with a wrong writer and stay green.

Mutation evidence, with only the writer path reverted to pre-fix:

```
edge_written_by_init_coop_is_visible_at_the_daemon_path .... FAILED
  "the daemon's trust store was never created at .../store/trust;
   init-coop wrote somewhere else"
init_coop_does_not_leave_a_sled_database_at_the_store_root . FAILED
the_wizard_and_the_daemon_agree_on_where_trust_lives ....... ok
```

**The third test passes both ways and is documented in-file as not discriminating this defect** — it pins the canonical constant against a rename, nothing more. Calling it coverage would be false.

## Local verification

```
cargo fmt --all                                              clean
cargo clippy -p icn-core -p icnd -p icnctl --all-targets -D warnings   clean
cargo test -p icnctl --test init_coop_trust_persistence      3 passed, 0 failed
```

## Historical state — deliberately not migrated

An earlier `init-coop` may have left trust edges in the sled database at `<data_dir>/store`. **This PR does not move them.** It fixes future correctness only.

Whether that state is reachable in any deployed or rehearsed environment is unknown to me and was not investigated here; if recovery is required it needs its own bounded owner and its own evidence. **Do not read this PR as repairing any existing installation.**

## Non-goals

- No trust semantics, scoring or `TrustEdge` change.
- No change to the other subdirectory literals still duplicated between `icnctl` and `icn-core` (`ledger`, `cooperative`) — same shape, but not this defect.
- Not an N2-A change; advances no migration gate; does not touch #2627.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
