### PR TITLE
fix(cli): give init-coop the trust store path the daemon actually reads (#2718)

### DIFF
--- a/docs/architecture/n2-a-migration-gate.md
+++ b/docs/architecture/n2-a-migration-gate.md
@@ -1230,7 +1230,9 @@ carry no `required-features`; that is recorded as debt below, not treated as rea
 the gate call, but is *invoked* after it, and a refusal propagates out of `main`. Line order is not
 call order; the ordering is correct.
 
-**The bypass, reproduced.** `icnctl init-coop` runs `create_dir_all(<data_dir>/store)`,
+**The bypass, reproduced** (as `init-coop` stood at M4d; its path was corrected in #2718, which does
+not change what this evidence showed about gate coverage). `icnctl init-coop` ran
+`create_dir_all(<data_dir>/store)`,
 `SledStore::open` on it, and `TrustGraph::add_edge` — writing `trust/edges/`, a **registered**
 keyspace whose basis is `AwaitingDomainSignOff`, so a collision there fails closed however its
 disposition reads. On a real sled fixture holding an alias pair, the gate **refused** the data
@@ -1296,11 +1298,13 @@ every §11 disposition are untouched, and no readiness classification moves.
 - **`icnctl` is not proven exhaustively gated.** Four handlers are covered. Other subcommands touch
   the age keystore, snapshot files and backup archives; those are not sled and not N2-A-governed, and
   were not audited for other properties.
-- **`icnd` opens `<data_dir>/store/trust`; `icnctl init-coop` opens `<data_dir>/store` itself** as a
-  separate sibling sled database. The trust edges `init-coop` reports creating are therefore never
-  read by the daemon. That is a pre-existing functional defect, found while comparing call paths,
-  and is **recorded here rather than fixed** — repairing it changes `init-coop` semantics and belongs
-  to whoever owns that command.
+- ~~**`icnd` opens `<data_dir>/store/trust`; `icnctl init-coop` opens `<data_dir>/store` itself**~~
+  **— fixed in #2718.** M4d recorded this rather than fixing it: the wizard wrote its bootstrap trust
+  edges into a sibling sled database the daemon never reads, so it reported edges the node never saw.
+  The repair gave the layout an owner — `icn_core::config::trust_store_path` — that `icnd` and
+  `icnctl` both resolve through, instead of a documented convention plus a literal per caller.
+  Already-provisioned data directories keep their edges stranded in the old sibling database;
+  nothing migrates a row.
 - **The restart helpers remain ungated and unrestricted.** They are test-only by evidence, but they
   are ordinary `[[bin]]` targets with no `required-features`, so `cargo build --bins` produces them.
   The root `Dockerfile` builds them and copies only `icnd`/`icnctl`; `deploy/Dockerfile.icnd` avoids

--- a/icn/bins/icnctl/src/main.rs
+++ b/icn/bins/icnctl/src/main.rs
@@ -8443,9 +8443,9 @@ token_expiry_hours = 24
     // sled database `icnd` never opens, and the node started with an empty trust
     // graph (#2718). The path is now resolved through the same `icn-core` helper
     // the daemon uses, so the two cannot drift apart again.
-    let store_path = icn_core::config::trust_store_path(data_dir);
-    std::fs::create_dir_all(&store_path)?;
-    let store = SledStore::open(&store_path).context("Failed to open trust store")?;
+    let trust_store_path = icn_core::config::trust_store_path(data_dir);
+    std::fs::create_dir_all(&trust_store_path)?;
+    let store = SledStore::open(&trust_store_path).context("Failed to open trust store")?;
     let store = Arc::new(store);
     let mut trust_graph = TrustGraph::new(store, my_did.clone());
 

--- a/icn/bins/icnctl/src/main.rs
+++ b/icn/bins/icnctl/src/main.rs
@@ -2228,8 +2228,10 @@ fn get_keystore_path(data_dir: &Path) -> PathBuf {
     data_dir.join("identity.age")
 }
 
+/// The base store directory, resolved through the layout's owner in `icn-core`
+/// rather than re-derived here.
 fn get_store_path(data_dir: &Path) -> PathBuf {
-    data_dir.join("store")
+    icn_core::config::store_path(data_dir)
 }
 
 /// Refuse to touch a data directory the N2-A startup gate would refuse to open
@@ -8434,9 +8436,16 @@ token_expiry_hours = 24
     println!();
 
     // Step 7: Create trust edges for initial members
-    let store_path = get_store_path(data_dir);
+    //
+    // The daemon reads trust state from `<data_dir>/store/trust`. This opened
+    // `<data_dir>/store` — the directory that *contains* the per-domain stores —
+    // so every bootstrap edge the wizard reported creating went into a separate
+    // sled database `icnd` never opens, and the node started with an empty trust
+    // graph (#2718). The path is now resolved through the same `icn-core` helper
+    // the daemon uses, so the two cannot drift apart again.
+    let store_path = icn_core::config::trust_store_path(data_dir);
     std::fs::create_dir_all(&store_path)?;
-    let store = SledStore::open(&store_path).context("Failed to open store")?;
+    let store = SledStore::open(&store_path).context("Failed to open trust store")?;
     let store = Arc::new(store);
     let mut trust_graph = TrustGraph::new(store, my_did.clone());
 

--- a/icn/bins/icnctl/tests/init_coop_trust_path_test.rs
+++ b/icn/bins/icnctl/tests/init_coop_trust_path_test.rs
@@ -26,8 +26,12 @@ fn icnctl_bin() -> PathBuf {
     PathBuf::from(env!("CARGO_BIN_EXE_icnctl"))
 }
 
-/// The path `icnd` opens for trust state (`icnd/src/main.rs`, via
-/// `Config::store_path()`): `<data_dir>/store/trust`.
+/// The path `icnd` opens for trust state: `<data_dir>/store/trust`.
+///
+/// Spelled out here rather than called through `icn_core::config` on purpose —
+/// a test that resolved the path with the same helper the fix introduced would
+/// agree with the code by construction and could not catch the helper itself
+/// being wrong. `icnd` reaches this path via `Config::trust_store_path()`.
 fn daemon_trust_store_path(data_dir: &Path) -> PathBuf {
     data_dir.join("store").join("trust")
 }

--- a/icn/bins/icnctl/tests/init_coop_trust_path_test.rs
+++ b/icn/bins/icnctl/tests/init_coop_trust_path_test.rs
@@ -69,6 +69,15 @@ fn init_identity(data_dir: &Path) -> Output {
 fn run_init_coop(data_dir: &Path, member: &Did) -> Output {
     Command::new(icnctl_bin())
         .env("ICN_KEYSTORE_PASSPHRASE", PASSPHRASE)
+        // Step 6 probes `$ICN_GATEWAY/v1/health` (default `localhost:8080`) and,
+        // if `ICN_TOKEN` is set, POSTs a governance domain to it. A unit test
+        // must not create real state on whatever happens to be listening on a
+        // developer machine or a CI runner, so the gateway is pointed at a port
+        // nothing can be serving and the token is removed from the inherited
+        // environment. Step 7 — the step under test — runs either way, and this
+        // also drops the 3s health-check timeout from every run.
+        .env("ICN_GATEWAY", "http://127.0.0.1:1")
+        .env_remove("ICN_TOKEN")
         .arg("--data-dir")
         .arg(data_dir)
         .args([
@@ -152,7 +161,15 @@ fn init_coop_does_not_materialise_a_sled_database_at_the_store_root() {
     let member = fresh_did();
     assert!(init_identity(dir.path()).status.success());
 
-    run_init_coop(dir.path(), &member);
+    let out = run_init_coop(dir.path(), &member);
+    let text = combined(&out);
+    // Guard, for the same reason the sibling test has one: if the wizard failed
+    // before step 7 it would write nothing under `<data_dir>/store` at all, and
+    // both assertions below would pass while proving nothing.
+    assert!(
+        text.contains("Trust edges created"),
+        "the wizard must reach step 7 for this test to mean anything:\n{text}"
+    );
 
     let root = store_root(dir.path());
     for artifact in ["db", "conf"] {

--- a/icn/bins/icnctl/tests/init_coop_trust_path_test.rs
+++ b/icn/bins/icnctl/tests/init_coop_trust_path_test.rs
@@ -1,0 +1,166 @@
+//! A trust edge `init-coop` reports creating must be visible to the daemon (#2718).
+//!
+//! `icnctl init-coop` step 7 opened `<data_dir>/store` and wrote trust edges
+//! there; `icnd` reads trust state from `<data_dir>/store/trust`. Those are two
+//! different sled databases, so the wizard printed "✓ Trust edges created" and
+//! the node then started with an empty trust graph. Trust gates rate limiting,
+//! connection admission and federated placement, so a freshly initialised
+//! cooperative came up with none of its intended bootstrap trust.
+//!
+//! **The proof has to cross the writer/reader boundary.** A test that writes an
+//! edge and reads it back through the same handle — or through the same wrong
+//! path — passes on the defect and proves nothing. So these tests run the real
+//! `icnctl` binary, let the process exit (closing its sled handles), and then
+//! open the database *at the path the daemon uses*, resolved the way `icnd`
+//! resolves it.
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
+use std::path::{Path, PathBuf};
+use std::process::{Command, Output};
+
+use icn_identity::Did;
+use icn_store::{SledStore, Store};
+use tempfile::TempDir;
+
+fn icnctl_bin() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_icnctl"))
+}
+
+/// The path `icnd` opens for trust state (`icnd/src/main.rs`, via
+/// `Config::store_path()`): `<data_dir>/store/trust`.
+fn daemon_trust_store_path(data_dir: &Path) -> PathBuf {
+    data_dir.join("store").join("trust")
+}
+
+/// The directory that *contains* the per-domain stores. `init-coop` used to
+/// materialise a sled database here, nesting a root inside the tree the N2-A
+/// startup gate walks.
+fn store_root(data_dir: &Path) -> PathBuf {
+    data_dir.join("store")
+}
+
+fn fresh_did() -> Did {
+    icn_identity::KeyPair::generate().unwrap().did().clone()
+}
+
+/// A passphrase supplied the way `icnd` and every scripted `icnctl` call supply
+/// one, so the wizard runs without a TTY.
+const PASSPHRASE: &str = "m4d-2718-fixture-passphrase";
+
+/// Create the keystore first, so `init-coop` takes its *existing identity*
+/// branch.
+///
+/// The wizard's new-identity branch calls `rpassword` directly instead of the
+/// crate's `read_passphrase`/`confirm_passphrase` helpers, so it ignores
+/// `ICN_KEYSTORE_PASSPHRASE` and cannot run unattended. That is a separate
+/// defect from the one under test here and is recorded rather than fixed; this
+/// fixture sidesteps it by provisioning the identity through `id init`, which
+/// does honour the variable.
+fn init_identity(data_dir: &Path) -> Output {
+    Command::new(icnctl_bin())
+        .env("ICN_KEYSTORE_PASSPHRASE", PASSPHRASE)
+        .arg("--data-dir")
+        .arg(data_dir)
+        .args(["id", "init"])
+        .output()
+        .unwrap()
+}
+
+fn run_init_coop(data_dir: &Path, member: &Did) -> Output {
+    Command::new(icnctl_bin())
+        .env("ICN_KEYSTORE_PASSPHRASE", PASSPHRASE)
+        .arg("--data-dir")
+        .arg(data_dir)
+        .args([
+            "init-coop",
+            "--name",
+            "Trust Path Coop",
+            "--members",
+            member.as_str(),
+            "--yes",
+            "--no-start",
+        ])
+        .output()
+        .unwrap()
+}
+
+fn combined(out: &Output) -> String {
+    format!(
+        "{}{}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr)
+    )
+}
+
+/// Read `trust/edges/` rows through a freshly opened handle at `path`.
+///
+/// Opening here — after the `icnctl` process has exited — is what makes this a
+/// cross-process, cross-handle read rather than a round-trip through the
+/// writer's own state.
+fn trust_edge_rows(path: &Path) -> Vec<String> {
+    if !path.exists() {
+        return Vec::new();
+    }
+    let store = SledStore::open(path).unwrap();
+    let rows = store
+        .scan(b"trust/edges/")
+        .unwrap()
+        .into_iter()
+        .map(|(k, _)| String::from_utf8_lossy(&k).into_owned())
+        .collect();
+    drop(store);
+    rows
+}
+
+#[test]
+fn an_init_coop_trust_edge_is_readable_through_the_daemons_trust_store() {
+    let dir = TempDir::new().unwrap();
+    let member = fresh_did();
+    let id_out = init_identity(dir.path());
+    assert!(
+        id_out.status.success(),
+        "fixture setup: {}",
+        combined(&id_out)
+    );
+
+    let out = run_init_coop(dir.path(), &member);
+    let text = combined(&out);
+    assert!(
+        text.contains("Trust edges created"),
+        "the wizard must report creating trust edges — otherwise this test is \
+         not exercising the claim it exists to check:\n{text}"
+    );
+
+    // The whole point: read where the DAEMON reads, from a handle the wizard
+    // never held.
+    let seen = trust_edge_rows(&daemon_trust_store_path(dir.path()));
+    assert!(
+        seen.iter().any(|k| k.contains(member.as_str())),
+        "the edge `init-coop` reported creating must be present in the store \
+         `icnd` opens ({}); found {:?}\n{text}",
+        daemon_trust_store_path(dir.path()).display(),
+        seen
+    );
+}
+
+#[test]
+fn init_coop_does_not_materialise_a_sled_database_at_the_store_root() {
+    // `<data_dir>/store` is the directory that holds `trust/`, `ledger/`,
+    // `governance/` and the rest. A sled database opened *at* it nests a root
+    // inside the tree `find_sled_roots` walks for the N2-A startup gate.
+    let dir = TempDir::new().unwrap();
+    let member = fresh_did();
+    assert!(init_identity(dir.path()).status.success());
+
+    run_init_coop(dir.path(), &member);
+
+    let root = store_root(dir.path());
+    for artifact in ["db", "conf"] {
+        assert!(
+            !root.join(artifact).exists(),
+            "a sled `{artifact}` file at {} means a database was opened on the \
+             store root itself",
+            root.display()
+        );
+    }
+}

--- a/icn/bins/icnctl/tests/n2a_gate_coverage_test.rs
+++ b/icn/bins/icnctl/tests/n2a_gate_coverage_test.rs
@@ -45,9 +45,12 @@ fn alias_pair() -> (Did, Did) {
     (a, b)
 }
 
-/// `icnctl init-coop` opens `<data_dir>/store` itself as a sled database — a
-/// sibling of the daemon's `<data_dir>/store/{trust,ledger,...}` stores, and a
-/// sled root the gate discovers like any other.
+/// The directory that holds the per-domain stores. These fixtures plant their
+/// own rows here, so this is a sled root the gate discovers like any other.
+///
+/// `init-coop` used to materialise a database here too — that is how M4d found
+/// the path defect — but #2718 gave it the daemon's `store/trust` path, so the
+/// root is now this test's own construction and nothing else's.
 fn store_root(data_dir: &Path) -> PathBuf {
     data_dir.join("store")
 }

--- a/icn/bins/icnd/src/main.rs
+++ b/icn/bins/icnd/src/main.rs
@@ -121,7 +121,7 @@ async fn build_services(
     let own_did = bundle.did().clone();
 
     // Open trust store
-    let trust_store_path = config.store_path().join("trust");
+    let trust_store_path = config.trust_store_path();
     std::fs::create_dir_all(&trust_store_path)?;
     let trust_store: Arc<dyn icn_store::Store> =
         Arc::new(icn_store::SledStore::open(&trust_store_path)?);

--- a/icn/crates/icn-core/src/config/mod.rs
+++ b/icn/crates/icn-core/src/config/mod.rs
@@ -42,7 +42,7 @@ pub use trust::*;
 pub use icn_net::{FanoutConfig, NeighborLimitsConfig, NodeRole, TopologyConfig};
 
 use serde::{Deserialize, Serialize};
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 /// ICNd configuration
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -164,6 +164,28 @@ impl Default for Config {
     }
 }
 
+/// The base store path for a data directory (`{data_dir}/store/`).
+///
+/// A free function as well as a [`Config`] method because not every consumer of
+/// this layout holds a `Config`: `icnctl` works from a `--data-dir` alone. Both
+/// forms resolve here, so the layout has one owner instead of a documented
+/// convention plus a literal in each caller.
+pub fn store_path(data_dir: &Path) -> PathBuf {
+    data_dir.join("store")
+}
+
+/// The trust store path for a data directory (`{data_dir}/store/trust/`).
+///
+/// This existed only as a line in [`Config::store_path`]'s doc comment and as a
+/// `.join("trust")` literal inside `icnd`. `icnctl init-coop` re-derived the
+/// path itself, omitted the subdirectory, and wrote its bootstrap trust edges
+/// into `{data_dir}/store` — a different database from the one the daemon
+/// reads, so the wizard reported edges the node never saw (#2718). Naming the
+/// path here is what stops a third caller repeating that.
+pub fn trust_store_path(data_dir: &Path) -> PathBuf {
+    store_path(data_dir).join("trust")
+}
+
 impl Config {
     /// Load configuration from a TOML file
     pub fn from_file(path: impl AsRef<std::path::Path>) -> anyhow::Result<Self> {
@@ -193,7 +215,12 @@ impl Config {
     /// - `store/governance/`      — Governance actor state (proposals, votes)
     /// - `store/dead_letter/`     — Failed operation recovery queue
     pub fn store_path(&self) -> PathBuf {
-        self.data_dir.join("store")
+        store_path(&self.data_dir)
+    }
+
+    /// Get the trust store path (sled DB for trust edges, scores and attestations)
+    pub fn trust_store_path(&self) -> PathBuf {
+        trust_store_path(&self.data_dir)
     }
 
     /// Get the protocol parameter store path (sled DB for governance parameters)


### PR DESCRIPTION
<!-- ICN-DELIVERY-LIFECYCLE:BEGIN -->
- **State:** FROZEN at `71f99ac1` — re-frozen after the mandatory strict branch update. 11/11 required contexts green on the exact head, 0 unresolved threads, merge-base = `origin/main` `65795ca4`, evaluator `icn-merge-pr check 2726` → **READY**. Awaiting merge under the authorization given for this resulting head.
- **Lane:** #2718 — `init-coop` bootstrap trust edges are invisible to the daemon
- **Acceptance contract:** after `init-coop` creates the initial member trust relationship through the production writer path, the same edge is observable through the storage path the daemon uses, after close/reopen. Non-goals: trust semantics, `TrustEdge`, TrustGraph redesign, migration of already-stranded edges, #2627, the N2-A gate.
- **Review generation:** 1 bounded FULL review on `015caa3f` → **0 BLOCKER**, 5 FOLLOW_UP, 1 QUESTION, 4 NOT_A_FINDING, all dispositioned in `099e2794`. Generation CLOSED. One DELTA review on `099e2794 → 71f99ac1` → **0 BLOCKER** (see below).
- **Freeze head:** `71f99ac147dd0da0a43b060b9d50c73b68813a99` (was `099e2794`, invalidated by #2728 landing under `strict:true`)
- **Strict update — what moved, proven:** head is a 2-parent merge of `099e2794` + `65795ca4`; **zero** non-merge commits introduced; `gh pr diff` SHA-256 `329548531ac9…` **byte-identical** before and after, so this PR's own patch is unchanged; merge-base now equals `origin/main`.
- **DELTA review scope:** the delta is the branch-update merge alone, so the only live question is interaction with what #2728 landed. File sets are **disjoint** (#2728: `what-matters-now.sh`, its workflow, its test; #2726: Rust sources, two tests, one architecture doc). None of #2726's paths fall in any of the drift gate's three scopes (canonical truth files under `ops/state/`, skill symlinks, the stale-path scan of `ops/automation/skills` / `.claude/agents` / `.claude/skills` / `ops/CLAUDE.md`). Confirmed empirically: `Agent Tooling Drift Check` passed on the new head **under #2728's corrected aggregating machinery**, which is precisely why that PR was landed first.
- **Known blockers:** none open
- **Unresolved threads:** 0 (3 Copilot threads, all dispositioned in `099e2794`; no new material review since)
- **Non-required red:** `Security Audit` (#2579) and `Build and verify` (#2639) only — both separately owned and red on `main` itself, neither caused here. `UNSTABLE` is the expected colour; the merge contract is the 11 required contexts, all green.
- **Follow-up ledger:**
  - #2727 — `init-coop`'s new-identity branch ignores `ICN_KEYSTORE_PASSPHRASE`. **Canonical owner** (#2729 was a parallel-session duplicate, closed as `DUPLICATE` with its stronger acceptance language merged into #2727 first — including the criterion that the minimum-length check must survive, since `confirm_passphrase()` does not carry one).
  - #2725 — existing `icn.toml` `data_dir` not honoured. **Confirmed out of scope here, with evidence:** this PR's diff changes only the *subdirectory* resolution (`store` → `store/trust`) through a shared `icn-core` owner and never touches the existing-config branch or reads `icn.toml`'s `data_dir`. #2725 is a *root-path* disagreement, a distinct defect reached by a different route.
  - Historical already-stranded edges are not migrated. Safe path resolution is not a migration.
<!-- ICN-DELIVERY-LIFECYCLE:END -->

Closes #2718. Base `dd21b2d008963dad91cc9b1c8c485133680115a3`.

## The defect

`icnctl init-coop` step 7 opened `<data_dir>/store` and wrote bootstrap trust edges there. `icnd` reads trust state from `<data_dir>/store/trust`. Two different sled databases — so the wizard printed `✓ Trust edges created` and the node started with an empty trust graph. Trust gates rate limiting, connection admission and federated placement, so a freshly initialised cooperative came up with none of the trust it had just been told it had. An operator-visible false success.

## Root cause — narrower than a wrong string

`Config::store_path` **documents** the whole subdirectory layout in its doc comment (`store/trust/`, `store/ledger/`, `store/governance/`, …) but exposed helpers for only two of them: `ledger_store_path` and `protocol_params_path`. Trust had none. So `icnd` re-derived it as a `.join("trust")` literal, and the wizard re-derived it independently and dropped the subdirectory.

Every other sibling call in the workspace includes the subdirectory — including `icnctl`'s own ledger and cooperative commands (`get_store_path(data_dir).join("ledger")`, `…join("cooperative")`). This was the one site that did not, and a layout with a documented convention but no single owner is what made that possible.

## Fix — at the ownership level, not the call site

- `icn-core::config` gains free functions `store_path(&Path)` and `trust_store_path(&Path)`, plus `Config::trust_store_path()`, so consumers holding only a `--data-dir` resolve through the same owner as those holding a `Config`.
- `icnd` uses `config.trust_store_path()` instead of its literal.
- `icnctl`'s `get_store_path` delegates to the owner; step 7 uses `trust_store_path(data_dir)`.

The layout now has an owner instead of a convention. (Nothing *enforces* the helper — a caller can still write the literal, and `handle_snapshot_command` legitimately does for the directory of stores — so this is ownership, not impossibility.)

## Proof crosses the writer/reader boundary

A test that writes an edge and reads it back through the same handle — or the same wrong path — **passes on the defect**. So the fixtures run the real `icnctl` binary, let the process exit (closing its sled handles), and then open the database at the path `icnd` uses:

```
init-coop writer path → sled → process exit → <data_dir>/store/trust → edge present
```

**Pre-fix (MUST-FAIL), both fail:**

```
the edge `init-coop` reported creating must be present in the store
`icnd` opens (/tmp/.../store/trust); found []

a sled `db` file at /tmp/.../store means a database was opened on the store root
```

**Post-fix:** both pass. The first test also guards that the wizard actually printed `Trust edges created`, so it cannot silently stop exercising the claim it exists to check — that guard caught an earlier attempt where the wizard never reached step 7 at all.

The second test covers the issue's secondary hazard: `init-coop` no longer materialises a sled root at `<data_dir>/store`, so it no longer nests a database inside the tree the N2-A startup gate walks.

## Verification (local, on `099e2794`)

`cargo fmt --all --check` · `cargo clippy -p icnctl -p icn-core --all-targets --all-features -- -D warnings` (0) · `cargo test -p icnctl -p icn-core --all-features` → 813 passed, 71 suites, 1 unrelated failure: `dry_run_reports_collision_without_failing` hit sled flock contention under parallel execution and passes twice in isolation (known flake class, not this change — it opens `store/cooperative`, a path this PR does not touch) · meaning firewall · doc control · readiness · compliance · drift (PASS) · `git diff --check`.

## Bounded FULL review — findings and dispositions

One FULL review on `015caa3f`: **0 BLOCKER**, 5 FOLLOW_UP, 1 QUESTION, 4 NOT_A_FINDING. The contract was verified empirically, not just read: the reviewer hand-drove `id init` + `init-coop` against the built binary and confirmed `<data_dir>/store/trust/{db,conf,blobs}` exists and `<data_dir>/store/db` does not.

- **Test fixtures made live HTTP calls (FIXED).** `init-coop` step 6 probes `$ICN_GATEWAY/v1/health` (default `localhost:8080`) and POSTs a governance domain when `ICN_TOKEN` is set. The fixtures inherited both, so on a machine with a gateway up and a token exported a unit test would have created real governance state. I verified it is latent *here* (nothing listening, no token) — but that is luck about this host. Gateway now points at an unservable port, token removed from the environment.
- **Second test could pass vacuously (FIXED).** It discarded the wizard's exit status; had `init-coop` failed before step 7, nothing would be written under `<data_dir>/store` and both assertions would pass. Reachable with a malformed `--members` DID. Now carries the same guard its sibling has.
- **Migration-gate §10.7 and an M4d fixture comment became false (FIXED).** Both said this defect was recorded-not-fixed. Corrected to record the repair and the surviving debt; the M4d reproduction paragraph is scoped to what it showed about gate coverage, which this path fix does not change.
- **Commit-message overclaim (WITHDRAWN).** "A third caller cannot now drift" — nothing enforces the helper, and `handle_snapshot_command` still uses the literal (correctly, for the directory rather than a database). The accurate claim is ownership, not impossibility.
- **QUESTION — `Trust edges created for 0 member(s)`** on a single-member `init-coop`: the count comes from the parsed member list, not from write outcomes, so it prints having written nothing. Pre-existing and outside this contract; left alone rather than folded in.

The review independently confirmed `store/trust` is the durable contract (verified three ways, including that both sides construct plain `TrustGraph` whose `DEFAULT_PREFIX` yields the same `trust/edges/` namespace — so the rows land where the daemon's reader scans, not merely in the directory it opens), that the test cannot pass on the unfixed code, that `Config::store_path()` is behaviour-identical, and that there is no layering problem, no gate regression, no migration, and no scope leak.

**Three further Copilot threads, all dispositioned in `099e2794`:**

- **Second test could pass vacuously** — raised against `015caa3f`, already fixed in `7c320a1e`. The reviewer was right that it was reachable: a malformed `--members` DID exits before step 7.
- **Step 7's local was still named `store_path`** while holding `.../store/trust` (FIXED) — the exact misreading the defect came from, left in the line that fixes it.
- **Test helper's doc comment named the old resolver** (FIXED). It now also records *why* the helper spells the path literally rather than calling `icn_core::config`: a test resolving it through the same helper the fix introduced would agree with the code by construction and could not catch the helper itself being wrong.

## Explicit non-claims

- **No trust semantics change.** No `TrustEdge`, score, or TrustGraph change.
- **No migration.** Data directories already provisioned by the old wizard keep their edges stranded in the sibling `<data_dir>/store` database. Nothing here moves a row, and recovering them is a separate decision — as the issue requires, this is stated rather than silently done.
- **New finding, recorded not fixed:** `init-coop`'s *new-identity* branch calls `rpassword` directly instead of the crate's own `read_passphrase`/`confirm_passphrase` helpers, so it ignores `ICN_KEYSTORE_PASSPHRASE` and cannot run unattended on a fresh machine — unlike every other `icnctl` path. The fixtures provision the identity via `id init` to work around it. Needs its own issue.
- **#2627 untouched**, N2-A gate untouched, #2717 untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


