### PR TITLE
fix(ops): stop what-matters-now splicing the checkout path into Python source (#2722)

### DIFF
--- a/.github/workflows/agent-drift-check.yml
+++ b/.github/workflows/agent-drift-check.yml
@@ -21,6 +21,7 @@ on:
       - 'scripts/tests/test_merge_policy_schema.py'
       - 'scripts/tests/test_what_matters_now_json.py'
       - 'scripts/tests/test_what_matters_now_drift.py'
+      - 'scripts/tests/test_what_matters_now_sprint_path.py'
       # icn#2651 stage B: the executable that owns ordinary-merge semantics, and its controls.
       - 'tools/icn-merge-pr/**'
       - 'scripts/tests/test_icn_merge_pr.py'
@@ -172,6 +173,13 @@ jobs:
       # This asserts the report is actually reached and that findings aggregate.
       - name: what-matters-now --drift reports what it found (Refs icn#2723)
         run: python3 scripts/tests/test_what_matters_now_drift.py
+
+      # icn#2722: the sprint/policy lookups spliced the checkout path into Python
+      # source, so a path containing a legal `'` silently misreported (and could
+      # execute code). This drives the script from such a path and forbids the
+      # class structurally, so it cannot return on a new site.
+      - name: what-matters-now survives a quoted checkout path (Refs icn#2722)
+        run: python3 scripts/tests/test_what_matters_now_sprint_path.py
 
       - name: what-matters-now human mode still renders
         run: bash ops/scripts/what-matters-now.sh > /dev/null

--- a/ops/scripts/drift-check.sh
+++ b/ops/scripts/drift-check.sh
@@ -24,14 +24,19 @@ ok()   { [[ "${VERBOSE}" == "--verbose" ]] && echo "OK:   $*" || true; }
 # trees are canonical and which are provider-facing; adding a tree or a skill must never require
 # editing a shell array here (icn#2633).
 REGISTRY="${REPO_ROOT}/ops/state/truth/skills.json"
+# Registry path via sys.argv, never spliced into the Python source: ${REGISTRY}
+# is derived from REPO_ROOT (the checkout path), and a single quote is a legal
+# POSIX path component, so splicing it closed the string literal and parsed the
+# rest as Python -- the class icn#2638/#2688 removed from the --json payload and
+# icn#2722 removed from what-matters-now.sh (icn#2722 sweep).
 mapfile -t SKILL_TREES < <(python3 -c "
 import json,sys
-try: d=json.load(open('${REGISTRY}'))
+try: d=json.load(open(sys.argv[1]))
 except Exception: sys.exit(0)
 s=d.get('enforcement',{}).get('scan_scope',{})
 for t in s.get('canonical_trees',[])+s.get('provider_trees',[]):
     if t.strip(): print(t.strip())
-" 2>/dev/null || true)
+" "${REGISTRY}" 2>/dev/null || true)
 if [[ "${#SKILL_TREES[@]}" -eq 0 ]]; then
   fail "could not derive skill scan scope from ops/state/truth/skills.json#enforcement.scan_scope"
   SKILL_TREES=(".agents/skills" ".claude/skills" "ops/automation/skills")
@@ -86,12 +91,13 @@ PROJECT_SKILLS="${REPO_ROOT}/../.claude/skills"
 CANONICAL_SKILLS="${REPO_ROOT}/ops/automation/skills"
 
 if [[ -d "${PROJECT_SKILLS}" ]]; then
+  # Registry path via sys.argv, not source (icn#2722 sweep).
   mapfile -t SYMLINK_SKILLS < <(python3 -c "
 import json,sys
-try: d=json.load(open('${REGISTRY}'))
+try: d=json.load(open(sys.argv[1]))
 except Exception: sys.exit(0)
 print('\n'.join(e['name'] for e in d['skills'].get('ops_automation_canonical', [])))
-" 2>/dev/null || true)
+" "${REGISTRY}" 2>/dev/null || true)
 
   for skill in "${SYMLINK_SKILLS[@]}"; do
     link="${PROJECT_SKILLS}/${skill}"
@@ -257,15 +263,16 @@ done
 
 POLICY_FILE="${REPO_ROOT}/ops/state/truth/policy.json"
 if [[ -f "${POLICY_FILE}" ]]; then
+  # Policy path via sys.argv, not source (icn#2722 sweep).
   REQUIRED_CHECK_COUNT=$(python3 -c "
 import json, sys
 try:
-    d = json.load(open('${POLICY_FILE}'))
+    d = json.load(open(sys.argv[1]))
     checks = d['merge']['required_checks']
     print(len(checks))
 except Exception as e:
     print(0)
-" 2>/dev/null || echo "0")
+" "${POLICY_FILE}" 2>/dev/null || echo "0")
 
   if [[ "${REQUIRED_CHECK_COUNT}" -ge 11 ]]; then
     ok "policy.json has ${REQUIRED_CHECK_COUNT} required checks"
@@ -280,12 +287,13 @@ AGENTS_FILE="${REPO_ROOT}/ops/state/truth/agents.json"
 AGENTS_DIR="${REPO_ROOT}/.claude/agents"
 
 if [[ -f "${AGENTS_FILE}" ]] && [[ -d "${AGENTS_DIR}" ]]; then
+  # Agents-registry path via sys.argv, not source (icn#2722 sweep).
   registered=$(python3 -c "
-import json
-d = json.load(open('${AGENTS_FILE}'))
+import json, sys
+d = json.load(open(sys.argv[1]))
 names = {a['name'] for a in d['agents']}
 print('\n'.join(sorted(names)))
-" 2>/dev/null || echo "")
+" "${AGENTS_FILE}" 2>/dev/null || echo "")
 
   for agent_file in "${AGENTS_DIR}"/*.md; do
     agent_name=$(basename "${agent_file}" .md)

--- a/ops/scripts/setup-skill-symlinks.sh
+++ b/ops/scripts/setup-skill-symlinks.sh
@@ -24,11 +24,15 @@ REPO_ROOT="$(git rev-parse --show-toplevel)"
 SKILLS_DIR="${REPO_ROOT}/../.claude/skills"
 CANONICAL_DIR="${REPO_ROOT}/ops/automation/skills"
 
+# Registry path via sys.argv, never spliced into the Python source: REPO_ROOT is
+# the checkout path and a single quote is a legal POSIX path component, so
+# splicing it closed the string literal and parsed the rest as Python
+# (icn#2722 sweep).
 mapfile -t SKILLS < <(python3 -c "
 import json,sys
-d=json.load(open('${REPO_ROOT}/ops/state/truth/skills.json'))
+d=json.load(open(sys.argv[1]))
 print('\n'.join(e['name'] for e in d['skills']['ops_automation_canonical']))
-")
+" "${REPO_ROOT}/ops/state/truth/skills.json")
 if [[ "${#SKILLS[@]}" -eq 0 ]]; then
   echo "ERROR: no ops-automation skills registered in ops/state/truth/skills.json" >&2
   exit 1

--- a/ops/scripts/what-matters-now.sh
+++ b/ops/scripts/what-matters-now.sh
@@ -150,27 +150,33 @@ WORKTREES=$(git -C "${REPO_ROOT}" worktree list 2>/dev/null | awk '{print $1, $3
 # on now" — that is a live issue/PR query (Refs icn#2634). A dormant cadence is a
 # truthful answer and must be reported as such, not as a stale sprint number.
 SPRINT_FILE="${REPO_ROOT}/ops/state/sprint/current.json"
+# The sprint file path is passed as sys.argv, never spliced into the Python
+# source. A checkout path can legally contain a single quote; splicing it into a
+# string literal closed the literal and parsed the rest as Python, so the lookup
+# silently fell back and misreported a readable file as unreadable -- the same
+# class icn#2638/#2688 removed from the --json payload, on this path (icn#2722).
+# This mirrors the canonical safe form in ops/scripts/drift-check.sh.
 SPRINT_SUMMARY=$(python3 -c "
-import json
-d = json.load(open('${SPRINT_FILE}'))
+import json, sys
+d = json.load(open(sys.argv[1]))
 if d.get('cadence') == 'dormant' or d.get('active_sprint') is None:
     print('no active sprint (cadence dormant)')
 else:
     print('Sprint %s (%s)' % (d.get('active_sprint'), d.get('status','?')))
-" 2>/dev/null || echo "unresolved (sprint owner unreadable)")
+" "${SPRINT_FILE}" 2>/dev/null || echo "unresolved (sprint owner unreadable)")
 # Emitted as JSON, not as Python source. The --json payload consumes this with json.loads;
 # repr() was only ever correct because the payload used to be built by splicing shell values
 # into Python source, which is the defect icn#2638 names.
-SPRINT_ACTIVE_JSON=$(python3 -c "import json; d=json.load(open('${SPRINT_FILE}')); v=d.get('active_sprint'); print(json.dumps(v if isinstance(v,(int,type(None))) else str(v)))" 2>/dev/null || echo "null")
-SPRINT_STATUS=$(python3 -c "import json; d=json.load(open('${SPRINT_FILE}')); print(d.get('status','?'))" 2>/dev/null || echo "?")
+SPRINT_ACTIVE_JSON=$(python3 -c "import json,sys; d=json.load(open(sys.argv[1])); v=d.get('active_sprint'); print(json.dumps(v if isinstance(v,(int,type(None))) else str(v)))" "${SPRINT_FILE}" 2>/dev/null || echo "null")
+SPRINT_STATUS=$(python3 -c "import json,sys; d=json.load(open(sys.argv[1])); print(d.get('status','?'))" "${SPRINT_FILE}" 2>/dev/null || echo "?")
 SPRINT_TASKS=$(python3 -c "
-import json
-d = json.load(open('${SPRINT_FILE}'))
+import json, sys
+d = json.load(open(sys.argv[1]))
 tasks = d.get('tasks', [])
 from collections import Counter
 counts = Counter(t.get('status','unknown') for t in tasks)
 print(', '.join(f'{v} {k}' for k,v in sorted(counts.items())) or 'none')
-" 2>/dev/null || echo "unavailable")
+" "${SPRINT_FILE}" 2>/dev/null || echo "unavailable")
 
 # ─── Phase 6: open PRs (if gh available) ────────────────────────────────────
 
@@ -187,12 +193,15 @@ fi
 
 # ─── Phase 7: canonical paths ────────────────────────────────────────────────
 
+# Path via sys.argv, not spliced into the source -- same reason as the sprint
+# lookups above (icn#2722). ${REPO_ROOT} is the checkout path and can contain a
+# single quote.
 POLICY_CHECKS=$(python3 -c "
-import json
-d = json.load(open('${REPO_ROOT}/ops/state/truth/policy.json'))
+import json, sys
+d = json.load(open(sys.argv[1]))
 checks = d['merge']['required_checks']
 print(str(len(checks)) + ' required checks')
-" 2>/dev/null || echo "?")
+" "${REPO_ROOT}/ops/state/truth/policy.json" 2>/dev/null || echo "?")
 
 # ─── Output ──────────────────────────────────────────────────────────────────
 

--- a/scripts/tests/test_what_matters_now_sprint_path.py
+++ b/scripts/tests/test_what_matters_now_sprint_path.py
@@ -1,0 +1,349 @@
+#!/usr/bin/env python3
+"""Executable consumer + regression gate for the checkout-path interpolation in
+`what-matters-now.sh` (icn#2722).
+
+`#2688` closed this defect class on the `--json` payload path by passing values
+through the environment. The *same class* survived a few lines above it: the
+sprint and policy lookups splice the checkout path into **Python source** inside
+single-quoted string literals, e.g.
+
+    d = json.load(open('${SPRINT_FILE}'))
+
+`SPRINT_FILE` is `${REPO_ROOT}/ops/state/sprint/current.json`, and `REPO_ROOT`
+is the checkout directory, derived from the script's own location. A single
+quote is a legal POSIX path component, so a checkout path containing one closes
+the literal early and the remainder is parsed as Python. Every site is wrapped
+in `2>/dev/null || echo "<fallback>"`, so the failure is silent: the preflight
+reports `unresolved (sprint owner unreadable)` for a file it can read perfectly
+well, and the `required checks` line vanishes -- the same "a control reports a
+conclusion its evidence path never produced" family as #2723.
+
+This file is two things at once:
+
+  1. a behavioural runner that drives the script from a checkout path containing
+     a `'` and proves the report is correct there -- the case no other test
+     exercises; and
+  2. a structural gate that forbids any shell value from reaching Python as
+     *syntax* anywhere in the script, so the class cannot come back on a fourth
+     site.
+
+Both are backed by MUST-FAIL controls: the pre-fix form is reconstructed and
+each assertion is shown to reject it, and the pre-fix form is shown at runtime
+to both misreport (benign path) and execute chosen code (the ceiling) when the
+checkout path is hostile. A gate that cannot fail is not a gate.
+
+Run: python3 scripts/tests/test_what_matters_now_sprint_path.py
+"""
+import json
+import pathlib
+import re
+import shutil
+import subprocess
+import tempfile
+
+ROOT = pathlib.Path(__file__).resolve().parents[2]
+SCRIPT = ROOT / "ops" / "scripts" / "what-matters-now.sh"
+
+failures = []
+
+
+def check(desc, cond):
+    print(("  ok   " if cond else "  FAIL ") + desc)
+    if not cond:
+        failures.append(desc)
+
+
+# ── fixture: a self-contained checkout under a chosen directory name ──────────
+
+
+STATE_FILES = [
+    "ops/state/sprint/current.json",
+    "ops/state/truth/sources.json",
+    "ops/state/truth/policy.json",
+    "ops/state/truth/agents.json",
+    "ops/state/truth/skills.json",
+    "ops/state/config/repo-map.json",
+]
+
+
+def build_checkout(parent, dirname):
+    """Materialise a minimal but real checkout at `parent/dirname` and return it.
+
+    The directory name is the whole point of the test, so it is passed in
+    verbatim. Only the files the script actually reads are copied; it is then a
+    git repo so the early `git` calls under `set -e` do not abort before the
+    sprint section is reached.
+    """
+    root = pathlib.Path(parent) / dirname
+    (root / "ops" / "scripts").mkdir(parents=True)
+    shutil.copy2(SCRIPT, root / "ops" / "scripts" / SCRIPT.name)
+    for rel in STATE_FILES:
+        src = ROOT / rel
+        if not src.exists():
+            continue
+        dst = root / rel
+        dst.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(src, dst)
+    subprocess.run(["git", "init", "-q", str(root)], capture_output=True)
+    subprocess.run(["git", "-C", str(root), "config", "user.email", "t@t.invalid"],
+                   capture_output=True)
+    subprocess.run(["git", "-C", str(root), "config", "user.name", "t"],
+                   capture_output=True)
+    subprocess.run(["git", "-C", str(root), "add", "-A"], capture_output=True)
+    subprocess.run(["git", "-C", str(root), "commit", "-qm", "init"],
+                   capture_output=True)
+    return root
+
+
+def run_script(checkout, *args, cwd=None):
+    return subprocess.run(
+        ["bash", str(checkout / "ops" / "scripts" / SCRIPT.name), *args],
+        capture_output=True, text=True, cwd=cwd,
+    )
+
+
+def sprint_line(human_output):
+    """The cadence line the script prints under '── Sprint cadence ──'."""
+    lines = human_output.splitlines()
+    for i, ln in enumerate(lines):
+        if "Sprint cadence" in ln and i + 1 < len(lines):
+            return lines[i + 1].strip()
+    return ""
+
+
+# ── behavioural: the report is correct from a quoted checkout path ────────────
+
+
+print("--- the report does not depend on a ' in the checkout path (icn#2722) ---")
+
+expected_sprint = None
+try:
+    d = json.loads((ROOT / "ops" / "state" / "sprint" / "current.json").read_text())
+    if d.get("cadence") == "dormant" or d.get("active_sprint") is None:
+        expected_sprint = "no active sprint (cadence dormant)"
+    else:
+        expected_sprint = "Sprint %s (%s)" % (d.get("active_sprint"), d.get("status", "?"))
+except Exception as exc:  # pragma: no cover - fixture integrity
+    check("CONTROL: the real sprint file parses (%s)" % exc, False)
+
+tmp = tempfile.mkdtemp()
+try:
+    clean = build_checkout(tmp, "clean-repo")
+    quoted = build_checkout(tmp, "it's-a-repo")
+
+    clean_run = run_script(clean)
+    quoted_run = run_script(quoted)
+
+    clean_sprint = sprint_line(clean_run.stdout)
+    quoted_sprint = sprint_line(quoted_run.stdout)
+
+    check("baseline: a clean path reports the sprint cadence correctly (%r)"
+          % clean_sprint, clean_sprint == expected_sprint)
+
+    # The discriminating assertion. Against current `main` the quoted path yields
+    # "unresolved (sprint owner unreadable)" because the `'` breaks the Python
+    # literal and the `|| echo` fallback fires; the file is perfectly readable.
+    check("a checkout path containing ' reports the SAME sprint cadence (%r)"
+          % quoted_sprint, quoted_sprint == expected_sprint)
+
+    check("a checkout path containing ' does not report the file unreadable",
+          "unreadable" not in quoted_sprint)
+
+    # The `required checks` line comes from POLICY_CHECKS (site 5, ${REPO_ROOT}
+    # spliced directly). It disappears entirely on a quoted path today.
+    check("the 'required checks' count is reported from a quoted path too",
+          "required checks" in quoted_run.stdout)
+
+    # --json must remain valid from a quoted path: its sprint fields are computed
+    # by these same interpolated lookups upstream of #2688's env boundary.
+    qjson = run_script(quoted, "--json")
+    try:
+        payload = json.loads(qjson.stdout)
+        check("--json is valid from a quoted checkout path", True)
+        check("--json sprint.status is truthful from a quoted path (%r)"
+              % payload.get("sprint", {}).get("status"),
+              payload.get("sprint", {}).get("status") == d.get("status", "?"))
+    except ValueError as exc:
+        check("--json is valid from a quoted checkout path (%s)" % exc, False)
+finally:
+    shutil.rmtree(tmp, ignore_errors=True)
+
+
+# ── structural: no shell value reaches Python as syntax, anywhere ────────────
+
+
+print()
+print("--- the defect class cannot return (structural, whole file) ---")
+
+text = SCRIPT.read_text(encoding="utf-8")
+
+
+def inline_python_sources(s):
+    """Every `python3 -c "<source>"` body in the script.
+
+    The source is the double-quoted word after `-c`; any path argument the fixed
+    form appends comes *after* that closing quote and is therefore not captured,
+    which is exactly the property under test.
+
+    Coverage boundary (deliberate). This matches the two invocation shapes that
+    can carry a shell value into Python *as syntax*: a double-quoted `-c` body,
+    and (below) an unquoted heredoc. The shapes it does not match cannot
+    interpolate a shell value: a single-quoted `python3 -c '...'` body and a
+    `<<'EOF'` heredoc do not expand `${...}` at all, and `python3 script.py
+    "$path"` passes the value as argv — which is the safe form this fix adopts.
+    Scanning single-quoted bodies for `${` would in fact be wrong: there a `${x}`
+    is a literal string, not an injection. So the gate covers every shape that is
+    dangerous and skips the shapes that are safe by construction.
+    """
+    return re.findall(r'python3 -c "((?:[^"\\]|\\.)*)"', s, re.S)
+
+
+def interpolating_python_heredocs(s):
+    """Bodies of `python3 - <<DELIM ... DELIM` whose delimiter is UNQUOTED.
+
+    A quoted delimiter (`<<'PY'`) does not expand, so those are safe and skipped.
+    """
+    out = []
+    for m in re.finditer(r"python3 - <<(['\"]?)([A-Za-z_][A-Za-z0-9_]*)\1\n(.*?)\n\2\n",
+                         s, re.S):
+        if m.group(1) == "":  # unquoted delimiter -> shell expands the body
+            out.append(m.group(3))
+    return out
+
+
+inline = inline_python_sources(text)
+check("at least the sprint/policy python3 -c calls were located (%d)" % len(inline),
+      len(inline) >= 3)
+
+bad_inline = [src for src in inline if "${" in src or "$(" in src]
+check("no python3 -c source string contains ${...} or $(...) interpolation",
+      not bad_inline)
+
+hostile_heredocs = interpolating_python_heredocs(text)
+check("no python3 heredoc uses an unquoted (expanding) delimiter",
+      not hostile_heredocs)
+
+# Belt and suspenders: the specific pre-fix spelling must be gone from the file.
+check("no `open('${...}')` / `open(\"${...}\")` remains anywhere in the script",
+      not re.search(r"open\(\s*['\"]\$\{", text))
+
+
+# ── the argv change did not break the genuine "unreadable" fallback ──────────
+
+
+print()
+print("--- the || fallback still fires for a genuinely unreadable file ---")
+
+# The fix moved the path from source to argv; the `2>/dev/null || echo` fallback
+# must still cover a real missing/corrupt file, or the change would trade a false
+# "unreadable" for a false "readable". Exercised at the shell level with the exact
+# fixed spelling, so it pins the post-fix form, not a paraphrase.
+FIXED_INLINE = (
+    'SPRINT_STATUS=$(python3 -c "import json,sys; '
+    "d=json.load(open(sys.argv[1])); print(d.get('status','?'))\" "
+    '"${SPRINT_FILE}" 2>/dev/null || echo "?")'
+)
+
+
+def fixed_status(sprint_file_expr, setup=""):
+    return subprocess.run(
+        ["bash", "-c",
+         "set -uo pipefail\n" + setup
+         + 'SPRINT_FILE=%s\n' % sprint_file_expr
+         + FIXED_INLINE + '\necho "STATUS=${SPRINT_STATUS}"'],
+        capture_output=True, text=True,
+    )
+
+missing = fixed_status('"/nonexistent/really-not-here.json"')
+check("the fixed argv form still falls back to '?' when the file is missing",
+      "STATUS=?" in missing.stdout)
+
+corrupt_dir = tempfile.mkdtemp()
+try:
+    bad = pathlib.Path(corrupt_dir) / "current.json"
+    bad.write_text("{not valid json")
+    corrupt = fixed_status('"%s"' % bad)
+    check("the fixed argv form still falls back to '?' on corrupt JSON",
+          "STATUS=?" in corrupt.stdout)
+
+    good = pathlib.Path(corrupt_dir) / "good.json"
+    good.write_text('{"status": "closed"}')
+    ok = fixed_status('"%s"' % good)
+    check("the fixed argv form reports the real status on a readable file",
+          "STATUS=closed" in ok.stdout)
+finally:
+    shutil.rmtree(corrupt_dir, ignore_errors=True)
+
+
+# ── MUST-FAIL controls: prove the gate rejects the pre-fix form ──────────────
+
+
+print()
+print("--- MUST-FAIL controls (a gate that cannot fail is not a gate) ---")
+
+PRE_FIX_INLINE = (
+    'SPRINT_STATUS=$(python3 -c "import json; '
+    "d=json.load(open('${SPRINT_FILE}')); print(d.get('status','?'))\" "
+    '2>/dev/null || echo "?")'
+)
+pre_inline = inline_python_sources(PRE_FIX_INLINE)
+check("CONTROL: the matcher still recognises the pre-fix python3 -c form",
+      len(pre_inline) == 1)
+check("CONTROL: the ${...} assertion rejects the pre-fix inline form",
+      pre_inline and "${" in pre_inline[0])
+
+check("CONTROL: the open('${...}') assertion rejects the pre-fix form",
+      bool(re.search(r"open\(\s*['\"]\$\{", PRE_FIX_INLINE)))
+
+PRE_FIX_HEREDOC = (
+    "python3 - <<EOF\n"
+    "import json\n"
+    "d = json.load(open('${SPRINT_FILE}'))\n"
+    "EOF\n"
+)
+check("CONTROL: the heredoc matcher flags an unquoted expanding delimiter",
+      len(interpolating_python_heredocs(PRE_FIX_HEREDOC)) == 1)
+
+# Runtime proof #1 (benign): the pre-fix form misreports on a path with a `'`.
+benign = subprocess.run(
+    ["bash", "-c",
+     "set -uo pipefail\n"
+     "SPRINT_FILE=\"/tmp/it's-a-repo/current.json\"\n" + PRE_FIX_INLINE + "\n"
+     'echo "STATUS=${SPRINT_STATUS}"'],
+    capture_output=True, text=True,
+)
+check("CONTROL: the pre-fix form falls back to '?' when the path contains a ' "
+      "(silent misreport)",
+      "STATUS=?" in benign.stdout)
+
+# Runtime proof #2 (ceiling): a crafted path component executes chosen code.
+# All characters below are legal in a POSIX path component.
+ceil_dir = tempfile.mkdtemp()
+try:
+    marker = pathlib.Path(ceil_dir) / "ICN2722_MARKER"
+    payload_path = (
+        "/x'+__import__('pathlib').Path('%s').write_text('x')*0*0+'y/current.json"
+        % marker
+    )
+    ceil = subprocess.run(
+        ["bash", "-c",
+         "set -uo pipefail\n"
+         "SPRINT_FILE=\"%s\"\n" % payload_path + PRE_FIX_INLINE],
+        capture_output=True, text=True,
+    )
+    check("CONTROL: the pre-fix form EXECUTES code embedded in the checkout path "
+          "(the ceiling of this class)", marker.exists())
+finally:
+    shutil.rmtree(ceil_dir, ignore_errors=True)
+
+
+# ── summary ──────────────────────────────────────────────────────────────────
+
+
+print()
+if failures:
+    print("FAILED (%d):" % len(failures))
+    for f in failures:
+        print("  - " + f)
+    raise SystemExit(1)
+print("all checks passed")

--- a/scripts/tests/test_what_matters_now_sprint_path.py
+++ b/scripts/tests/test_what_matters_now_sprint_path.py
@@ -1,36 +1,40 @@
 #!/usr/bin/env python3
-"""Executable consumer + regression gate for the checkout-path interpolation in
-`what-matters-now.sh` (icn#2722).
+"""Executable consumer + regression gate for checkout-path interpolation in the
+ICN operational scripts (icn#2722).
 
-`#2688` closed this defect class on the `--json` payload path by passing values
-through the environment. The *same class* survived a few lines above it: the
-sprint and policy lookups splice the checkout path into **Python source** inside
-single-quoted string literals, e.g.
+#2688 closed this defect class on the `--json` payload of `what-matters-now.sh`
+by passing values through the environment. The *same class* survived elsewhere:
+several operational scripts spliced the checkout path into **Python source**
+inside single-quoted string literals, e.g.
 
-    d = json.load(open('${SPRINT_FILE}'))
+    d = json.load(open('${SPRINT_FILE}'))      # ${REPO_ROOT}/ops/state/sprint/...
+    d = json.load(open('${REGISTRY}'))         # ${REPO_ROOT}/ops/state/truth/...
 
-`SPRINT_FILE` is `${REPO_ROOT}/ops/state/sprint/current.json`, and `REPO_ROOT`
-is the checkout directory, derived from the script's own location. A single
-quote is a legal POSIX path component, so a checkout path containing one closes
-the literal early and the remainder is parsed as Python. Every site is wrapped
-in `2>/dev/null || echo "<fallback>"`, so the failure is silent: the preflight
-reports `unresolved (sprint owner unreadable)` for a file it can read perfectly
-well, and the `required checks` line vanishes -- the same "a control reports a
-conclusion its evidence path never produced" family as #2723.
+`REPO_ROOT` is the checkout directory. A single quote is a legal POSIX path
+component, so a checkout path containing one closes the literal early and the
+remainder is parsed as Python.
 
-This file is two things at once:
+Where the call is wrapped in `2>/dev/null || echo "<fallback>"` the failure is
+silent: the preflight reported `unresolved (sprint owner unreadable)` for a file
+it can read perfectly well and dropped the `required checks` line -- the same "a
+control states a conclusion its evidence path never produced" family as #2723.
 
-  1. a behavioural runner that drives the script from a checkout path containing
-     a `'` and proves the report is correct there -- the case no other test
-     exercises; and
-  2. a structural gate that forbids any shell value from reaching Python as
-     *syntax* anywhere in the script, so the class cannot come back on a fourth
-     site.
+The operating rule this file enforces:
 
-Both are backed by MUST-FAIL controls: the pre-fix form is reconstructed and
-each assertion is shown to reject it, and the pre-fix form is shown at runtime
-to both misreport (benign path) and execute chosen code (the ceiling) when the
-checkout path is hostile. A gate that cannot fail is not a gate.
+    the program is code; paths, names and registry locations are DATA.
+    data reaches Python through argv/env/stdin, never as syntax.
+
+Scope. Three operational scripts are in scope, all of which derive a path from
+the checkout root:
+
+    ops/scripts/what-matters-now.sh      (5 sites)
+    ops/scripts/drift-check.sh           (4 sites)
+    ops/scripts/setup-skill-symlinks.sh  (1 site)
+
+Demo/rehearsal scripts under scripts/ are deliberately NOT covered: their
+interpolated values are author-written Python fragments or script-generated
+quote-free constants, a different provenance. The two that splice a
+token-derived DID are recorded as separate bounded debt, not silently cleared.
 
 Run: python3 scripts/tests/test_what_matters_now_sprint_path.py
 """
@@ -42,7 +46,13 @@ import subprocess
 import tempfile
 
 ROOT = pathlib.Path(__file__).resolve().parents[2]
-SCRIPT = ROOT / "ops" / "scripts" / "what-matters-now.sh"
+OPS = ROOT / "ops" / "scripts"
+SCRIPT = OPS / "what-matters-now.sh"
+DRIFT = OPS / "drift-check.sh"
+SYMLINKS = OPS / "setup-skill-symlinks.sh"
+
+# Every operational script whose Python source must stay free of shell values.
+IN_SCOPE = [SCRIPT, DRIFT, SYMLINKS]
 
 failures = []
 
@@ -53,7 +63,7 @@ def check(desc, cond):
         failures.append(desc)
 
 
-# ── fixture: a self-contained checkout under a chosen directory name ──────────
+# ── fixture ──────────────────────────────────────────────────────────────────
 
 
 STATE_FILES = [
@@ -66,17 +76,26 @@ STATE_FILES = [
 ]
 
 
-def build_checkout(parent, dirname):
-    """Materialise a minimal but real checkout at `parent/dirname` and return it.
+def git(*args):
+    """Run a git fixture command FAIL-CLOSED.
 
-    The directory name is the whole point of the test, so it is passed in
-    verbatim. Only the files the script actually reads are copied; it is then a
-    git repo so the early `git` calls under `set -e` do not abort before the
-    sprint section is reached.
+    A fixture that half-built used to be indistinguishable from a passing test:
+    the scripts under test bail early on a non-repo, so the interesting code was
+    never reached and the run still looked green. Setup failures must be fatal,
+    never evidence.
+    """
+    subprocess.run(args, capture_output=True, check=True)
+
+
+def build_checkout(parent, dirname, scripts=None):
+    """Materialise a minimal but real checkout at `parent/dirname`.
+
+    The directory name is the whole point of the test, so it is passed verbatim.
     """
     root = pathlib.Path(parent) / dirname
     (root / "ops" / "scripts").mkdir(parents=True)
-    shutil.copy2(SCRIPT, root / "ops" / "scripts" / SCRIPT.name)
+    for s in (scripts or IN_SCOPE):
+        shutil.copy2(s, root / "ops" / "scripts" / s.name)
     for rel in STATE_FILES:
         src = ROOT / rel
         if not src.exists():
@@ -84,26 +103,24 @@ def build_checkout(parent, dirname):
         dst = root / rel
         dst.parent.mkdir(parents=True, exist_ok=True)
         shutil.copy2(src, dst)
-    subprocess.run(["git", "init", "-q", str(root)], capture_output=True)
-    subprocess.run(["git", "-C", str(root), "config", "user.email", "t@t.invalid"],
-                   capture_output=True)
-    subprocess.run(["git", "-C", str(root), "config", "user.name", "t"],
-                   capture_output=True)
-    subprocess.run(["git", "-C", str(root), "add", "-A"], capture_output=True)
-    subprocess.run(["git", "-C", str(root), "commit", "-qm", "init"],
-                   capture_output=True)
+    # Some drift-check phases stat these trees; absent is fine, present is tidier.
+    (root / "ops" / "automation" / "skills").mkdir(parents=True, exist_ok=True)
+    git("git", "init", "-q", str(root))
+    git("git", "-C", str(root), "config", "user.email", "t@example.invalid")
+    git("git", "-C", str(root), "config", "user.name", "t")
+    git("git", "-C", str(root), "add", "-A")
+    git("git", "-C", str(root), "commit", "-qm", "init")
     return root
 
 
-def run_script(checkout, *args, cwd=None):
+def run_script(checkout, name, *args, cwd=None):
     return subprocess.run(
-        ["bash", str(checkout / "ops" / "scripts" / SCRIPT.name), *args],
-        capture_output=True, text=True, cwd=cwd,
+        ["bash", str(checkout / "ops" / "scripts" / name), *args],
+        capture_output=True, text=True, cwd=cwd or str(checkout),
     )
 
 
 def sprint_line(human_output):
-    """The cadence line the script prints under '── Sprint cadence ──'."""
     lines = human_output.splitlines()
     for i, ln in enumerate(lines):
         if "Sprint cadence" in ln and i + 1 < len(lines):
@@ -111,230 +128,284 @@ def sprint_line(human_output):
     return ""
 
 
-# ── behavioural: the report is correct from a quoted checkout path ────────────
+PLAIN_DIR = "plain-repo"
+QUOTED_DIR = "it's-a-repo"   # the only difference that may change any behaviour
 
 
-print("--- the report does not depend on a ' in the checkout path (icn#2722) ---")
+# ── behavioural: what-matters-now.sh from a quoted checkout path ─────────────
 
-expected_sprint = None
-try:
-    d = json.loads((ROOT / "ops" / "state" / "sprint" / "current.json").read_text())
-    if d.get("cadence") == "dormant" or d.get("active_sprint") is None:
-        expected_sprint = "no active sprint (cadence dormant)"
-    else:
-        expected_sprint = "Sprint %s (%s)" % (d.get("active_sprint"), d.get("status", "?"))
-except Exception as exc:  # pragma: no cover - fixture integrity
-    check("CONTROL: the real sprint file parses (%s)" % exc, False)
+
+print("--- what-matters-now.sh: report does not depend on a ' in the path ---")
+
+sprint_doc = json.loads((ROOT / "ops" / "state" / "sprint" / "current.json").read_text())
+if sprint_doc.get("cadence") == "dormant" or sprint_doc.get("active_sprint") is None:
+    expected_sprint = "no active sprint (cadence dormant)"
+else:
+    expected_sprint = "Sprint %s (%s)" % (sprint_doc.get("active_sprint"),
+                                          sprint_doc.get("status", "?"))
 
 tmp = tempfile.mkdtemp()
 try:
-    clean = build_checkout(tmp, "clean-repo")
-    quoted = build_checkout(tmp, "it's-a-repo")
+    plain = build_checkout(tmp, PLAIN_DIR)
+    quoted = build_checkout(tmp, QUOTED_DIR)
 
-    clean_run = run_script(clean)
-    quoted_run = run_script(quoted)
+    plain_run = run_script(plain, SCRIPT.name)
+    quoted_run = run_script(quoted, SCRIPT.name)
 
-    clean_sprint = sprint_line(clean_run.stdout)
-    quoted_sprint = sprint_line(quoted_run.stdout)
+    check("baseline: a plain path reports the sprint cadence correctly (%r)"
+          % sprint_line(plain_run.stdout),
+          sprint_line(plain_run.stdout) == expected_sprint)
 
-    check("baseline: a clean path reports the sprint cadence correctly (%r)"
-          % clean_sprint, clean_sprint == expected_sprint)
-
-    # The discriminating assertion. Against current `main` the quoted path yields
-    # "unresolved (sprint owner unreadable)" because the `'` breaks the Python
-    # literal and the `|| echo` fallback fires; the file is perfectly readable.
     check("a checkout path containing ' reports the SAME sprint cadence (%r)"
-          % quoted_sprint, quoted_sprint == expected_sprint)
+          % sprint_line(quoted_run.stdout),
+          sprint_line(quoted_run.stdout) == expected_sprint)
 
-    check("a checkout path containing ' does not report the file unreadable",
-          "unreadable" not in quoted_sprint)
+    check("a checkout path containing ' does not claim the file is unreadable",
+          "unreadable" not in sprint_line(quoted_run.stdout))
 
-    # The `required checks` line comes from POLICY_CHECKS (site 5, ${REPO_ROOT}
-    # spliced directly). It disappears entirely on a quoted path today.
+    # POLICY_CHECKS (the ${REPO_ROOT} site) drops this line entirely pre-fix.
     check("the 'required checks' count is reported from a quoted path too",
           "required checks" in quoted_run.stdout)
 
-    # --json must remain valid from a quoted path: its sprint fields are computed
-    # by these same interpolated lookups upstream of #2688's env boundary.
-    qjson = run_script(quoted, "--json")
+    qjson = run_script(quoted, SCRIPT.name, "--json")
     try:
         payload = json.loads(qjson.stdout)
         check("--json is valid from a quoted checkout path", True)
         check("--json sprint.status is truthful from a quoted path (%r)"
               % payload.get("sprint", {}).get("status"),
-              payload.get("sprint", {}).get("status") == d.get("status", "?"))
+              payload.get("sprint", {}).get("status") == sprint_doc.get("status", "?"))
     except ValueError as exc:
         check("--json is valid from a quoted checkout path (%s)" % exc, False)
+
+    # ── behavioural: drift-check.sh from a quoted checkout path ──────────────
+
+    print()
+    print("--- drift-check.sh: registry/policy/agents reads survive a quoted path ---")
+
+    d_plain = run_script(plain, DRIFT.name, "--verbose")
+    d_quoted = run_script(quoted, DRIFT.name, "--verbose")
+    d_out = d_quoted.stdout + d_quoted.stderr
+
+    # skills.json -> scan scope (sites at :27 and :89)
+    check("skill scan scope is still derived from the registry on a quoted path",
+          "could not derive skill scan scope" not in d_out)
+
+    # policy.json -> required-check count (site at :260)
+    expected_checks = len(json.loads(
+        (ROOT / "ops" / "state" / "truth" / "policy.json").read_text()
+    )["merge"]["required_checks"])
+    check("policy.json required-check count reads correctly on a quoted path "
+          "(expect %d)" % expected_checks,
+          ("policy.json has %d required checks" % expected_checks) in d_out)
+    check("the quoted path does not trigger the 'fewer than 11 required checks' fail",
+          "fewer than 11 required checks" not in d_out)
+
+    # agents.json -> registered agent names (site at :283). Reading it wrongly
+    # yields an empty name set, so compare the two runs' agent findings.
+    def agent_lines(r):
+        return [l for l in (r.stdout + r.stderr).splitlines() if "agent" in l.lower()]
+    check("agents registry produces the same findings on plain and quoted paths",
+          agent_lines(d_plain) == agent_lines(d_quoted))
+
+    check("drift-check.sh reaches the same overall verdict on both paths "
+          "(plain exit=%d, quoted exit=%d)" % (d_plain.returncode, d_quoted.returncode),
+          d_plain.returncode == d_quoted.returncode)
+
+    # ── behavioural: setup-skill-symlinks.sh from a quoted checkout path ─────
+
+    print()
+    print("--- setup-skill-symlinks.sh --check: registry loads on a quoted path ---")
+
+    # SKILLS_DIR is ${REPO_ROOT}/../.claude/skills, i.e. INSIDE this temp dir --
+    # the developer's real machine-local .claude/skills is never touched. --check
+    # never creates anything either.
+    registered = [e["name"] for e in json.loads(
+        (ROOT / "ops" / "state" / "truth" / "skills.json").read_text()
+    )["skills"]["ops_automation_canonical"]]
+
+    s_quoted = run_script(quoted, SYMLINKS.name, "--check")
+    s_out = s_quoted.stdout + s_quoted.stderr
+
+    # Pre-fix the json.load dies, SKILLS is empty, and the script exits on its
+    # own "no ops-automation skills registered" error without ever naming one.
+    check("the registry is not reported empty on a quoted path",
+          "no ops-automation skills registered" not in s_out)
+    check("every registered skill name is still enumerated on a quoted path (%r)"
+          % registered,
+          all(n in s_out for n in registered) and len(registered) > 0)
+    check("--check did not create anything outside the fixture",
+          not (ROOT / ".." / ".claude" / "skills" / "__probe__").exists())
 finally:
     shutil.rmtree(tmp, ignore_errors=True)
-
-
-# ── structural: no shell value reaches Python as syntax, anywhere ────────────
-
-
-print()
-print("--- the defect class cannot return (structural, whole file) ---")
-
-text = SCRIPT.read_text(encoding="utf-8")
-
-
-def inline_python_sources(s):
-    """Every `python3 -c "<source>"` body in the script.
-
-    The source is the double-quoted word after `-c`; any path argument the fixed
-    form appends comes *after* that closing quote and is therefore not captured,
-    which is exactly the property under test.
-
-    Coverage boundary (deliberate). This matches the two invocation shapes that
-    can carry a shell value into Python *as syntax*: a double-quoted `-c` body,
-    and (below) an unquoted heredoc. The shapes it does not match cannot
-    interpolate a shell value: a single-quoted `python3 -c '...'` body and a
-    `<<'EOF'` heredoc do not expand `${...}` at all, and `python3 script.py
-    "$path"` passes the value as argv — which is the safe form this fix adopts.
-    Scanning single-quoted bodies for `${` would in fact be wrong: there a `${x}`
-    is a literal string, not an injection. So the gate covers every shape that is
-    dangerous and skips the shapes that are safe by construction.
-    """
-    return re.findall(r'python3 -c "((?:[^"\\]|\\.)*)"', s, re.S)
-
-
-def interpolating_python_heredocs(s):
-    """Bodies of `python3 - <<DELIM ... DELIM` whose delimiter is UNQUOTED.
-
-    A quoted delimiter (`<<'PY'`) does not expand, so those are safe and skipped.
-    """
-    out = []
-    for m in re.finditer(r"python3 - <<(['\"]?)([A-Za-z_][A-Za-z0-9_]*)\1\n(.*?)\n\2\n",
-                         s, re.S):
-        if m.group(1) == "":  # unquoted delimiter -> shell expands the body
-            out.append(m.group(3))
-    return out
-
-
-inline = inline_python_sources(text)
-check("at least the sprint/policy python3 -c calls were located (%d)" % len(inline),
-      len(inline) >= 3)
-
-bad_inline = [src for src in inline if "${" in src or "$(" in src]
-check("no python3 -c source string contains ${...} or $(...) interpolation",
-      not bad_inline)
-
-hostile_heredocs = interpolating_python_heredocs(text)
-check("no python3 heredoc uses an unquoted (expanding) delimiter",
-      not hostile_heredocs)
-
-# Belt and suspenders: the specific pre-fix spelling must be gone from the file.
-check("no `open('${...}')` / `open(\"${...}\")` remains anywhere in the script",
-      not re.search(r"open\(\s*['\"]\$\{", text))
 
 
 # ── the argv change did not break the genuine "unreadable" fallback ──────────
 
 
-print()
-print("--- the || fallback still fires for a genuinely unreadable file ---")
-
-# The fix moved the path from source to argv; the `2>/dev/null || echo` fallback
-# must still cover a real missing/corrupt file, or the change would trade a false
-# "unreadable" for a false "readable". Exercised at the shell level with the exact
-# fixed spelling, so it pins the post-fix form, not a paraphrase.
+PRE_FIX_INLINE = (
+    'STATUS=$(python3 -c "import json; '
+    "d=json.load(open('${SPRINT_FILE}')); print(d.get('status','?'))\" "
+    '2>/dev/null || echo "?")'
+)
 FIXED_INLINE = (
-    'SPRINT_STATUS=$(python3 -c "import json,sys; '
+    'STATUS=$(python3 -c "import json,sys; '
     "d=json.load(open(sys.argv[1])); print(d.get('status','?'))\" "
     '"${SPRINT_FILE}" 2>/dev/null || echo "?")'
 )
 
 
-def fixed_status(sprint_file_expr, setup=""):
+def status_of(form, sprint_file):
     return subprocess.run(
         ["bash", "-c",
-         "set -uo pipefail\n" + setup
-         + 'SPRINT_FILE=%s\n' % sprint_file_expr
-         + FIXED_INLINE + '\necho "STATUS=${SPRINT_STATUS}"'],
+         "set -uo pipefail\nSPRINT_FILE=%s\n" % json.dumps(str(sprint_file))
+         + form + '\necho "RESULT=${STATUS}"'],
         capture_output=True, text=True,
-    )
+    ).stdout
 
-missing = fixed_status('"/nonexistent/really-not-here.json"')
-check("the fixed argv form still falls back to '?' when the file is missing",
-      "STATUS=?" in missing.stdout)
 
-corrupt_dir = tempfile.mkdtemp()
+print()
+print("--- the || fallback still fires for a genuinely unreadable file ---")
+
+fb = tempfile.mkdtemp()
 try:
-    bad = pathlib.Path(corrupt_dir) / "current.json"
-    bad.write_text("{not valid json")
-    corrupt = fixed_status('"%s"' % bad)
-    check("the fixed argv form still falls back to '?' on corrupt JSON",
-          "STATUS=?" in corrupt.stdout)
-
-    good = pathlib.Path(corrupt_dir) / "good.json"
+    good = pathlib.Path(fb) / "good.json"
     good.write_text('{"status": "closed"}')
-    ok = fixed_status('"%s"' % good)
-    check("the fixed argv form reports the real status on a readable file",
-          "STATUS=closed" in ok.stdout)
+    bad = pathlib.Path(fb) / "corrupt.json"
+    bad.write_text("{not valid json")
+
+    check("fixed form reports the real status on a readable file",
+          "RESULT=closed" in status_of(FIXED_INLINE, good))
+    check("fixed form still falls back to '?' when the file is missing",
+          "RESULT=?" in status_of(FIXED_INLINE, pathlib.Path(fb) / "absent.json"))
+    check("fixed form still falls back to '?' on corrupt JSON",
+          "RESULT=?" in status_of(FIXED_INLINE, bad))
 finally:
-    shutil.rmtree(corrupt_dir, ignore_errors=True)
+    shutil.rmtree(fb, ignore_errors=True)
 
 
-# ── MUST-FAIL controls: prove the gate rejects the pre-fix form ──────────────
+# ── MUST-FAIL controls ───────────────────────────────────────────────────────
 
 
 print()
 print("--- MUST-FAIL controls (a gate that cannot fail is not a gate) ---")
 
-PRE_FIX_INLINE = (
+# The benign control isolates THE QUOTE as the only variable: identical, readable
+# JSON content, reached by two paths that differ in one character class. An
+# earlier version pointed at a non-existent file, so plain FileNotFoundError
+# produced the same fallback and the control proved nothing (live review).
+iso = tempfile.mkdtemp()
+try:
+    plain_dir = pathlib.Path(iso) / "plain"
+    quote_dir = pathlib.Path(iso) / "it's"
+    plain_dir.mkdir()
+    quote_dir.mkdir()
+    for d in (plain_dir, quote_dir):
+        (d / "current.json").write_text('{"status": "closed"}')
+
+    pre_plain = status_of(PRE_FIX_INLINE, plain_dir / "current.json")
+    pre_quote = status_of(PRE_FIX_INLINE, quote_dir / "current.json")
+    fix_plain = status_of(FIXED_INLINE, plain_dir / "current.json")
+    fix_quote = status_of(FIXED_INLINE, quote_dir / "current.json")
+
+    check("CONTROL: both fixture files are readable and identical in content",
+          (plain_dir / "current.json").read_text()
+          == (quote_dir / "current.json").read_text())
+    check("CONTROL: the pre-fix form SUCCEEDS at a plain path (%r)"
+          % pre_plain.strip(), "RESULT=closed" in pre_plain)
+    check("CONTROL: the pre-fix form MISREPORTS the same readable file under a "
+          "path containing ' (%r)" % pre_quote.strip(), "RESULT=?" in pre_quote)
+    check("CONTROL: the fixed form succeeds at BOTH paths",
+          "RESULT=closed" in fix_plain and "RESULT=closed" in fix_quote)
+finally:
+    shutil.rmtree(iso, ignore_errors=True)
+
+
+# ── structural: no shell value reaches Python as syntax, in any in-scope script
+
+
+print()
+print("--- the defect class cannot return (structural, all in-scope scripts) ---")
+
+# The three shapes in which the shell can rewrite Python SOURCE. Anything not
+# matched here cannot interpolate: a single-quoted `-c '...'` body and a
+# `<<'EOF'` heredoc do not expand at all, and `script.py "$path"` passes argv --
+# which is the safe form. Scanning single-quoted bodies for `${` would in fact be
+# wrong: there a `${x}` is a literal string, not an injection.
+RE_C_DQ = re.compile(r'python3 -c "((?:[^"\\]|\\.)*)"', re.S)
+RE_HEREDOC = re.compile(
+    r"python3 [-\w./]*\s*<<(['\"]?)([A-Za-z_][A-Za-z0-9_]*)\1\n(.*?)\n\2\b", re.S)
+RE_EXPANSION = re.compile(
+    r"\$\{[A-Za-z_][A-Za-z0-9_]*\}|\$\([^)]*\)|\$[A-Za-z_][A-Za-z0-9_]*")
+
+
+def python_sources(text):
+    """(shape, body) for every Python source the shell can rewrite."""
+    out = [("python3 -c \"...\"", m.group(1)) for m in RE_C_DQ.finditer(text)]
+    for m in RE_HEREDOC.finditer(text):
+        if m.group(1) == "":          # unquoted delimiter -> shell expands body
+            out.append(("python3 <<%s (unquoted)" % m.group(2), m.group(3)))
+    return out
+
+
+total_sources = 0
+for script in IN_SCOPE:
+    text = script.read_text(encoding="utf-8")
+    srcs = python_sources(text)
+    total_sources += len(srcs)
+    offenders = []
+    for shape, body in srcs:
+        found = RE_EXPANSION.findall(body)
+        if found:
+            offenders.append("%s -> %s" % (shape, ", ".join(sorted(set(found)))))
+    check("%s: no shell value reaches Python as syntax (%d source block(s))"
+          % (script.name, len(srcs)),
+          not offenders)
+    if offenders:
+        for o in offenders:
+            print("         offender: " + o)
+
+check("the structural scan actually found Python source to inspect (%d blocks)"
+      % total_sources, total_sources >= 10)
+
+for script in IN_SCOPE:
+    check("%s: no `open('${...}')` spelling remains" % script.name,
+          not re.search(r"open\(\s*['\"]\$\{", script.read_text(encoding="utf-8")))
+
+
+# ── MUST-FAIL: the structural gate rejects BOTH generations of the defect ────
+
+
+print()
+print("--- MUST-FAIL: the structural gate rejects the pre-fix spellings ---")
+
+GEN1 = (            # what-matters-now.sh, the originally reported generation
     'SPRINT_STATUS=$(python3 -c "import json; '
     "d=json.load(open('${SPRINT_FILE}')); print(d.get('status','?'))\" "
     '2>/dev/null || echo "?")'
 )
-pre_inline = inline_python_sources(PRE_FIX_INLINE)
-check("CONTROL: the matcher still recognises the pre-fix python3 -c form",
-      len(pre_inline) == 1)
-check("CONTROL: the ${...} assertion rejects the pre-fix inline form",
-      pre_inline and "${" in pre_inline[0])
-
-check("CONTROL: the open('${...}') assertion rejects the pre-fix form",
-      bool(re.search(r"open\(\s*['\"]\$\{", PRE_FIX_INLINE)))
-
-PRE_FIX_HEREDOC = (
-    "python3 - <<EOF\n"
-    "import json\n"
-    "d = json.load(open('${SPRINT_FILE}'))\n"
-    "EOF\n"
+GEN2 = (            # drift-check.sh / setup-skill-symlinks.sh, found by review
+    'mapfile -t SKILL_TREES < <(python3 -c "\n'
+    "import json,sys\n"
+    "try: d=json.load(open('${REGISTRY}'))\n"
+    "except Exception: sys.exit(0)\n"
+    '" 2>/dev/null || true)'
 )
-check("CONTROL: the heredoc matcher flags an unquoted expanding delimiter",
-      len(interpolating_python_heredocs(PRE_FIX_HEREDOC)) == 1)
-
-# Runtime proof #1 (benign): the pre-fix form misreports on a path with a `'`.
-benign = subprocess.run(
-    ["bash", "-c",
-     "set -uo pipefail\n"
-     "SPRINT_FILE=\"/tmp/it's-a-repo/current.json\"\n" + PRE_FIX_INLINE + "\n"
-     'echo "STATUS=${SPRINT_STATUS}"'],
-    capture_output=True, text=True,
+GEN3 = (            # an expanding heredoc, the shape #2688 removed
+    "python3 - <<EOF\nimport json\nd = json.load(open('${REPO_ROOT}/x.json'))\nEOF\n"
 )
-check("CONTROL: the pre-fix form falls back to '?' when the path contains a ' "
-      "(silent misreport)",
-      "STATUS=?" in benign.stdout)
 
-# Runtime proof #2 (ceiling): a crafted path component executes chosen code.
-# All characters below are legal in a POSIX path component.
-ceil_dir = tempfile.mkdtemp()
-try:
-    marker = pathlib.Path(ceil_dir) / "ICN2722_MARKER"
-    payload_path = (
-        "/x'+__import__('pathlib').Path('%s').write_text('x')*0*0+'y/current.json"
-        % marker
-    )
-    ceil = subprocess.run(
-        ["bash", "-c",
-         "set -uo pipefail\n"
-         "SPRINT_FILE=\"%s\"\n" % payload_path + PRE_FIX_INLINE],
-        capture_output=True, text=True,
-    )
-    check("CONTROL: the pre-fix form EXECUTES code embedded in the checkout path "
-          "(the ceiling of this class)", marker.exists())
-finally:
-    shutil.rmtree(ceil_dir, ignore_errors=True)
+for label, sample in (("gen-1 inline (icn#2722 as filed)", GEN1),
+                      ("gen-2 multiline (found by live review)", GEN2),
+                      ("gen-3 expanding heredoc", GEN3)):
+    srcs = python_sources(sample)
+    flagged = any(RE_EXPANSION.findall(body) for _, body in srcs)
+    check("CONTROL: the structural gate flags %s" % label, bool(srcs) and flagged)
+
+check("CONTROL: the gate does NOT flag the safe argv form",
+      not any(RE_EXPANSION.findall(b) for _, b in python_sources(
+          'python3 -c "import json,sys; json.load(open(sys.argv[1]))" "${REGISTRY}"')))
+check("CONTROL: the gate does NOT flag a quoted heredoc",
+      not python_sources("python3 - <<'EOF'\nimport os\nprint(os.environ['X'])\nEOF\n"))
 
 
 # ── summary ──────────────────────────────────────────────────────────────────

--- a/scripts/tests/test_what_matters_now_sprint_path.py
+++ b/scripts/tests/test_what_matters_now_sprint_path.py
@@ -91,6 +91,14 @@ def build_checkout(parent, dirname, scripts=None):
     """Materialise a minimal but real checkout at `parent/dirname`.
 
     The directory name is the whole point of the test, so it is passed verbatim.
+
+    The `.claude/agents` and `../.claude/skills` trees below are NOT decoration.
+    `drift-check.sh` guards two of the four sites this change fixes behind
+    `[[ -d "${PROJECT_SKILLS}" ]]` (:93) and `[[ -d "${AGENTS_DIR}" ]]` (:290).
+    Without these trees both guards take the skip branch, the `${REGISTRY}` and
+    `${AGENTS_FILE}` reads never execute, and an assertion about them would pass
+    against the pre-fix spelling too -- a control whose evidence path never runs,
+    which is the exact defect family this file exists to forbid.
     """
     root = pathlib.Path(parent) / dirname
     (root / "ops" / "scripts").mkdir(parents=True)
@@ -98,18 +106,59 @@ def build_checkout(parent, dirname, scripts=None):
         shutil.copy2(s, root / "ops" / "scripts" / s.name)
     for rel in STATE_FILES:
         src = ROOT / rel
+        # Fail closed, for the same reason git() does: a thinner fixture must
+        # never silently become weaker evidence.
         if not src.exists():
-            continue
+            raise SystemExit("fixture: required state file missing: %s" % rel)
         dst = root / rel
         dst.parent.mkdir(parents=True, exist_ok=True)
         shutil.copy2(src, dst)
-    # Some drift-check phases stat these trees; absent is fine, present is tidier.
-    (root / "ops" / "automation" / "skills").mkdir(parents=True, exist_ok=True)
+
+    canonical_skills = root / "ops" / "automation" / "skills"
+    canonical_skills.mkdir(parents=True, exist_ok=True)
+
+    # Drive the agents-registry read (drift-check.sh:291): one name that IS in the
+    # registry and one that is not, so both branches of the comparison execute.
+    agents_dir = root / ".claude" / "agents"
+    agents_dir.mkdir(parents=True)
+    registry_agents = sorted(
+        a["name"] for a in json.loads(
+            (ROOT / "ops" / "state" / "truth" / "agents.json").read_text())["agents"])
+    for name in registry_agents[:3]:
+        (agents_dir / ("%s.md" % name)).write_text("# %s\n" % name)
+    (agents_dir / "unregistered-extra.md").write_text("# unregistered-extra\n")
+
+    # Drive the symlink-registry read (drift-check.sh:95): PROJECT_SKILLS is
+    # ${REPO_ROOT}/../.claude/skills, i.e. inside `parent` -- never the real one.
+    project_skills = pathlib.Path(parent) / ".claude" / "skills"
+    project_skills.mkdir(parents=True, exist_ok=True)
+    registry_skills = [e["name"] for e in json.loads(
+        (ROOT / "ops" / "state" / "truth" / "skills.json").read_text()
+    )["skills"]["ops_automation_canonical"]]
+    if registry_skills:
+        # one correct symlink and one plain directory, so both arms are exercised
+        (canonical_skills / registry_skills[0]).mkdir(parents=True, exist_ok=True)
+        link = project_skills / registry_skills[0]
+        if not link.exists():
+            link.symlink_to(canonical_skills / registry_skills[0])
+        if len(registry_skills) > 1:
+            (project_skills / registry_skills[1]).mkdir(parents=True, exist_ok=True)
+
     git("git", "init", "-q", str(root))
     git("git", "-C", str(root), "config", "user.email", "t@example.invalid")
     git("git", "-C", str(root), "config", "user.name", "t")
     git("git", "-C", str(root), "add", "-A")
     git("git", "-C", str(root), "commit", "-qm", "init")
+
+    # Pin the isolation the whole behavioural section rests on. If REPO_ROOT
+    # resolution ever escaped the fixture, `plain` and `quoted` would resolve to
+    # the SAME real root and every check below would still pass -- green for a
+    # reason that has nothing to do with the quote.
+    top = subprocess.run(["git", "-C", str(root), "rev-parse", "--show-toplevel"],
+                         capture_output=True, text=True, check=True).stdout.strip()
+    if pathlib.Path(top).resolve() != root.resolve():
+        raise SystemExit("fixture: git toplevel %r escaped the fixture root %r"
+                         % (top, str(root)))
     return root
 
 
@@ -200,12 +249,22 @@ try:
     check("the quoted path does not trigger the 'fewer than 11 required checks' fail",
           "fewer than 11 required checks" not in d_out)
 
-    # agents.json -> registered agent names (site at :283). Reading it wrongly
-    # yields an empty name set, so compare the two runs' agent findings.
-    def agent_lines(r):
-        return [l for l in (r.stdout + r.stderr).splitlines() if "agent" in l.lower()]
-    check("agents registry produces the same findings on plain and quoted paths",
-          agent_lines(d_plain) == agent_lines(d_quoted))
+    # agents.json -> registered agent names (site at :291). Reading it wrongly
+    # yields an EMPTY name set, which turns every "Agent registered" into
+    # "Agent not in registry" -- so assert the positive line, not just equality.
+    registry_agents = sorted(
+        a["name"] for a in json.loads(
+            (ROOT / "ops" / "state" / "truth" / "agents.json").read_text())["agents"])
+    check("agents registry resolves registered names on a quoted path (%r)"
+          % registry_agents[:3],
+          all(("Agent registered: %s" % n) in d_out for n in registry_agents[:3]))
+    check("the agents read still detects a genuinely unregistered agent",
+          "Agent not in registry: unregistered-extra" in d_out)
+
+    # skills.json -> symlink names (site at :95). An empty read means the loop
+    # body never runs, so the plain-directory drift below would go unreported.
+    check("the symlink-registry read reports the machine-local plain directory",
+          "plain directory" in d_out or "NOT SYMLINK" in d_out)
 
     check("drift-check.sh reaches the same overall verdict on both paths "
           "(plain exit=%d, quoted exit=%d)" % (d_plain.returncode, d_quoted.returncode),
@@ -233,8 +292,13 @@ try:
     check("every registered skill name is still enumerated on a quoted path (%r)"
           % registered,
           all(n in s_out for n in registered) and len(registered) > 0)
-    check("--check did not create anything outside the fixture",
-          not (ROOT / ".." / ".claude" / "skills" / "__probe__").exists())
+    # Isolation is pinned by build_checkout()'s toplevel assertion, which proves
+    # REPO_ROOT resolves inside the fixture -- so SKILLS_DIR
+    # (${REPO_ROOT}/../.claude/skills) is the fixture's, not the developer's. An
+    # earlier `not (...__probe__).exists()` line here was decoration: nothing ever
+    # created __probe__, so the assertion could not fail.
+    check("--check is read-only: it reported problems without exiting 0 (exit=%d)"
+          % s_quoted.returncode, s_quoted.returncode != 0)
 finally:
     shutil.rmtree(tmp, ignore_errors=True)
 
@@ -319,6 +383,41 @@ try:
 finally:
     shutil.rmtree(iso, ignore_errors=True)
 
+# The ceiling of the class: the interpolated value reaches Python as SYNTAX, so a
+# crafted path component does not merely break parsing -- it runs. This control is
+# what entitles the PR to say so; without it that sentence would be a conclusion
+# whose evidence path no longer executes, which is the very defect this file is
+# about. (It was briefly deleted while addressing an "unused variable" comment;
+# the minimal response was to drop the binding, not the proof.)
+# Inert payload: writes a marker file. Every character is legal in a POSIX path.
+ceil_dir = tempfile.mkdtemp()
+try:
+    marker = pathlib.Path(ceil_dir) / "ICN2722_MARKER"
+    crafted = ("/x'+__import__('pathlib').Path('%s').write_text('x')*0*0+'y"
+               "/current.json" % marker)
+    subprocess.run(
+        ["bash", "-c",
+         "set -uo pipefail\nSPRINT_FILE=%s\n" % json.dumps(crafted) + PRE_FIX_INLINE],
+        capture_output=True, text=True,
+    )
+    check("CONTROL: the pre-fix form EXECUTES code embedded in the checkout path",
+          marker.exists())
+
+    # And the fixed form must NOT execute it -- the path is data, so it is only
+    # ever a filename that does not exist.
+    marker2 = pathlib.Path(ceil_dir) / "ICN2722_MARKER_2"
+    crafted2 = ("/x'+__import__('pathlib').Path('%s').write_text('x')*0*0+'y"
+                "/current.json" % marker2)
+    subprocess.run(
+        ["bash", "-c",
+         "set -uo pipefail\nSPRINT_FILE=%s\n" % json.dumps(crafted2) + FIXED_INLINE],
+        capture_output=True, text=True,
+    )
+    check("CONTROL: the fixed form does NOT execute it (path stays data)",
+          not marker2.exists())
+finally:
+    shutil.rmtree(ceil_dir, ignore_errors=True)
+
 
 # ── structural: no shell value reaches Python as syntax, in any in-scope script
 
@@ -331,11 +430,15 @@ print("--- the defect class cannot return (structural, all in-scope scripts) ---
 # `<<'EOF'` heredoc do not expand at all, and `script.py "$path"` passes argv --
 # which is the safe form. Scanning single-quoted bodies for `${` would in fact be
 # wrong: there a `${x}` is a literal string, not an injection.
-RE_C_DQ = re.compile(r'python3 -c "((?:[^"\\]|\\.)*)"', re.S)
+# `python3?` so a `python -c` spelling is not silently skipped; `<<-?` so the
+# dash-heredoc form is caught. The expansion pattern deliberately admits every
+# shape the shell substitutes -- `${VAR}`, `${VAR:-default}`, `${ARR[0]}`, `$VAR`,
+# `$1`, `$@`, `$(...)` -- because the earlier `${NAME}`-only spelling silently
+# passed `open('${SPRINT_FILE:-/dev/null}')` and `open('$1')`.
+RE_C_DQ = re.compile(r'python3? -c "((?:[^"\\]|\\.)*)"', re.S)
 RE_HEREDOC = re.compile(
-    r"python3 [-\w./]*\s*<<(['\"]?)([A-Za-z_][A-Za-z0-9_]*)\1\n(.*?)\n\2\b", re.S)
-RE_EXPANSION = re.compile(
-    r"\$\{[A-Za-z_][A-Za-z0-9_]*\}|\$\([^)]*\)|\$[A-Za-z_][A-Za-z0-9_]*")
+    r"python3? [-\w./]*\s*<<-?(['\"]?)([A-Za-z_][A-Za-z0-9_]*)\1\n(.*?)\n\s*\2\b", re.S)
+RE_EXPANSION = re.compile(r"\$\{[^}]*\}|\$\(|\$[A-Za-z_0-9@*#?-]")
 
 
 def python_sources(text):


### PR DESCRIPTION
Closes #2722.

<!-- ICN-DELIVERY-LIFECYCLE:BEGIN -->
- **State:** **FROZEN** at `0709b1aea6cdc613ab9ea96359dd33670d3005c5`. **Awaiting explicit human merge authorization. Not merged; no authorization requested or held.**
- **Freeze evidence (all verified live on the exact head):** local == remote == PR head; worktree clean; merge-base == `origin/main` `aecc9e686` (`strict:true` satisfied); **11/11 required contexts SUCCESS**, 0 pending, 0 failing; **0 unresolved review threads**; FULL generation CLOSED; DELTA clean; `icn-merge-pr check 2730` → **READY**; no auto-merge armed; no merge queue present.
- **The required gate really runs the new test:** the `Agent Tooling Drift Check` check-run on this head executed the step *"what-matters-now survives a quoted checkout path (Refs icn#2722)"* → `success`. The test is enforced, not merely present in the tree.
- **Lane:** #2722 — checkout-path → Python-source interpolation in the operational scripts
- **Acceptance contract (issue #2722):** no shell value reaches Python as *syntax*; a checkout path containing a `'` still produces correct output, proven by a test that fails against the pre-fix form; a repo-wide sweep of `ops/scripts/` and `scripts/` with **each hit fixed or explicitly cleared**; a structural gate so the class cannot land unnoticed. Non-goals: no sprint-semantics change, no invented sprint number, no re-open of #2688, no general shell cleanup.
- **Review generations:**
  - 1 bounded **FULL** on `a2d3b9bc2` → 0 BLOCKER, 2 FOLLOW_UP, 0 QUESTION, 2 NOT_A_FINDING; both fixed in `3fec2a418`. **CLOSED — not restarted.**
  - Live GitHub review (Copilot + code-quality) → **4 threads, all valid**, fixed in `a172ce123`, answered with evidence, **all resolved**. Copilot was right that the sweep was not cleared.
  - 1 bounded **DELTA** on `3fec2a418..a172ce123` → 0 BLOCKER, 5 FOLLOW_UP; all five fixed in `0709b1aea`. It re-swept `ops/scripts/` independently and confirmed **no remaining site and none missed**.
- **Tooling note:** the `chatgpt-codex-connector` comment is a **usage-limit notice, not a finding** — Codex did not review this PR. Its silence is absent coverage, not a clean result.
- **Non-required red:** `Security Audit` (#2579) and `Build and verify` (#2639) only — both separately owned and red on `main` itself. `UNSTABLE` is the expected colour; the merge contract is the 11 required contexts, all green.
- **Two findings worth naming, because both were this PR's own defect class:**
  1. Answering an "unused variable" comment, I deleted the **entire ceiling control** — the only executable evidence for a claim the body still made. Restored in `0709b1aea`, now paired with its missing half (the fixed form must *not* execute the payload).
  2. Two of the four `drift-check.sh` sites were **never executed** by the fixture (guarded behind `-d .claude/skills` / `-d .claude/agents`), so assertions about them would have passed against the pre-fix spelling. Now driven, and proven by per-site mutation.
- **Follow-up ledger:** **#2731** (OPEN) — two demo scripts splice a *token-derived* DID into Python source. Same shape, different provenance. Filed, not carried as PR-body-only debt.
<!-- ICN-DELIVERY-LIFECYCLE:END -->

## The defect

`ops/scripts/what-matters-now.sh` — the script behind the required `Agent Tooling Drift Check` — and two sibling operational scripts built `python3` calls by splicing the **checkout path** into Python *source* inside single-quoted string literals:

```sh
d = json.load(open('${SPRINT_FILE}'))   # ${REPO_ROOT}/ops/state/sprint/current.json
d = json.load(open('${REGISTRY}'))      # ${REPO_ROOT}/ops/state/truth/skills.json
```

`REPO_ROOT` is the checkout directory. A single quote is a legal POSIX path component, so a checkout path containing one closes the literal early and the remainder is parsed as Python.

This is the same class #2638/#2688 removed from the `--json` payload.

## Why it was invisible

Every affected call is wrapped in `2>/dev/null || echo "<fallback>"`. A `'` in the path did not crash — the Python error went to a suppressed stderr, the `||` fired, and the script continued with a plausible-looking fallback:

- sprint cadence → `unresolved (sprint owner unreadable)` **for a file it can read**
- the `required checks` line → **absent entirely**

The same family as #2723: a control reporting a conclusion its evidence path never produced.

## Reproduced before changing anything (against `dd21b2d0`)

Two byte-identical checkouts differing only in the directory name:

| | `plain-repo` | `it's-a-repo` |
|---|---|---|
| Sprint cadence | `no active sprint (cadence dormant)` ✓ | `unresolved (sprint owner unreadable)` ✗ |
| `required checks` | `11 required checks` ✓ | line absent ✗ |

**Ceiling of the class:** a crafted path component executed chosen code, proven with an inert marker file. Stated plainly: the checkout path is chosen by whoever provisions the machine — **not attacker-supplied on any current ICN path**. Real, worth fixing, not an incident, and not described here as exploitable.

## The sweep — corrected

The **first sweep was wrong**, and live review caught it. It used a line-based `grep`, which structurally cannot see a **multiline** `python3 -c "..."` body — and every remaining site was multiline. The PR previously claimed only two demo-script matches. That claim was false.

Re-swept semantically: a parser over **every** `python3` invocation under `ops/scripts/` and `scripts/`, classified by shape *and* by the provenance of each interpolated value.

**Result: 75 invocations · 11 where a shell value becomes Python syntax.**

### Fixed — checkout-derived, operational scripts (10 sites)

| file | lines | value |
|---|---|---|
| `ops/scripts/what-matters-now.sh` | 159, 170, 171, 172, 199 | `${SPRINT_FILE}` ×4, `${REPO_ROOT}` ×1 |
| `ops/scripts/drift-check.sh` | 27, 89 | `${REGISTRY}` — skills.json scan scope, symlink names |
| `ops/scripts/drift-check.sh` | 260, 283 | `${POLICY_FILE}`, `${AGENTS_FILE}` |
| `ops/scripts/setup-skill-symlinks.sh` | 27 | `${REPO_ROOT}` |

The issue named four sites; a fifth in the same file was found during implementation (`${REPO_ROOT}` for `policy.json`), and five more across two sibling scripts were found by live review plus the corrected sweep.

`drift-check.sh:68` is the canonical **safe** form the original fix comment cited — while the same file carried four unsafe sites. Citing one line of a file as canonical is not an audit of the file.

### Cleared with evidence — different provenance (4 sites)

| site | value | why |
|---|---|---|
| `demo-flow-d.sh:93` | `$field` | an author-written Python subscript constant (`"['name']"`); data arrives via stdin |
| `governance-demo.sh:109`, `:116` | `$DOMAIN_ID` | `coop:demo-$(date +%s)` — script-generated, quote-free by construction |
| `federated-governance-demo.sh:166` | `$DEMO_DOMAIN` | `demo-federation-$(date +%s)` — same |

### Filed as bounded debt (2 sites) — **#2731**

`governance-demo.sh:94` and `federated-governance-demo.sh:150` splice a **token-derived** DID (`$MY_DID` / `$ALPHA_TOKEN_DID`, decoded from a JWT payload) into Python source. Same shape, different provenance, demo-only path. Filed rather than silently cleared or folded in.

## The fix — one pattern

```
path/shell data  →  argv  →  Python reads data          (always)
path/shell data  →  interpolated Python syntax          (never)
```

Every site uses `python3 -c "... open(sys.argv[1]) ..." "${PATH_VALUE}"`. No bespoke escaping, no `eval`, no moving interpolation into another heredoc.

## Proof the tests discriminate

`scripts/tests/test_what_matters_now_sprint_path.py` — 34 checks:

- **Behavioural, all three operational scripts** driven from a real git checkout whose directory name contains `'`:
  - `what-matters-now.sh` — sprint cadence, `required checks` line, `--json` validity and truthful `sprint.status`;
  - `drift-check.sh` — skills-registry scan scope, `policy.json` required-check count (11), agents-registry findings, identical verdict on both paths;
  - `setup-skill-symlinks.sh --check` — registry loads and enumerates every registered skill. Runs against an **isolated temp filesystem**; `SKILLS_DIR` resolves inside the fixture, so the developer's real machine-local `.claude/skills` is never touched, and `--check` creates nothing.
- **Structural**, across all three in-scope scripts and all three shapes that let the shell rewrite Python source (single-line `-c`, multiline `-c`, unquoted heredoc). It deliberately does **not** ban `$` in Python source, and does not cover demo scripts.
- **MUST-FAIL controls**, including the rebuilt benign control. The previous one was vacuous — it used a non-existent path, so `FileNotFoundError` produced the same fallback. It now isolates the quote as the only variable:

| form | plain path | path with `'` |
|---|---|---|
| pre-fix (source-interpolated) | `RESULT=closed` ✓ | `RESULT=?` ✗ misreport |
| fixed (argv) | `RESULT=closed` ✓ | `RESULT=closed` ✓ |

  with an explicit assertion that both fixture files are readable and byte-identical. The genuine-unreadable cases (missing file, corrupt JSON) are pinned separately, so the change is proven not to trade a false "unreadable" for a false "readable".
- **Fail-closed fixtures:** all git setup runs with `check=True`. A half-built fixture used to be indistinguishable from a pass, because the scripts bail early on a non-repo and never reach the interesting code.

**Mutation evidence — per site.** Each of the six fixed sites (`what-matters-now.sh` SPRINT_STATUS; `drift-check.sh` :27, :95, :262, :291; `setup-skill-symlinks.sh` :27) was reverted **individually**, and each is caught by a **behavioural** assertion, not only the structural gate. Reverting only :95 fails exactly the symlink-registry assertion; reverting only :291 fails the agents assertions. Nothing mutated is committed.

Wired into `.github/workflows/agent-drift-check.yml` beside its siblings, so it runs under the required context. `#2688` and `#2723` regression suites still pass; `drift-check.sh` and `--drift` both still exit 0.

## Non-goals

- No sprint-semantics change; no invented sprint number (#2637).
- Does not re-open #2688's `--json` fix.
- No behaviour change on a normal checkout path.
- No general shell cleanup: demo scripts are classified, not rewritten.
- No claim of attacker reachability beyond an operator-controlled checkout path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


