### PR TITLE
fix(ops): stop the drift gate aborting on its first finding (#2723)

### DIFF
--- a/.github/workflows/agent-drift-check.yml
+++ b/.github/workflows/agent-drift-check.yml
@@ -20,6 +20,7 @@ on:
       - 'scripts/check-merge-policy-schema.py'
       - 'scripts/tests/test_merge_policy_schema.py'
       - 'scripts/tests/test_what_matters_now_json.py'
+      - 'scripts/tests/test_what_matters_now_drift.py'
       # icn#2651 stage B: the executable that owns ordinary-merge semantics, and its controls.
       - 'tools/icn-merge-pr/**'
       - 'scripts/tests/test_icn_merge_pr.py'
@@ -165,6 +166,12 @@ jobs:
 
       - name: what-matters-now --json is machine-readable (Refs icn#2638)
         run: python3 scripts/tests/test_what_matters_now_json.py
+
+      # icn#2723: the step above this one is the gate itself, and it could exit
+      # non-zero with no output at all -- so a red required check said nothing.
+      # This asserts the report is actually reached and that findings aggregate.
+      - name: what-matters-now --drift reports what it found (Refs icn#2723)
+        run: python3 scripts/tests/test_what_matters_now_drift.py
 
       - name: what-matters-now human mode still renders
         run: bash ops/scripts/what-matters-now.sh > /dev/null

--- a/ops/scripts/what-matters-now.sh
+++ b/ops/scripts/what-matters-now.sh
@@ -272,8 +272,8 @@ if [[ "${MODE}" == "--drift" ]]; then
       echo "  Missing canonical truth files:"
       printf '%s' "${MISSING_TRUTH_FILES}"
     fi
-    [[ "${SYMLINKS_OK}" == "false" ]] && printf "${SYMLINK_WARNINGS}"
-    [[ -n "${STALE_HITS}" ]] && printf "Stale paths:\n${STALE_HITS}"
+    [[ "${SYMLINKS_OK}" == "false" ]] && printf '%s' "${SYMLINK_WARNINGS}"
+    [[ -n "${STALE_HITS}" ]] && printf 'Stale paths:\n%s' "${STALE_HITS}"
     exit 1
   fi
   echo "OK: no drift detected"
@@ -324,7 +324,7 @@ section "Skill Symlinks"
 if [[ "${SYMLINKS_OK}" == "true" ]]; then
   echo "  ✓ status, sync-and-build, worktree → ops/automation/skills/"
 else
-  printf "  ✗ Problems:\n${SYMLINK_WARNINGS}"
+  printf '  ✗ Problems:\n%s' "${SYMLINK_WARNINGS}"
   echo "  Fix: bash ops/scripts/setup-skill-symlinks.sh"
 fi
 
@@ -332,7 +332,7 @@ section "Drift Check"
 if [[ ${DRIFT_ERRORS} -eq 0 ]]; then
   echo "  ✓ No stale paths detected"
 elif [[ -n "${STALE_HITS}" ]]; then
-  printf "  ✗ Stale path hits:\n${STALE_HITS}"
+  printf '  ✗ Stale path hits:\n%s' "${STALE_HITS}"
 fi
 
 echo ""

--- a/ops/scripts/what-matters-now.sh
+++ b/ops/scripts/what-matters-now.sh
@@ -81,16 +81,16 @@ if [[ -d "${PROJECT_SKILLS}" ]]; then
       canonical="${REPO_ROOT}/ops/automation/skills/${skill}"
       if [[ "${resolved}" != "${canonical}" ]]; then
         SYMLINKS_OK=false
-        SYMLINK_WARNINGS+="  WRONG TARGET: .claude/skills/${skill} → ${resolved}\n"
+        SYMLINK_WARNINGS+="  WRONG TARGET: .claude/skills/${skill} → ${resolved}"$'\n'
         DRIFT_ERRORS=$(( DRIFT_ERRORS + 1 ))
       fi
     elif [[ -d "${link}" ]]; then
       SYMLINKS_OK=false
-      SYMLINK_WARNINGS+="  NOT SYMLINK: .claude/skills/${skill} is a plain directory (run ops/scripts/setup-skill-symlinks.sh)\n"
+      SYMLINK_WARNINGS+="  NOT SYMLINK: .claude/skills/${skill} is a plain directory (run ops/scripts/setup-skill-symlinks.sh)"$'\n'
       DRIFT_ERRORS=$(( DRIFT_ERRORS + 1 ))
     else
       SYMLINKS_OK=false
-      SYMLINK_WARNINGS+="  MISSING: .claude/skills/${skill} (run ops/scripts/setup-skill-symlinks.sh)\n"
+      SYMLINK_WARNINGS+="  MISSING: .claude/skills/${skill} (run ops/scripts/setup-skill-symlinks.sh)"$'\n'
       DRIFT_ERRORS=$(( DRIFT_ERRORS + 1 ))
     fi
   done
@@ -118,9 +118,9 @@ for pattern in "${STALE_PATTERNS[@]}"; do
     if [[ -e "${full_dir}" ]]; then
       hits=$(grep -rn "${pattern}" "${full_dir}" 2>/dev/null | grep -v ".pyc" | grep -v "Binary" || true)
       if [[ -n "${hits}" ]]; then
-        STALE_HITS+="  [${pattern}] in ${dir}:\n"
+        STALE_HITS+="  [${pattern}] in ${dir}:"$'\n'
         while IFS= read -r line; do
-          STALE_HITS+="    ${line}\n"
+          STALE_HITS+="    ${line}"$'\n'
         done <<< "${hits}"
         DRIFT_ERRORS=$(( DRIFT_ERRORS + 1 ))
       fi

--- a/ops/scripts/what-matters-now.sh
+++ b/ops/scripts/what-matters-now.sh
@@ -17,6 +17,11 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
 
 MODE="${1:-human}"
+# Counted with an assignment, never `((DRIFT_ERRORS++))`. Under `set -e` an
+# arithmetic *command* whose value is zero exits 1, and post-increment evaluates to
+# the value before the increment -- so the very first drift (0 -> 1) aborted this
+# script and the report below became unreachable exactly when it had something to
+# say (icn#2723).
 DRIFT_ERRORS=0
 
 # ─── helpers ────────────────────────────────────────────────────────────────
@@ -27,7 +32,7 @@ check_file() {
   local f="$1"
   if [[ ! -f "${REPO_ROOT}/${f}" ]]; then
     echo "MISSING: ${f}" >&2
-    ((DRIFT_ERRORS++))
+    DRIFT_ERRORS=$(( DRIFT_ERRORS + 1 ))
     return 1
   fi
   return 0
@@ -47,10 +52,15 @@ TRUTH_FILES=(
 )
 
 TRUTH_OK=true
+MISSING_TRUTH_FILES=""
 for f in "${TRUTH_FILES[@]}"; do
   if [[ ! -f "${REPO_ROOT}/${f}" ]]; then
     TRUTH_OK=false
-    ((DRIFT_ERRORS++))
+    # Record which one. This loop previously counted silently, so the report
+    # below could say only "Missing canonical truth files" and an operator was
+    # left to find the gap by hand (icn#2723).
+    MISSING_TRUTH_FILES="${MISSING_TRUTH_FILES}    ${f}"$'\n'
+    DRIFT_ERRORS=$(( DRIFT_ERRORS + 1 ))
   fi
 done
 
@@ -72,16 +82,16 @@ if [[ -d "${PROJECT_SKILLS}" ]]; then
       if [[ "${resolved}" != "${canonical}" ]]; then
         SYMLINKS_OK=false
         SYMLINK_WARNINGS+="  WRONG TARGET: .claude/skills/${skill} → ${resolved}\n"
-        ((DRIFT_ERRORS++))
+        DRIFT_ERRORS=$(( DRIFT_ERRORS + 1 ))
       fi
     elif [[ -d "${link}" ]]; then
       SYMLINKS_OK=false
       SYMLINK_WARNINGS+="  NOT SYMLINK: .claude/skills/${skill} is a plain directory (run ops/scripts/setup-skill-symlinks.sh)\n"
-      ((DRIFT_ERRORS++))
+      DRIFT_ERRORS=$(( DRIFT_ERRORS + 1 ))
     else
       SYMLINKS_OK=false
       SYMLINK_WARNINGS+="  MISSING: .claude/skills/${skill} (run ops/scripts/setup-skill-symlinks.sh)\n"
-      ((DRIFT_ERRORS++))
+      DRIFT_ERRORS=$(( DRIFT_ERRORS + 1 ))
     fi
   done
 fi
@@ -112,7 +122,7 @@ for pattern in "${STALE_PATTERNS[@]}"; do
         while IFS= read -r line; do
           STALE_HITS+="    ${line}\n"
         done <<< "${hits}"
-        ((DRIFT_ERRORS++))
+        DRIFT_ERRORS=$(( DRIFT_ERRORS + 1 ))
       fi
     fi
   done
@@ -258,7 +268,10 @@ fi
 if [[ "${MODE}" == "--drift" ]]; then
   if [[ ${DRIFT_ERRORS} -gt 0 ]]; then
     echo "DRIFT DETECTED: ${DRIFT_ERRORS} problem(s)"
-    [[ "${TRUTH_OK}" == "false" ]] && echo "  Missing canonical truth files"
+    if [[ "${TRUTH_OK}" == "false" ]]; then
+      echo "  Missing canonical truth files:"
+      printf '%s' "${MISSING_TRUTH_FILES}"
+    fi
     [[ "${SYMLINKS_OK}" == "false" ]] && printf "${SYMLINK_WARNINGS}"
     [[ -n "${STALE_HITS}" ]] && printf "Stale paths:\n${STALE_HITS}"
     exit 1

--- a/scripts/tests/test_what_matters_now_drift.py
+++ b/scripts/tests/test_what_matters_now_drift.py
@@ -1,0 +1,161 @@
+#!/usr/bin/env python3
+"""Executable consumer + regression gate for `what-matters-now.sh --drift` (icn#2723).
+
+`Agent Tooling Drift Check` is a *required* context, and this script is what it
+runs. Under `set -euo pipefail` the drift count was kept with `((DRIFT_ERRORS++))`,
+and an arithmetic *command* whose value is zero exits 1. Post-increment evaluates
+to the value **before** the increment, so the very first drift (0 -> 1) aborted the
+script: the `DRIFT DETECTED: N problem(s)` report was unreachable exactly when it
+had something to say, findings could not aggregate, and `exit ${DRIFT_ERRORS}`
+could only ever run with `0`.
+
+Measured on the pre-fix script: one missing canonical truth file produced exit 1
+with **completely empty stdout and stderr** -- the truth-file loop counts without
+printing, so a required check went red and said nothing at all.
+
+The controls below fail against the pre-fix form. A gate that cannot fail is not
+a gate.
+"""
+
+import os
+import re
+import shutil
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPT_REL = "ops/scripts/what-matters-now.sh"
+
+FAILURES = []
+
+
+def check(desc, cond):
+    print(("  ok   " if cond else "  FAIL ") + desc)
+    if not cond:
+        FAILURES.append(desc)
+
+
+def git(cwd, *args):
+    subprocess.run(
+        ["git", "-c", "user.email=t@t", "-c", "user.name=t", *args],
+        cwd=cwd,
+        check=True,
+        capture_output=True,
+    )
+
+
+def make_fixture(tmp):
+    """A minimal repo the script will accept: a git checkout carrying `ops/`.
+
+    The real `ops/` tree is copied rather than synthesised, so the fixture cannot
+    drift from what the script actually inspects.
+    """
+    root = Path(tmp) / "repo"
+    root.mkdir()
+    git(root, "init", "-q", ".")
+    shutil.copytree(REPO_ROOT / "ops", root / "ops", symlinks=True)
+    git(root, "add", "-A")
+    git(root, "commit", "-q", "-m", "fixture")
+    return root
+
+
+def run_drift(root):
+    proc = subprocess.run(
+        ["bash", SCRIPT_REL, "--drift"],
+        cwd=root,
+        capture_output=True,
+        text=True,
+    )
+    return proc.returncode, proc.stdout + proc.stderr
+
+
+print("--- a clean tree reports clean and exits 0 ---")
+with tempfile.TemporaryDirectory() as tmp:
+    root = make_fixture(tmp)
+    rc, out = run_drift(root)
+    check("clean tree exits 0 (rc=%d)" % rc, rc == 0)
+    check("clean tree says so (%r)" % out.strip()[:60], "no drift detected" in out)
+
+print()
+print("--- one drift is reported, not silently aborted ---")
+with tempfile.TemporaryDirectory() as tmp:
+    root = make_fixture(tmp)
+    (root / "ops/state/truth/agents.json").unlink()
+    rc, out = run_drift(root)
+    check("one drift exits non-zero (rc=%d)" % rc, rc != 0)
+    # This is the assertion the pre-fix script could not satisfy: it exited 1
+    # with no output whatsoever.
+    check("the DRIFT DETECTED report is reached (output=%r)" % out.strip()[:80],
+          "DRIFT DETECTED" in out)
+    check("the report counts exactly one problem",
+          re.search(r"DRIFT DETECTED: 1 problem", out) is not None)
+    check("the report names the file that is missing, not just that some are",
+          "ops/state/truth/agents.json" in out)
+
+print()
+print("--- findings aggregate; they did not before, because the first aborted ---")
+with tempfile.TemporaryDirectory() as tmp:
+    root = make_fixture(tmp)
+    (root / "ops/state/truth/agents.json").unlink()
+    (root / "ops/state/truth/skills.json").unlink()
+    rc, out = run_drift(root)
+    check("two drifts still exit non-zero (rc=%d)" % rc, rc != 0)
+    check("the count aggregates to 2 (output=%r)" % out.strip()[:80],
+          re.search(r"DRIFT DETECTED: 2 problem", out) is not None)
+    check("both missing files are named",
+          "ops/state/truth/agents.json" in out and "ops/state/truth/skills.json" in out)
+
+print()
+print("--- no counter in this script can abort under `set -e` ---")
+script = (REPO_ROOT / SCRIPT_REL).read_text()
+
+# `((VAR++))` / `((VAR--))` as a *command* is the hazard: its exit status is 1
+# whenever the expression evaluates to 0. Assignment forms are safe.
+UNSAFE = re.compile(r"^\s*\(\(\s*[A-Za-z_][A-Za-z0-9_]*\s*(\+\+|--)\s*\)\)", re.M)
+UNSAFE_PREFIX = re.compile(r"^\s*\(\(\s*(\+\+|--)\s*[A-Za-z_][A-Za-z0-9_]*\s*\)\)", re.M)
+
+check("the script sets -e (otherwise this whole class is moot)",
+      re.search(r"^set -[a-z]*e", script, re.M) is not None)
+check("no `((VAR++))` / `((VAR--))` command form remains (found %d)"
+      % len(UNSAFE.findall(script)), not UNSAFE.search(script))
+check("no `((++VAR))` / `((--VAR))` command form either (found %d)"
+      % len(UNSAFE_PREFIX.findall(script)), not UNSAFE_PREFIX.search(script))
+check("the drift counter is incremented by assignment",
+      re.search(r"DRIFT_ERRORS=\$\(\(\s*DRIFT_ERRORS\s*\+\s*1\s*\)\)", script) is not None)
+
+print()
+print("--- MUST-FAIL controls (a gate that cannot fail is not a gate) ---")
+PRE_FIX = "    ((DRIFT_ERRORS++))\n"
+check("CONTROL: the matcher recognises the pre-fix increment",
+      UNSAFE.search(PRE_FIX) is not None)
+check("CONTROL: the matcher recognises a pre-increment variant",
+      UNSAFE_PREFIX.search("  ((++N))\n") is not None)
+check("CONTROL: the matcher does NOT flag the assignment form",
+      UNSAFE.search("  N=$(( N + 1 ))\n") is None)
+
+# The shell semantics this whole issue rests on, asserted rather than assumed.
+probe = subprocess.run(
+    ["bash", "-c", 'set -euo pipefail; N=0; ((N++)); echo "reached"'],
+    capture_output=True, text=True,
+)
+check("CONTROL: `((N++))` with N=0 really does abort under `set -e` "
+      "(rc=%d, stdout=%r)" % (probe.returncode, probe.stdout.strip()),
+      probe.returncode != 0 and "reached" not in probe.stdout)
+
+safe_probe = subprocess.run(
+    ["bash", "-c", 'set -euo pipefail; N=0; N=$(( N + 1 )); echo "reached $N"'],
+    capture_output=True, text=True,
+)
+check("CONTROL: the assignment form does not abort (rc=%d, stdout=%r)"
+      % (safe_probe.returncode, safe_probe.stdout.strip()),
+      safe_probe.returncode == 0 and "reached 1" in safe_probe.stdout)
+
+print()
+if FAILURES:
+    print("test_what_matters_now_drift: %d check(s) FAILED" % len(FAILURES))
+    for f in FAILURES:
+        print("  - " + f)
+    sys.exit(1)
+print("test_what_matters_now_drift: all checks passed")

--- a/scripts/tests/test_what_matters_now_drift.py
+++ b/scripts/tests/test_what_matters_now_drift.py
@@ -17,7 +17,6 @@ The controls below fail against the pre-fix form. A gate that cannot fail is not
 a gate.
 """
 
-import os
 import re
 import shutil
 import subprocess

--- a/scripts/tests/test_what_matters_now_drift.py
+++ b/scripts/tests/test_what_matters_now_drift.py
@@ -107,6 +107,38 @@ with tempfile.TemporaryDirectory() as tmp:
           "ops/state/truth/agents.json" in out and "ops/state/truth/skills.json" in out)
 
 print()
+print("--- every diagnostic channel renders as separate lines, not one run-on ---")
+# icn#2723 review: switching these `printf`s to a literal `%s` format stopped the
+# old accidental escape processing, so accumulators appending a two-character
+# `\n` collapsed into a single line. Nothing exercised the symlink or stale-path
+# channels, which is exactly why that landed unnoticed. It is covered now.
+with tempfile.TemporaryDirectory() as tmp:
+    root = make_fixture(tmp)
+    (root / "ops/state/truth/agents.json").unlink()
+
+    # `PROJECT_SKILLS` is `${REPO_ROOT}/../.claude/skills` -- a sibling of the repo.
+    skills = Path(tmp) / ".claude/skills"
+    skills.mkdir(parents=True)
+    (skills / "status").mkdir()            # plain dir  -> NOT SYMLINK
+    # `sync-and-build` and `worktree` are simply absent -> MISSING (two more)
+
+    # A stale pattern the script greps for, in a file it scans.
+    (root / "ops/CLAUDE.md").write_text("see sync-from-icn.sh for details\n")
+
+    rc, out = run_drift(root)
+    check("multi-channel drift exits non-zero (rc=%d)" % rc, rc != 0)
+    check("findings from every phase aggregate (output=%r)" % out.strip()[:60],
+          re.search(r"DRIFT DETECTED: (?!0|1\b)\d+ problem", out) is not None)
+
+    # The regression this covers: literal backslash-n reaching the terminal.
+    check("no literal backslash-n leaks into the report",
+          "\\n" not in out)
+    check("symlink findings are on their own lines",
+          any(l.strip().startswith("NOT SYMLINK:") for l in out.splitlines()))
+    check("the stale-path finding is on its own line",
+          any(l.strip().startswith("[sync-from-icn.sh]") for l in out.splitlines()))
+
+print()
 print("--- no counter in this script can abort under `set -e` ---")
 script = (REPO_ROOT / SCRIPT_REL).read_text()
 
@@ -133,6 +165,22 @@ check("CONTROL: the matcher recognises a pre-increment variant",
       UNSAFE_PREFIX.search("  ((++N))\n") is not None)
 check("CONTROL: the matcher does NOT flag the assignment form",
       UNSAFE.search("  N=$(( N + 1 ))\n") is None)
+
+# `printf "$VAR"` treats content as a FORMAT: `%s` silently eats what follows.
+fmt_probe = subprocess.run(
+    ["bash", "-c", 'S=$(printf "a%%sb"); printf "$S"'],
+    capture_output=True, text=True,
+)
+check("CONTROL: `printf \"$VAR\"` really does eat content (got %r)"
+      % fmt_probe.stdout, fmt_probe.stdout == "ab")
+fmt_safe = subprocess.run(
+    ["bash", "-c", 'S=$(printf "a%%sb"); printf "%s" "$S"'],
+    capture_output=True, text=True,
+)
+check("CONTROL: `printf '%%s' \"$VAR\"` preserves it (got %r)"
+      % fmt_safe.stdout, fmt_safe.stdout == "a%sb")
+check("the script never passes a variable as a printf format",
+      re.search(r'printf\s+"\$\{', script) is None)
 
 # The shell semantics this whole issue rests on, asserted rather than assumed.
 probe = subprocess.run(


### PR DESCRIPTION
Closes #2723.

<!-- ICN-DELIVERY-LIFECYCLE:BEGIN -->
```
ICN DELIVERY LIFECYCLE
State:                FROZEN  (11/11 required contexts green on the exact head;
                      awaiting explicit human merge authorization)
Lane:                 FAST -- required-gate observability
Acceptance contract:  when drift exists the script must continue through every check, count
                      each finding, reach the final report, print bounded actionable
                      diagnostics, and exit non-zero. When none exists it must inspect every
                      check, report clean, and exit zero.
Review generation:    1 bounded FULL review -> 1 BLOCKER, 2 FOLLOW_UP, 0 QUESTION,
                      6 NOT_A_FINDING. The blocker (a newline regression introduced by this
                      PR's own printf fix) and the coverage gap that hid it are both fixed in
                      2cfcc29c4. Generation CLOSED; review is now DELTA only.
Freeze head:          2cfcc29c418afc5e4d796db35496a0c2bc64f979
Base:                 main dd21b2d008963dad91cc9b1c8c485133680115a3 -- merge-base equals
                      origin/main (strict:true satisfied)
Known blockers:       none open
Unresolved threads:   0 (3 Copilot threads: two valid and fixed, one declined with evidence)
Non-required red:     Security Audit only (icn#2579) -- red on main itself, not caused here
Follow-up ledger:     (1) icn#2722 -- ${SPRINT_FILE} still spliced into python3 source in this
                          same file; deliberately untouched, separate owner
                      (2) check_file() has no callers, so one of the six corrected increments
                          is dead code. Pre-existing; fails `introduced_here`. Deleting a
                          helper is a separate decision from making a counter safe
```
<!-- ICN-DELIVERY-LIFECYCLE:END -->

## The defect

`Agent Tooling Drift Check` is one of the **11 required contexts**, and `ops/scripts/what-matters-now.sh --drift` is what it runs.

Under `set -euo pipefail` the count was kept with `((DRIFT_ERRORS++))`. An arithmetic **command** whose value is zero exits 1, and post-increment evaluates to the value *before* the increment — so the very first drift, `0 → 1`, aborted the script.

Everything downstream became unreachable exactly when it mattered: the `DRIFT DETECTED: N problem(s)` report, the per-category detail lines, and `exit ${DRIFT_ERRORS}` — which could only ever run with `0`.

## Reproduced before changing anything

A git fixture carrying the real `ops/` tree, with one canonical truth file removed, run against the **pre-fix** script:

```
exit 1
stdout: (empty)
stderr: (empty)
```

**A required check went red and said nothing at all.** That is worse than a failing check — it is a control that stops before producing the evidence it exists to produce. The truth-file loop counts *silently* (the `MISSING:` message lives in `check_file`, which that loop does not use), so there was not even a partial clue.

## The fix

All six increments become `DRIFT_ERRORS=$(( DRIFT_ERRORS + 1 ))`, whose exit status does not depend on the value. The declaration carries a note so the form is not "simplified" back later.

Two repairs the same acceptance contract requires:

- the canonical-truth loop now **records which files are missing**, so the report names them instead of saying only "Missing canonical truth files";
- the test is wired into the workflow **beside the gate it guards** — a mode with no runner is how the original defect survived, and #2688 had just established that pattern.

## Behaviour now

```
clean tree   ->  "OK: no drift detected"                                    exit 0
one drift    ->  "DRIFT DETECTED: 1 problem(s)" + the file named            exit 1
two drifts   ->  "DRIFT DETECTED: 2 problem(s)" + both named                exit 1
```

**Aggregation is the load-bearing case.** It was impossible before, because the first finding ended the run.

## Proof the tests discriminate

`scripts/tests/test_what_matters_now_drift.py` — 18 checks, all passing. With only the six increments reverted, **7 fail**, including both behavioural assertions reporting `output=''`.

The controls assert the shell semantics rather than assuming them: `((N++))` with `N=0` under `set -e` is *executed* and shown to abort, and the assignment form is shown not to. The matcher is also proved to recognise the pre-fix form and to **not** flag the safe form, so it cannot pass by being blind.

Per the issue's C3 requirement, the structural check rejects `((VAR++))`, `((VAR--))`, `((++VAR))` **and** `((--VAR))` anywhere in the script — a different unsafe counter cannot be introduced later on the same executed path. I swept `ops/scripts/` for the same hazard: **`what-matters-now.sh` is the only `set -e` script that carried it.**

## Non-goals

- **Does not weaken the required context.** Drift still exits non-zero; it now explains itself.
- **#2722 is untouched** — `${SPRINT_FILE}` is still spliced into `python3` source in this same file. Different defect, separate owner, deliberately not folded in.
- No change to what counts as drift, only to whether the script survives long enough to report it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
