### PR TITLE
refactor(cli): give entry-intrinsic ledger validation one owner and make verify-backup consult it (#2736)

### DIFF
--- a/docs/architecture/n2-a-migration-gate.md
+++ b/docs/architecture/n2-a-migration-gate.md
@@ -1322,7 +1322,10 @@ every §11 disposition are untouched, and no readiness classification moves.
   `--verify-ledger` branch names only what it computed — archive integrity, the N2-A audit of the
   restored tree, and — since icn#2736 — that every ledger entry is valid under
   `icn_ledger::entry_validation`, the owner `Ledger::validate_entry` itself consults, together with
-  the ledger validations it did not perform (hashes, signatures, provenance, parent existence).
+  the ledger validations it did not perform (amount signs, hashes, signatures, provenance,
+  parent existence). Amount signs stay named: `icn-ledger` owns a sign check in
+  `entry::validate_positive_amounts`, reached by `JournalEntryBuilder`, which this command does
+  not run, so "valid under icn-ledger's entry validation" must not be read as the crate's union.
   Before icn#2736 the invariant was claimed only **when a balance was actually computed**, because a
   journal whose entries carried no currency deltas satisfied it vacuously and the summary said so
   instead of claiming it; delegating to the owner made that state unreachable — an entry with no

--- a/docs/architecture/n2-a-migration-gate.md
+++ b/docs/architecture/n2-a-migration-gate.md
@@ -1320,14 +1320,20 @@ every §11 disposition are untouched, and no readiness classification moves.
   command never establishes it: bare `verify-backup` now states that ledger contents and the N2-A
   audit were **not** verified and that `--verify-ledger` is how to check them, and the
   `--verify-ledger` branch names only what it computed — archive integrity, the N2-A audit of the
-  restored tree, and the double-entry invariant **when a balance was actually computed**; a journal
-  whose entries carry no currency deltas satisfies that invariant vacuously, so there the summary
-  says so instead of claiming it — together with the ledger validations it did not perform (amount
-  signs, hashes, signatures, provenance, parent existence, empty-entry rejection). **The bare branch's checks
-  are unchanged — only its claim narrowed.** The `--verify-ledger` branch did change what it
-  checks, and the bullet below records how: it resolves the canonical ledger path, refuses an
-  absent or partial database before the gate can create one, decodes rows as `JournalEntry`, and
-  balances per entry. Widening what the *bare* command verifies would change what it means and is
+  restored tree, and — since icn#2736 — that every ledger entry is valid under
+  `icn_ledger::entry_validation`, the owner `Ledger::validate_entry` itself consults, together with
+  the ledger validations it did not perform (hashes, signatures, provenance, parent existence).
+  Before icn#2736 the invariant was claimed only **when a balance was actually computed**, because a
+  journal whose entries carried no currency deltas satisfied it vacuously and the summary said so
+  instead of claiming it; delegating to the owner made that state unreachable — an entry with no
+  account deltas is now **refused** rather than passed over — so the remaining no-balance terminal is
+  an empty journal. Freeze state, credit limits and progressive limits stay outside the claim by
+  construction: they are append-time policy evaluated against live ledger state and the current
+  clock, so an offline verifier applying them would reject entries that were valid when appended.
+  **The bare branch's checks are unchanged — only its claim narrowed.** The `--verify-ledger` branch
+  did change what it checks, and the bullet below records how: it resolves the canonical ledger path,
+  refuses an absent or partial database before the gate can create one, decodes rows as
+  `JournalEntry`, and asks the ledger's own validator whether each one is valid. Widening what the *bare* command verifies would change what it means and is
   still not done here.
 - **A pre-existing `verify-backup` path bug, found while placing that gate. FIXED by icn#2717.**
   `verify_ledger_in_backup` looked for `<restore_dir>/ledger`, but `backup` archives the data

--- a/icn/bins/icnctl/src/main.rs
+++ b/icn/bins/icnctl/src/main.rs
@@ -6839,11 +6839,18 @@ fn handle_verify_backup_command(input: &Path, verify_ledger: bool) -> Result<()>
             println!("restored tree. The ledger contains no entries, so no entry was");
             println!("validated and no double-entry balance was computed.");
         }
-        println!("NOT verified: content hashes, signatures, provenance, parent");
-        println!("existence. Freeze state, credit limits and progressive limits are");
-        println!("append-time policy — evaluated against live ledger state and the");
-        println!("current clock — so they are not properties of a backup at rest and");
-        println!("are deliberately not checked here.");
+        // "amount signs" STAYS in this list. Delegation did not make signs a
+        // checked property, and dropping the token would have been a silent
+        // widening in the one sentence an operator reads as the not-verified set
+        // — the sharper because `icn-ledger` DOES own a sign check
+        // (`entry::validate_positive_amounts`, reached by `JournalEntryBuilder`),
+        // which this command does not run. "Valid under icn-ledger's own entry
+        // validation" must therefore say plainly that signs are not part of it.
+        println!("NOT verified: amount signs, content hashes, signatures,");
+        println!("provenance, parent existence. Freeze state, credit limits and");
+        println!("progressive limits are append-time policy — evaluated against live");
+        println!("ledger state and the current clock — so they are not properties of a");
+        println!("backup at rest and are deliberately not checked here.");
     } else {
         println!("Verified: archive integrity, checksum, and required files.");
         println!("NOT verified: ledger contents and the N2-A principal audit.");

--- a/icn/bins/icnctl/src/main.rs
+++ b/icn/bins/icnctl/src/main.rs
@@ -6814,31 +6814,36 @@ fn handle_verify_backup_command(input: &Path, verify_ledger: bool) -> Result<()>
     // it never established (#2717). The bare command's *checks* are unchanged;
     // only the claim is narrowed to them.
     if verify_ledger {
-        // Name the ONE invariant that was checked. `verify_ledger_in_backup`
-        // verifies Σdebit == Σcredit per currency and nothing else — not positive
-        // amounts, content hashes, signatures, provenance or parent existence — so
-        // "ledger invariants" in the plural claimed a validation this command does
-        // not perform. Narrowing the sentence is the same correction this PR makes
-        // to the bare command, applied to the line it added.
-        // Name only what was actually computed. A journal whose entries carry
-        // no currency deltas satisfies the per-currency invariant vacuously, so
-        // claiming "the double-entry invariant" there would contradict the
-        // detail line printed three lines above it.
-        let balanced = ledger_check
+        // Name exactly what was established, and widen it only as far as the
+        // checks actually widened. Entry validity is now decided by
+        // `icn_ledger::entry_validation` — the owner `Ledger::validate_entry`
+        // consults on append — so "empty-entry rejection" moves out of the
+        // NOT-performed list and into the claim. Nothing else does (icn#2736).
+        let entries = ledger_check.as_ref().map(|c| c.entries).unwrap_or(0);
+        let currencies = ledger_check
             .as_ref()
-            .map(|c| c.currencies_balanced > 0)
-            .unwrap_or(false);
-        if balanced {
-            println!("Verified: archive integrity, the double-entry invariant, and the");
-            println!("N2-A principal audit of the restored tree.");
+            .map(|c| c.currencies_balanced)
+            .unwrap_or(0);
+        if entries > 0 {
+            println!("Verified: archive integrity; that all {entries} ledger entries are valid");
+            println!("under icn-ledger's own entry validation (at least one account delta,");
+            println!("and the double-entry invariant per entry under checked i64, across");
+            println!(
+                "{currencies} currencies); and the N2-A principal audit of the restored tree."
+            );
         } else {
-            let entries = ledger_check.as_ref().map(|c| c.entries).unwrap_or(0);
+            // Reachable only for a journal with no entries at all. Every
+            // `AccountDelta` carries a currency and an entry with none is now
+            // refused, so a non-empty journal always yields a computed balance.
             println!("Verified: archive integrity and the N2-A principal audit of the");
-            println!("restored tree. {entries} ledger entries carried no currency delta,");
-            println!("so no double-entry balance was computed.");
+            println!("restored tree. The ledger contains no entries, so no entry was");
+            println!("validated and no double-entry balance was computed.");
         }
-        println!("Other ledger validations (amount signs, hashes, signatures,");
-        println!("provenance, parent existence, empty-entry rejection) were NOT performed.");
+        println!("NOT verified: content hashes, signatures, provenance, parent");
+        println!("existence. Freeze state, credit limits and progressive limits are");
+        println!("append-time policy — evaluated against live ledger state and the");
+        println!("current clock — so they are not properties of a backup at rest and");
+        println!("are deliberately not checked here.");
     } else {
         println!("Verified: archive integrity, checksum, and required files.");
         println!("NOT verified: ledger contents and the N2-A principal audit.");
@@ -6961,11 +6966,11 @@ fn sanitize_diagnostic(line: &str) -> String {
 
 /// What `verify_ledger_in_backup` actually established.
 ///
-/// Returned rather than inferred so the operator-facing summary cannot claim a
-/// balance that was never computed: a journal whose entries carry no currency
-/// deltas satisfies the per-currency invariant vacuously, and saying "the
-/// double-entry invariant" was verified there would be the same overclaim this
-/// command exists to stop making.
+/// Returned rather than inferred so the operator-facing summary reports coverage
+/// from evidence and never from the absence of an error. `currencies_balanced`
+/// counts only currencies `icn_ledger::entry_validation` summed to zero, so the
+/// summary can name the breadth of the double-entry claim instead of asserting
+/// it flatly.
 struct LedgerCheck {
     entries: usize,
     currencies_balanced: usize,
@@ -7014,14 +7019,10 @@ fn verify_ledger_in_backup(restore_dir: &Path) -> Result<LedgerCheck> {
     let entry_count = entries.len();
     println!("  Found {entry_count} ledger entries");
 
-    // Verify the double-entry invariant: within EACH entry, Σ debits == Σ credits
-    // per currency — the same scope `Ledger::validate_entry` enforces on append.
-    let mut unbalanced_rows: Vec<String> = Vec::new();
-    // Detail lines are per CURRENCY; a row imbalanced in two currencies
-    // contributes two. Counting rows separately stops the report claiming
-    // "2 of 1 ledger row(s) do not balance" — an impossible statement
-    // about the operator's own data.
-    let mut unbalanced_row_count = 0usize;
+    // Decide each row's validity by asking icn-ledger, not by re-deriving its
+    // rules here. See the call site below for why that owner exists (icn#2736).
+    let mut invalid_rows: Vec<String> = Vec::new();
+    let mut invalid_row_count = 0usize;
     let mut currencies_seen: std::collections::BTreeSet<String> = std::collections::BTreeSet::new();
     // Deserialize each row into the PERSISTED LEDGER TYPE, not an untyped
     // `serde_json::Value`.
@@ -7054,73 +7055,40 @@ fn verify_ledger_in_backup(restore_dir: &Path) -> Result<LedgerCheck> {
             }
         };
 
-        // Balance is checked PER ROW, matching what the ledger enforces.
-        // `Ledger::validate_entry` (icn-ledger/src/ledger.rs) scopes its
-        // `currency_sums` to a single entry — `for delta in &entry.accounts` — and
-        // requires every currency to sum to zero for THAT entry. Accumulating
-        // across the whole journal is a strictly weaker check: two rows at +60 and
-        // −60 `hours` cancel ledger-wide and would have been reported as verified,
-        // while the ledger would have rejected both on append. Per-row balance
-        // implies the ledger-wide total, so this subsumes the old check rather
-        // than adding to it.
-        // i64 with checked arithmetic, using the ledger's own `net_change()` —
-        // NOT a widened i128. `validate_entry` accumulates in `HashMap<String, i64>`
-        // and rejects overflow as `ArithmeticOverflow`, so a row whose running
-        // per-currency total exceeds i64 and later cancels (debits of i64::MAX and
-        // 1, then matching credits) is rejected there. Computing the same sum in
-        // i128 cannot overflow, so it reaches zero and would report the row
-        // verified — accepting exactly what the ledger refuses. Same words, weaker
-        // check, which is the shape this whole command kept failing in.
-        let mut row_sums: std::collections::HashMap<String, i64> = std::collections::HashMap::new();
-        let mut row_overflowed = false;
-
-        for account in &entry.accounts {
-            let currency = &account.currency;
-
-            let net = match account.net_change() {
-                Ok(net) => net,
-                Err(e) => {
-                    unbalanced_rows.push(sanitize_diagnostic(&format!("{row}: {e}")));
-                    row_overflowed = true;
-                    break;
-                }
-            };
-
-            let sum = row_sums.entry(currency.clone()).or_insert(0);
-            match sum.checked_add(net) {
-                Some(next) => *sum = next,
-                None => {
-                    unbalanced_rows.push(sanitize_diagnostic(&format!(
-                        "{row}: arithmetic overflow accumulating currency {currency}"
-                    )));
-                    row_overflowed = true;
-                    break;
-                }
+        // Ask icn-ledger whether this entry is valid. Do not re-derive the rule.
+        //
+        // `icn_ledger::entry_validation::inspect_entry` is the SAME owner
+        // `Ledger::validate_entry` consults on append, so the two cannot answer
+        // differently — which they twice did while this command kept its own copy
+        // (icn#2717): it summed balances across the whole journal where the ledger
+        // sums per entry, and it accumulated in a widened `i128` where the ledger
+        // uses checked `i64`, so a row the ledger rejects as an overflow reached
+        // zero here and was certified. A third divergence was already latent and is
+        // closed by the same move: an entry with an empty `accounts` array balances
+        // vacuously under a balance-only check, and the mirrored code passed it over
+        // while `validate_entry` rejects it on its first line (icn#2736).
+        //
+        // The owner is a free function over `&JournalEntry`: it opens nothing, locks
+        // nothing and reads no clock, so consulting it costs this command none of the
+        // read-only posture icn#2717 established. Deliberately NOT delegated to is
+        // the rest of `validate_entry` — freeze state, credit limits, progressive
+        // limits — which is evaluated against live ledger state and `SystemTime::now()`.
+        // Those are append-time policy, not properties of an archived journal;
+        // re-running them offline would reject entries that were valid when appended.
+        let intrinsics = icn_ledger::entry_validation::inspect_entry(&entry);
+        if intrinsics.is_valid() {
+            // Only currencies the owner actually summed to zero. Coverage is
+            // reported from evidence, never inferred from the absence of an error.
+            currencies_seen.extend(intrinsics.currencies_balanced().iter().cloned());
+        } else {
+            // Detail lines are per DEFECT; a row invalid in two currencies
+            // contributes two. Counting rows separately stops the report claiming
+            // "2 of 1 ledger row(s)" — an impossible statement about the
+            // operator's own data.
+            for defect in intrinsics.defects() {
+                invalid_rows.push(sanitize_diagnostic(&format!("{row}: {defect}")));
             }
-        }
-
-        if row_overflowed {
-            // The row is already recorded as failing; do not also fold its partial
-            // sums into the balance verdict. It still counts as ONE failing row —
-            // omitting it here would under-report the corruption scope by exactly
-            // the rows that failed hardest.
-            unbalanced_row_count += 1;
-            continue;
-        }
-
-        let mut row_unbalanced = false;
-        for (currency, sum) in row_sums {
-            if sum != 0 {
-                unbalanced_rows.push(sanitize_diagnostic(&format!(
-                    "{row}: currency {currency} sums to {sum}"
-                )));
-                row_unbalanced = true;
-            }
-            // Record the currency so the report can say how many were covered.
-            currencies_seen.insert(currency);
-        }
-        if row_unbalanced {
-            unbalanced_row_count += 1;
+            invalid_row_count += 1;
         }
     }
 
@@ -7138,32 +7106,42 @@ fn verify_ledger_in_backup(restore_dir: &Path) -> Result<LedgerCheck> {
         );
     }
 
-    if !unbalanced_rows.is_empty() {
-        for row in unbalanced_rows.iter().take(5) {
+    if !invalid_rows.is_empty() {
+        for row in invalid_rows.iter().take(5) {
             println!("  ✗ {row}");
         }
+        // "do not balance" was accurate while balance was the only rule checked.
+        // The owner also rejects an entry carrying no account deltas, which does
+        // not "fail to balance" — it has nothing to balance — so the sentence has
+        // to name the actual verdict rather than the rule it used to be about.
         bail!(
-            "FAILED: {} of {} ledger row(s) do not balance. The ledger enforces \
-             double entry per entry, so these rows would be rejected on append; \
-             a journal containing them is not a valid ledger even if the totals \
-             happen to cancel across rows.",
-            unbalanced_row_count,
+            "FAILED: {} of {} ledger row(s) are not valid journal entries. Each \
+             was rejected by icn-ledger's own entry validation — the same owner \
+             `Ledger::validate_entry` consults on append — so these rows would \
+             not have been accepted into a ledger, and a journal containing them \
+             is not a valid ledger even if the totals happen to cancel across rows.",
+            invalid_row_count,
             entry_count
         );
     }
 
-    if currencies_seen.is_empty() {
-        if entry_count == 0 {
-            println!("  ✓ Ledger empty (no entries)");
-        } else {
-            println!(
-                "  ✓ {entry_count} entries read; none carried a currency delta, \
-                 so no balance was computed"
-            );
-        }
+    if entry_count == 0 {
+        println!("  ✓ Ledger empty (no entries)");
     } else {
+        // Every surviving entry passed the owner, and the owner rejects an entry
+        // with no account deltas — so a non-empty journal that reaches here has
+        // at least one `AccountDelta`, and every `AccountDelta` carries a
+        // currency. `currencies_seen` therefore cannot be empty at this point.
+        // Before icn#2736 it could, and the summary needed a third arm for
+        // "entries read, nothing summed"; delegation removed that state rather
+        // than the wording papering over it.
+        debug_assert!(
+            !currencies_seen.is_empty(),
+            "a validated non-empty journal always yields at least one currency"
+        );
         println!(
-            "  ✓ Double-entry invariant verified per entry across {} entries and {} currencies",
+            "  ✓ {} entries valid under icn-ledger's entry validation; \
+             double-entry invariant holds per entry across {} currencies",
             entry_count,
             currencies_seen.len()
         );

--- a/icn/bins/icnctl/tests/verify_backup_ledger_test.rs
+++ b/icn/bins/icnctl/tests/verify_backup_ledger_test.rs
@@ -262,8 +262,13 @@ fn an_imbalanced_ledger_in_a_real_archive_is_not_reported_as_verified() {
     // changed when balance moved to per-entry scope; asserting the specific
     // wording is what keeps this from passing on a vaguer failure later.
     assert!(
-        text.contains("do not balance"),
-        "the failure must say the rows do not balance:\n{text}"
+        text.contains("are not valid journal entries"),
+        "the failure must say the rows were rejected as journal entries:\n{text}"
+    );
+    assert!(
+        text.contains("does not balance"),
+        "and the per-row detail must say why — that this row does not balance, \
+         which is a different statement from the row being unreadable:\n{text}"
     );
     assert!(
         text.contains("sums to 60"),
@@ -300,9 +305,14 @@ fn a_balanced_ledger_is_verified_and_reported_as_actually_inspected() {
         "a balanced ledger must verify:\n{text}"
     );
     assert!(
-        text.contains("Double-entry invariant verified"),
+        text.contains("double-entry invariant holds per entry"),
         "success must state that the invariant was actually checked, not merely \
          that the command finished:\n{text}"
+    );
+    assert!(
+        text.contains("valid under icn-ledger's entry validation"),
+        "and it must name the owner it asked, because that — not a local copy of \
+         the rule — is what the result is evidence of (icn#2736):\n{text}"
     );
     // The exact count, not a disjunction that its own second operand subsumes:
     // `contains("Found 1 ...") || contains("ledger entries")` can never fail on
@@ -321,9 +331,22 @@ fn a_balanced_ledger_is_verified_and_reported_as_actually_inspected() {
     // here, rewording it would make that negative unfalsifiable and leave the
     // balanced branch's headline claim pinned by nothing.
     assert!(
-        text.contains("Verified: archive integrity, the double-entry invariant"),
-        "a balanced ledger must state that the double-entry invariant was among \
-         the things verified:\n{text}"
+        text.contains("Verified: archive integrity; that all 1 ledger entries are valid"),
+        "a balanced ledger must state that every entry was validated, and over how \
+         many rows:\n{text}"
+    );
+    // The WIDENED claim. Delegation made "every entry carries at least one
+    // account delta" a checked property, so icn#2736 required the summary to say
+    // so in the same change. Without this the widening is unfalsifiable: dropping
+    // the sentence would leave every other assertion here green.
+    assert!(
+        text.contains("at least one account delta"),
+        "the summary must name the property delegation actually added:\n{text}"
+    );
+    assert!(
+        text.contains("checked i64"),
+        "and the arithmetic the balance was computed in, since a widened \
+         accumulator is the divergence that started this:\n{text}"
     );
     // The success summary must name only what was checked. This command verifies
     // Sigma-debit == Sigma-credit and nothing else about the ledger, so a plural
@@ -339,8 +362,17 @@ fn a_balanced_ledger_is_verified_and_reported_as_actually_inspected() {
          signatures or provenance, so it must not certify safe restoration:\n{text}"
     );
     assert!(
-        text.contains("were NOT performed"),
+        text.contains("NOT verified: content hashes, signatures, provenance"),
         "success must state which ledger validations it did not perform:\n{text}"
+    );
+    // Freeze state and credit limits are append-time policy, not properties of a
+    // backup. Delegation deliberately does NOT reach them, so the output must not
+    // let an operator read "validated by icn-ledger" as covering them.
+    assert!(
+        text.contains("Freeze state, credit limits and progressive limits are")
+            && text.contains("deliberately not checked here"),
+        "the summary must name what delegation deliberately did not bring with \
+         it, or 'valid under icn-ledger's entry validation' overclaims:\n{text}"
     );
 }
 
@@ -407,9 +439,14 @@ fn a_tampered_ledger_whose_rows_cannot_be_read_is_not_reported_as_verified() {
         "the failure must say the rows could not be read:\n{text}"
     );
     assert!(
-        !text.contains("Double-entry invariant verified"),
+        !text.contains("double-entry invariant holds per entry"),
         "it must not claim the invariant was verified over rows it could not \
          read:\n{text}"
+    );
+    assert!(
+        !text.contains("valid under icn-ledger's entry validation"),
+        "nor that the ledger's own validator accepted rows that never reached \
+         it:\n{text}"
     );
     assert!(
         !text.contains("BACKUP VERIFICATION PASSED"),
@@ -417,75 +454,63 @@ fn a_tampered_ledger_whose_rows_cannot_be_read_is_not_reported_as_verified() {
     );
 }
 
-/// The two success terminals that reach the banner WITHOUT computing a balance
+/// The one success terminal that reaches the banner WITHOUT computing a balance
 /// must not claim the double-entry invariant was verified.
 ///
-/// These were the only success paths in the command with no test. Both exit 0
-/// and print the full `--verify-ledger` summary, so under the acceptance ceiling
-/// they are claims the command makes and need discriminating evidence like any
-/// other. A journal whose entries carry no currency deltas satisfies the
-/// per-currency invariant *vacuously*; saying it was verified there would
-/// contradict the detail line printed three lines above.
+/// This was a success path in the command with no test. It exits 0 and prints the
+/// full `--verify-ledger` summary, so under the acceptance ceiling it is a claim
+/// the command makes and needs discriminating evidence like any other.
+///
+/// It used to have TWO arms. The second was a journal whose entries carried no
+/// currency deltas — an entry with an empty `accounts` array, which satisfies the
+/// per-currency invariant *vacuously*. icn#2717 responded by narrowing the claim
+/// there; icn#2736 moved the decision to `icn_ledger::entry_validation`, which
+/// REFUSES such an entry, so that arm is now a failure and lives in
+/// `an_entry_with_no_account_deltas_is_refused_rather_than_certified`.
+///
+/// What remains is genuinely unreachable by any other route: every `AccountDelta`
+/// carries a currency and an entry with no deltas is refused, so a journal that
+/// reaches the banner with nothing summed is a journal with no entries at all.
 #[test]
-fn success_without_a_computed_balance_does_not_claim_the_invariant_was_verified() {
-    // (label, seed the ledger, expected detail line)
-    let cases: [(&str, bool, &str); 2] = [
-        ("empty ledger", false, "Ledger empty (no entries)"),
-        (
-            "entries with no currency delta",
-            true,
-            // Must be unique to the DETAIL line. "carried no currency delta"
-            // alone also appears in the summary that BOTH arms print, so arm 2
-            // would pass without its terminal ever executing.
-            "1 entries read; none carried a currency delta",
-        ),
-    ];
+fn an_empty_ledger_does_not_claim_the_invariant_was_verified() {
+    let dir = TempDir::new().unwrap();
+    let data_dir = dir.path().join("data");
+    let archive = dir.path().join("backup.tar");
 
-    for (label, with_rows, expected_detail) in cases {
-        let dir = TempDir::new().unwrap();
-        let data_dir = dir.path().join("data");
-        let archive = dir.path().join("backup.tar");
+    init_identity(&data_dir);
+    // A real database with no journal rows at all.
+    let path = ledger_dir(&data_dir);
+    std::fs::create_dir_all(&path).unwrap();
+    let store = SledStore::open(&path).unwrap();
+    store.db().flush().unwrap();
+    drop(store);
+    make_backup(&data_dir, &archive);
 
-        init_identity(&data_dir);
-        if with_rows {
-            // A decodable entry with an empty `accounts` array: nothing to sum.
-            write_journal_row(&data_dir, &serde_json::to_vec(&journal_entry(&[])).unwrap());
-        } else {
-            // A real database with no journal rows at all.
-            let path = ledger_dir(&data_dir);
-            std::fs::create_dir_all(&path).unwrap();
-            let store = SledStore::open(&path).unwrap();
-            store.db().flush().unwrap();
-            drop(store);
-        }
-        make_backup(&data_dir, &archive);
+    let out = verify(&archive, true);
+    let text = combined(&out);
 
-        let out = verify(&archive, true);
-        let text = combined(&out);
-
-        assert!(
-            out.status.success(),
-            "[{label}] a ledger with nothing to balance is not itself a failure:\n{text}"
-        );
-        assert!(
-            text.contains(expected_detail),
-            "[{label}] the detail line must say what was actually read:\n{text}"
-        );
-        // The claim, which is the point of these two cases.
-        assert!(
-            !text.contains("Verified: archive integrity, the double-entry invariant"),
-            "[{label}] no balance was computed, so the summary must not claim the \
-             double-entry invariant was verified:\n{text}"
-        );
-        assert!(
-            text.contains("no double-entry balance was computed"),
-            "[{label}] the summary must say plainly that no balance was computed:\n{text}"
-        );
-        assert!(
-            !text.contains("This backup can be safely restored"),
-            "[{label}] it must not certify safe restoration:\n{text}"
-        );
-    }
+    assert!(
+        out.status.success(),
+        "a ledger with nothing to balance is not itself a failure:\n{text}"
+    );
+    assert!(
+        text.contains("Ledger empty (no entries)"),
+        "the detail line must say what was actually read:\n{text}"
+    );
+    // The claim, which is the point of this case.
+    assert!(
+        !text.contains("double-entry invariant per entry"),
+        "no balance was computed, so the summary must not claim the double-entry \
+         invariant was verified:\n{text}"
+    );
+    assert!(
+        text.contains("no double-entry balance was computed"),
+        "the summary must say plainly that no balance was computed:\n{text}"
+    );
+    assert!(
+        !text.contains("This backup can be safely restored"),
+        "it must not certify safe restoration:\n{text}"
+    );
 }
 
 /// A hostile journal key must not reach the operator's terminal verbatim.
@@ -640,7 +665,7 @@ fn one_row_imbalanced_in_two_currencies_is_counted_as_one_row() {
         "an imbalanced row must fail:\n{text}"
     );
     assert!(
-        text.contains("1 of 1 ledger row(s) do not balance"),
+        text.contains("1 of 1 ledger row(s) are not valid journal entries"),
         "the count must be of rows, not of per-currency detail lines:\n{text}"
     );
     // Both currencies should still be named in the detail lines.
@@ -727,8 +752,9 @@ fn two_rows_whose_imbalances_cancel_are_not_reported_as_verified() {
          cancel across the journal:\n{text}"
     );
     assert!(
-        text.contains("do not balance"),
-        "the failure must say which rows did not balance:\n{text}"
+        text.contains("are not valid journal entries") && text.contains("does not balance"),
+        "the failure must say which rows were rejected, and that the reason was \
+         balance rather than some other defect:\n{text}"
     );
     assert!(
         !text.contains("BACKUP VERIFICATION PASSED"),
@@ -977,7 +1003,8 @@ fn bare_verify_backup_does_not_claim_a_ledger_verification_it_did_not_do() {
     );
     // The bare command does not inspect the ledger, so it must not speak about it.
     assert!(
-        !text.contains("Double-entry invariant verified"),
+        !text.contains("double-entry invariant holds per entry")
+            && !text.contains("valid under icn-ledger's entry validation"),
         "bare verify-backup did not check the ledger and must not say it did:\n{text}"
     );
     assert!(
@@ -989,5 +1016,274 @@ fn bare_verify_backup_does_not_claim_a_ledger_verification_it_did_not_do() {
     assert!(
         text.contains("--verify-ledger"),
         "the report must name what was NOT verified and how to ask for it:\n{text}"
+    );
+}
+
+// ── icn#2736: the verifier consults icn-ledger's validator, not a copy ──────
+
+/// Recursive content identity of a directory tree.
+///
+/// Records every path *and* what is at it: directory, symlink target, or file
+/// length plus the SHA-256 of its bytes. Two properties matter and neither is
+/// decoration. Comparing the whole map catches a **new** file — the sled
+/// artefacts (`snap.*`, a grown `db`, a rewritten `conf`) an opening verifier
+/// would leave behind — because an added key makes the maps unequal. And the
+/// identity is content, never mtime, so the assertion cannot pass merely
+/// because a clock did not tick, nor fail merely because it did.
+fn tree_identity(root: &Path) -> std::collections::BTreeMap<String, String> {
+    use sha2::{Digest, Sha256};
+
+    let mut out = std::collections::BTreeMap::new();
+    for entry in walkdir::WalkDir::new(root)
+        .follow_links(false)
+        .sort_by_file_name()
+    {
+        let entry = entry.expect("could not walk tree");
+        let relative = entry
+            .path()
+            .strip_prefix(root)
+            .expect("walked path must be under root")
+            .to_string_lossy()
+            .to_string();
+        if relative.is_empty() {
+            continue; // the root itself
+        }
+        let identity = if entry.file_type().is_symlink() {
+            format!(
+                "symlink:{}",
+                std::fs::read_link(entry.path())
+                    .expect("could not read symlink")
+                    .display()
+            )
+        } else if entry.file_type().is_dir() {
+            "dir".to_string()
+        } else {
+            let bytes = std::fs::read(entry.path()).expect("could not read file");
+            let mut hasher = Sha256::new();
+            hasher.update(&bytes);
+            format!("file:{}:{:x}", bytes.len(), hasher.finalize())
+        };
+        out.insert(relative, identity);
+    }
+    assert!(
+        !out.is_empty(),
+        "fixture: a tree identity over an empty walk would make every comparison vacuous"
+    );
+    out
+}
+
+fn file_sha(path: &Path) -> String {
+    use sha2::{Digest, Sha256};
+    let mut hasher = Sha256::new();
+    hasher.update(std::fs::read(path).expect("could not read file"));
+    format!("{:x}", hasher.finalize())
+}
+
+/// THE discriminating case for icn#2736.
+///
+/// A `JournalEntry` with an empty `accounts` array decodes cleanly and satisfies
+/// a per-currency balance check **vacuously** — there is nothing to sum — so a
+/// verifier that mirrors only the balance rule accepts it. `Ledger::validate_entry`
+/// rejects it on its first line: *"Entry has no account deltas"*. The ledger
+/// would never have accepted this row on append.
+///
+/// Against `main` this test FAILS: the command exits 0 and prints
+/// `BACKUP VERIFICATION PASSED` with a narrowed claim. It can only pass once the
+/// verifier asks `icn-ledger`'s own validator instead of re-deriving one rule of
+/// it. That is the whole observable purchase of the delegation.
+#[test]
+fn an_entry_with_no_account_deltas_is_refused_rather_than_certified() {
+    let dir = TempDir::new().unwrap();
+    let data_dir = dir.path().join("data");
+    let archive = dir.path().join("backup.tar");
+
+    init_identity(&data_dir);
+    write_journal_row(&data_dir, &serde_json::to_vec(&journal_entry(&[])).unwrap());
+    make_backup(&data_dir, &archive);
+
+    let out = verify(&archive, true);
+    let text = combined(&out);
+
+    assert!(
+        !out.status.success(),
+        "the ledger rejects an entry with no account deltas, so a backup \
+         containing one must not verify:\n{text}"
+    );
+    assert!(
+        !text.contains("BACKUP VERIFICATION PASSED"),
+        "it must not print the success banner:\n{text}"
+    );
+    assert!(
+        text.contains("no account deltas"),
+        "the failure must name the actual defect, not a generic imbalance — an \
+         entry with nothing in it does not 'fail to balance':\n{text}"
+    );
+    assert!(
+        !text.contains("This backup can be safely restored"),
+        "it must not certify safe restoration:\n{text}"
+    );
+}
+
+/// Every path a verification run is allowed to touch inside the restored tree.
+///
+/// A PERMITLIST, not a denylist: anything not named here failing the comparison
+/// is the point. Each entry is a side effect that exists today and is understood:
+///
+/// - `n2a-startup-gate.json` — the N2-A gate writes its receipt into the very
+///   directory it audits.
+/// - `store/ledger/db`, `snap.*`, `blobs/*` — `SledStore::open` is `sled::open`,
+///   which has no read-only mode: it preallocates the backing file and may write
+///   a snapshot on open or flush on drop.
+///
+/// None of these is reached by icn#2736's delegation, which adds no store access
+/// at all. They are pre-existing and are tracked as their own debt; this list
+/// exists so that the moment anything *else* is written the test fails.
+fn is_known_verification_side_effect(path: &str) -> bool {
+    path == "n2a-startup-gate.json"
+        || path == "store/ledger/db"
+        || path.starts_with("store/ledger/snap.")
+        || path.starts_with("store/ledger/blobs/")
+}
+
+/// Verification must not disturb what it inspects (icn#2717's whole point).
+///
+/// Three things are proved, because the command destroys the tree it extracts and
+/// so the interesting object cannot be observed from outside the process:
+///
+/// 1. **Operator-visible bytes.** The data directory and the archive file are
+///    byte-for-byte identical after a real `--verify-ledger` run. This is the
+///    property an operator actually relies on and it holds exactly.
+/// 2. **The restored tree's mutation surface is bounded and known.** The archive
+///    is extracted here and driven through the *same* sequence the handler drives
+///    — `n2a_startup_gate::enforce`, then `SledStore::open` and a journal scan —
+///    with a full content identity taken either side. Every difference must be on
+///    the permitlist above, and nothing may disappear.
+/// 3. **The journal's contents survive.** The rows read back are exactly the row
+///    the fixture wrote, and reading them a second time returns the same bytes.
+///    So the side effects above are confined to sled's container: the evidence
+///    the verdict is about is not altered by the act of verifying it.
+///
+/// Claim 2 is deliberately NOT "the restored tree is byte-for-byte unchanged".
+/// That is false on `main` today and is not achievable through the current store
+/// API — see the permitlist. Asserting it would have meant either a red test or a
+/// quietly weakened one; asserting the exact surface instead keeps the statement
+/// true and still fails on any new write.
+#[test]
+fn verification_touches_nothing_outside_its_known_side_effect_surface() {
+    let dir = TempDir::new().unwrap();
+    let data_dir = dir.path().join("data");
+    let archive = dir.path().join("backup.tar");
+
+    init_identity(&data_dir);
+    seed_ledger(&data_dir, &[("hours", 60, 0), ("hours", 0, 60)]);
+    make_backup(&data_dir, &archive);
+
+    // ── 1. operator-visible bytes ──────────────────────────────────────────
+    let data_before = tree_identity(&data_dir);
+    let archive_before = file_sha(&archive);
+
+    let out = verify(&archive, true);
+    let text = combined(&out);
+    assert!(
+        out.status.success(),
+        "fixture: a balanced ledger must verify, or the claims below are made \
+         about a run that failed early:\n{text}"
+    );
+
+    assert_eq!(
+        tree_identity(&data_dir),
+        data_before,
+        "verification must not touch the operator's data directory"
+    );
+    assert_eq!(
+        file_sha(&archive),
+        archive_before,
+        "verification must not touch the archive it read"
+    );
+
+    // ── 2. the restored tree, driven through the handler's own sequence ────
+    let restore = dir.path().join("restored");
+    std::fs::create_dir_all(&restore).unwrap();
+    tar::Archive::new(std::fs::File::open(&archive).unwrap())
+        .unpack(&restore)
+        .expect("could not extract archive");
+
+    let restored_ledger = ledger_dir(&restore);
+    assert!(
+        restored_ledger.join("conf").is_file() && restored_ledger.join("db").is_file(),
+        "fixture: the extracted tree must carry a complete sled database, or the \
+         comparison below is about a directory nothing opened"
+    );
+
+    let before = tree_identity(&restore);
+
+    icn_store::n2a_startup_gate::enforce(&restore, std::time::SystemTime::now())
+        .expect("the N2-A gate must accept this tree");
+
+    let rows_first = {
+        let store = SledStore::open(&restored_ledger).expect("could not open restored ledger");
+        store
+            .scan(b"ledger:journal:")
+            .expect("could not scan journal")
+    };
+    assert!(
+        !rows_first.is_empty(),
+        "fixture: the scan must have read the journal, or every claim here would \
+         be about a database that was never opened"
+    );
+
+    let after = tree_identity(&restore);
+
+    let mut unexpected: Vec<String> = Vec::new();
+    for (path, identity) in &after {
+        if before.get(path) != Some(identity) && !is_known_verification_side_effect(path) {
+            unexpected.push(format!("written: {path}"));
+        }
+    }
+    for path in before.keys() {
+        if !after.contains_key(path) {
+            unexpected.push(format!("removed: {path}"));
+        }
+    }
+    assert!(
+        unexpected.is_empty(),
+        "verification wrote outside its known side-effect surface: {unexpected:?}\n\
+         A verifier is evidence about the artefact it inspected; a write nobody \
+         accounted for changes the very thing the verdict is about."
+    );
+
+    // `conf` carries sled's on-disk format parameters. Pinned by name because a
+    // rewritten `conf` would mean the open had renegotiated the database rather
+    // than read it — the difference between inspecting a backup and migrating it.
+    assert_eq!(
+        after.get("store/ledger/conf"),
+        before.get("store/ledger/conf"),
+        "opening the restored ledger must not rewrite its sled configuration"
+    );
+
+    // ── 3. the journal's contents survive being read ───────────────────────
+    let rows_second = {
+        let store = SledStore::open(&restored_ledger).expect("could not reopen restored ledger");
+        store
+            .scan(b"ledger:journal:")
+            .expect("could not rescan journal")
+    };
+    assert_eq!(
+        rows_first, rows_second,
+        "a second open must return the same journal bytes: the side effects above \
+         are sled's container, and must never reach the rows themselves"
+    );
+
+    let entry: icn_ledger::JournalEntry = serde_json::from_slice(&rows_first[0].1)
+        .expect("the restored row must still decode as the entry the fixture wrote");
+    assert_eq!(
+        entry.accounts.len(),
+        2,
+        "the restored row must still be the fixture's two-delta entry, not a \
+         re-encoded or repaired one"
+    );
+    assert!(
+        icn_ledger::entry_validation::inspect_entry(&entry).is_valid(),
+        "and it must still be valid under the ledger's own entry validation"
     );
 }

--- a/icn/bins/icnctl/tests/verify_backup_ledger_test.rs
+++ b/icn/bins/icnctl/tests/verify_backup_ledger_test.rs
@@ -43,6 +43,19 @@ fn combined(out: &Output) -> String {
     )
 }
 
+/// Collapse every run of whitespace to one space.
+///
+/// The operator summary is a wrapped paragraph printed as several `println!`
+/// lines, so a substring that reads as one sentence may straddle a line break.
+/// Asserting against the raw text made these tests depend on *where* the wrap
+/// falls, which is not a property any of them means to pin — and which broke
+/// three separate assertions when the sentences were rewritten. Flattening
+/// removes the dependence without weakening anything: the words, their order and
+/// their adjacency are all still asserted.
+fn flattened(text: &str) -> String {
+    text.split_whitespace().collect::<Vec<_>>().join(" ")
+}
+
 /// The canonical ledger location under a data directory.
 ///
 /// Spelled out here on purpose: this test must fail if the *product* stops
@@ -361,16 +374,30 @@ fn a_balanced_ledger_is_verified_and_reported_as_actually_inspected() {
         "even under --verify-ledger this command does not check hashes, \
          signatures or provenance, so it must not certify safe restoration:\n{text}"
     );
+    // Pin the ENUMERATION, not just its presence. This sentence is the one an
+    // operator reads as the not-verified set, so a token silently dropping out of
+    // it is a widening of the claim without a widening of the checks — which is
+    // exactly what happened to "amount signs" in review. `icn-ledger` does own a
+    // sign check (`entry::validate_positive_amounts`, via `JournalEntryBuilder`)
+    // that this command does not run, so the omission would have been actively
+    // misleading rather than merely incomplete.
     assert!(
-        text.contains("NOT verified: content hashes, signatures, provenance"),
-        "success must state which ledger validations it did not perform:\n{text}"
+        flattened(&text).contains(
+            "NOT verified: amount signs, content hashes, signatures, provenance, \
+             parent existence."
+        ),
+        "success must state which ledger validations it did not perform, as a \
+         complete enumeration — amount signs included, because icn-ledger owns a \
+         sign check (entry::validate_positive_amounts, via JournalEntryBuilder) \
+         that this command does not run:\n{text}"
     );
     // Freeze state and credit limits are append-time policy, not properties of a
     // backup. Delegation deliberately does NOT reach them, so the output must not
     // let an operator read "validated by icn-ledger" as covering them.
+    let flat = flattened(&text);
     assert!(
-        text.contains("Freeze state, credit limits and progressive limits are")
-            && text.contains("deliberately not checked here"),
+        flat.contains("Freeze state, credit limits and progressive limits are append-time policy")
+            && flat.contains("deliberately not checked here"),
         "the summary must name what delegation deliberately did not bring with \
          it, or 'valid under icn-ledger's entry validation' overclaims:\n{text}"
     );

--- a/icn/crates/icn-ledger/src/entry_validation.rs
+++ b/icn/crates/icn-ledger/src/entry_validation.rs
@@ -35,6 +35,23 @@
 //! owner both callers now consult (icn#2736): [`Ledger::validate_entry`] on the
 //! append path, and `icnctl verify-backup` on a restored journal.
 //!
+//! # Scope of this ownership, stated exactly
+//!
+//! This module is the owner for the two consumers named above:
+//! [`Ledger::validate_entry`](crate::Ledger) on the append path, and `icnctl
+//! verify-backup` on a restored journal. It is **not** yet the owner for entry
+//! *construction*: [`crate::entry::JournalEntryBuilder::build`] still applies its
+//! own `validate_double_entry` and `validate_positive_amounts`, and those diverge
+//! from this module in three ways — the builder accumulates with unchecked `+=`
+//! rather than `checked_add`, compares Σdebits to Σcredits rather than summing
+//! `net_change`, and does not reject an empty `accounts` array. Folding the
+//! builder in is its own bounded change; claiming that ownership here before it
+//! happens would be the same kind of overclaim this module exists to stop.
+//!
+//! The builder also owns a check this module does not have at all: amount signs.
+//! A caller reporting on what "icn-ledger's entry validation" established must
+//! therefore say so, rather than let the crate's name imply the union.
+//!
 //! # What this module deliberately does NOT own
 //!
 //! Freeze state, credit limits and progressive limits stay on `Ledger`. They are

--- a/icn/crates/icn-ledger/src/entry_validation.rs
+++ b/icn/crates/icn-ledger/src/entry_validation.rs
@@ -1,0 +1,452 @@
+//! The owner of a [`JournalEntry`]'s **entry-intrinsic** validity.
+//!
+//! # Why this is its own module
+//!
+//! [`Ledger::validate_entry`](crate::Ledger) answers two different questions in
+//! one method:
+//!
+//! 1. **Is this entry well formed on its own terms?** It carries at least one
+//!    account delta, and within the entry each currency's debits and credits
+//!    cancel under checked `i64`. This is a function of the entry *value* and
+//!    nothing else.
+//! 2. **May this entry be appended to *this* ledger, *now*?** The author and
+//!    accounts are not frozen; no account breaches a credit limit or a
+//!    progressive POPLevel limit. These read mutable ledger state — balances,
+//!    trust scores, cleared volume — and `SystemTime::now()`.
+//!
+//! Only the first question has an answer for an entry sitting in a backup, and
+//! only the first question is owned here.
+//!
+//! # The drift this exists to stop
+//!
+//! `icnctl verify-backup --verify-ledger` re-implemented question 1 rather than
+//! calling it, and the copy diverged twice before anyone noticed (icn#2717):
+//! it summed balances across the whole journal where the ledger sums per entry,
+//! so a `+60` row and a `-60` row cancelled and both were certified; and it
+//! accumulated in a widened `i128` where the ledger uses checked `i64`, so a row
+//! the ledger rejects as an overflow reached zero and was certified. Both wore
+//! the ledger's own words while asking a weaker question.
+//!
+//! Those two were patched. A third was already latent: an entry with an empty
+//! `accounts` array satisfies a per-currency balance check *vacuously*, so the
+//! mirrored code accepted what `validate_entry` rejects on its first line.
+//!
+//! Patching them one at a time is what produced them. This module is the single
+//! owner both callers now consult (icn#2736): [`Ledger::validate_entry`] on the
+//! append path, and `icnctl verify-backup` on a restored journal.
+//!
+//! # What this module deliberately does NOT own
+//!
+//! Freeze state, credit limits and progressive limits stay on `Ledger`. They are
+//! not merely inconvenient to call from a verifier — they are **wrong** to call
+//! there. A credit limit is computed against the balance a ledger holds now and
+//! against the wall clock now, so re-evaluating a historical journal against
+//! today's limits would reject entries that were valid when they were appended.
+//! That is a false-rejection engine, and a backup verifier that produces one is
+//! worse than one that admits the check is out of scope.
+
+use std::collections::{BTreeMap, BTreeSet};
+
+use crate::types::JournalEntry;
+use crate::LedgerError;
+
+/// A way in which a [`JournalEntry`] is invalid on its own terms.
+///
+/// Rendered straight into operator-facing diagnostics, so the wording is part of
+/// the contract: it has to read correctly both as a ledger rejection on append
+/// and as a row-level finding in a backup report.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum EntryDefect {
+    /// The entry carries no account deltas at all.
+    ///
+    /// A journal entry that moves nothing is not a balanced entry — it is an
+    /// entry with nothing to balance, which a per-currency sum accepts
+    /// vacuously. Named as its own defect so no caller can mistake the two.
+    NoAccountDeltas,
+
+    /// A single delta's own `debit - credit` overflowed `i64`.
+    DeltaOverflow {
+        /// The message from [`crate::AccountDelta::net_change`].
+        detail: String,
+    },
+
+    /// The running per-currency total overflowed `i64`.
+    ///
+    /// Distinct from an imbalance: the sum could not be computed at all. A
+    /// verifier that widened this accumulator to `i128` would find such a row
+    /// balanced and certify exactly what the ledger refuses.
+    CurrencyOverflow {
+        /// The currency whose accumulator overflowed.
+        currency: String,
+        /// The running total before the offending delta.
+        running: i64,
+        /// The delta that could not be added.
+        change: i64,
+    },
+
+    /// A currency's deltas do not sum to zero **within this entry**.
+    CurrencyImbalance {
+        /// The currency that does not balance.
+        currency: String,
+        /// The non-zero sum.
+        sum: i64,
+    },
+}
+
+impl std::fmt::Display for EntryDefect {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            EntryDefect::NoAccountDeltas => write!(f, "entry has no account deltas"),
+            EntryDefect::DeltaOverflow { detail } => write!(f, "{detail}"),
+            EntryDefect::CurrencyOverflow {
+                currency,
+                running,
+                change,
+            } => write!(
+                f,
+                "arithmetic overflow in double-entry check: {running} + {change} \
+                 for currency {currency}"
+            ),
+            EntryDefect::CurrencyImbalance { currency, sum } => write!(
+                f,
+                "currency {currency} sums to {sum}, so the entry does not balance"
+            ),
+        }
+    }
+}
+
+impl From<EntryDefect> for LedgerError {
+    /// Overflow stays [`LedgerError::ArithmeticOverflow`].
+    ///
+    /// `validate_entry` has always surfaced a failed accumulator as
+    /// `ArithmeticOverflow` rather than as an invalid entry, and that
+    /// distinction is what lets a caller tell "these numbers do not add up" from
+    /// "these numbers cannot be added". Collapsing both into `InvalidEntry`
+    /// while moving the code would be a silent narrowing.
+    fn from(defect: EntryDefect) -> Self {
+        let message = defect.to_string();
+        match defect {
+            EntryDefect::DeltaOverflow { .. } | EntryDefect::CurrencyOverflow { .. } => {
+                LedgerError::ArithmeticOverflow(message)
+            }
+            EntryDefect::NoAccountDeltas | EntryDefect::CurrencyImbalance { .. } => {
+                LedgerError::InvalidEntry(message)
+            }
+        }
+    }
+}
+
+/// What [`inspect_entry`] established about one entry.
+///
+/// Carries the evidence, not just a verdict, because a caller that reports to an
+/// operator must be able to say *which* currencies it actually balanced. A
+/// summary that infers "the double-entry invariant holds" from the mere absence
+/// of an error is the overclaim icn#2717 was about.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct EntryIntrinsics {
+    currencies_balanced: BTreeSet<String>,
+    defects: Vec<EntryDefect>,
+}
+
+impl EntryIntrinsics {
+    /// Every defect found, in a deterministic order.
+    pub fn defects(&self) -> &[EntryDefect] {
+        &self.defects
+    }
+
+    /// The currencies whose per-entry sum was computed **and found to be zero**.
+    ///
+    /// Empty when a defect stopped the sum from being computed, so a caller
+    /// cannot report coverage it did not obtain.
+    pub fn currencies_balanced(&self) -> &BTreeSet<String> {
+        &self.currencies_balanced
+    }
+
+    /// Whether the entry is valid on its own terms.
+    pub fn is_valid(&self) -> bool {
+        self.defects.is_empty()
+    }
+
+    /// The single-error view: the balanced currencies, or the first defect.
+    ///
+    /// This is the shape the append path wants, where any defect is a rejection
+    /// and only the first one needs a message.
+    pub fn into_result(self) -> Result<BTreeSet<String>, EntryDefect> {
+        match self.defects.into_iter().next() {
+            Some(defect) => Err(defect),
+            None => Ok(self.currencies_balanced),
+        }
+    }
+}
+
+/// Validate a [`JournalEntry`] against every rule that is a function of the
+/// entry alone.
+///
+/// Side-effect free and state-free by construction: it takes `&JournalEntry`,
+/// touches no ledger, opens no store, reads no clock. That is what makes it
+/// callable from `icnctl verify-backup`, which must not disturb the tree it is
+/// inspecting.
+///
+/// Reports **all** currency imbalances rather than the first, because a backup
+/// report lists findings per row; arithmetic failures stop the scan, matching
+/// the append path's `?`, since a sum that could not be computed makes every
+/// later sum for that entry meaningless.
+pub fn inspect_entry(entry: &JournalEntry) -> EntryIntrinsics {
+    let mut out = EntryIntrinsics::default();
+
+    if entry.accounts.is_empty() {
+        out.defects.push(EntryDefect::NoAccountDeltas);
+        return out;
+    }
+
+    // `BTreeMap`, not `HashMap`: these sums become operator-facing findings, and
+    // a hash-ordered walk makes two runs over the same corrupt row disagree
+    // about which currency to name first.
+    let mut sums: BTreeMap<String, i64> = BTreeMap::new();
+
+    for delta in &entry.accounts {
+        let change = match delta.net_change() {
+            Ok(change) => change,
+            Err(e) => {
+                out.defects.push(EntryDefect::DeltaOverflow {
+                    detail: e.to_string(),
+                });
+                return out;
+            }
+        };
+
+        let running = sums.entry(delta.currency.clone()).or_insert(0);
+        match running.checked_add(change) {
+            Some(next) => *running = next,
+            None => {
+                out.defects.push(EntryDefect::CurrencyOverflow {
+                    currency: delta.currency.clone(),
+                    running: *running,
+                    change,
+                });
+                return out;
+            }
+        }
+    }
+
+    for (currency, sum) in sums {
+        if sum == 0 {
+            out.currencies_balanced.insert(currency);
+        } else {
+            out.defects
+                .push(EntryDefect::CurrencyImbalance { currency, sum });
+        }
+    }
+
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::types::{AccountDelta, ProvenanceRef};
+
+    /// Build an entry from `(currency, debit, credit)` triples.
+    fn entry(deltas: &[(&str, i64, i64)]) -> JournalEntry {
+        let author = icn_identity::KeyPair::generate().unwrap().did().clone();
+        JournalEntry {
+            id: None,
+            timestamp: 1_700_000_000,
+            author: author.clone(),
+            contract_ref: None,
+            accounts: deltas
+                .iter()
+                .map(|(currency, debit, credit)| AccountDelta {
+                    account_id: author.clone(),
+                    currency: (*currency).to_string(),
+                    debit: if *debit == 0 { None } else { Some(*debit) },
+                    credit: if *credit == 0 { None } else { Some(*credit) },
+                })
+                .collect(),
+            parents: Vec::new(),
+            signature: None,
+            nonce: None,
+            provenance: ProvenanceRef::SystemGenerated {
+                reason: "icn#2736 unit fixture".to_string(),
+            },
+        }
+    }
+
+    #[test]
+    fn a_balanced_entry_reports_the_currencies_it_actually_balanced() {
+        let report = inspect_entry(&entry(&[
+            ("hours", 60, 0),
+            ("hours", 0, 60),
+            ("kwh", 5, 0),
+            ("kwh", 0, 5),
+        ]));
+
+        assert!(report.is_valid(), "defects: {:?}", report.defects());
+        // Naming the set, not just the count: a caller reports coverage from
+        // this, so "two currencies" must mean these two.
+        assert_eq!(
+            report
+                .currencies_balanced()
+                .iter()
+                .cloned()
+                .collect::<Vec<_>>(),
+            vec!["hours".to_string(), "kwh".to_string()],
+        );
+    }
+
+    /// The defect the mirrored implementation structurally could not see.
+    ///
+    /// An empty `accounts` array makes every per-currency sum vacuously zero, so
+    /// a balance-only check calls it valid. `validate_entry` rejects it on its
+    /// first line, and so must this owner (icn#2736).
+    #[test]
+    fn an_entry_with_no_account_deltas_is_a_defect_not_a_vacuous_pass() {
+        let report = inspect_entry(&entry(&[]));
+
+        assert_eq!(report.defects(), &[EntryDefect::NoAccountDeltas]);
+        assert!(
+            report.currencies_balanced().is_empty(),
+            "nothing was summed, so no currency may be reported as balanced"
+        );
+    }
+
+    #[test]
+    fn an_imbalanced_currency_is_reported_with_its_sum() {
+        let report = inspect_entry(&entry(&[("hours", 100, 0), ("hours", 0, 40)]));
+
+        assert_eq!(
+            report.defects(),
+            &[EntryDefect::CurrencyImbalance {
+                currency: "hours".to_string(),
+                sum: 60,
+            }]
+        );
+    }
+
+    /// Every imbalanced currency is reported, not just the first.
+    ///
+    /// A backup report lists findings per row; stopping at the first would
+    /// under-report the corruption an operator is being asked to act on.
+    #[test]
+    fn all_imbalanced_currencies_are_reported_in_a_deterministic_order() {
+        let report = inspect_entry(&entry(&[("kwh", 7, 0), ("hours", 100, 0)]));
+
+        assert_eq!(
+            report.defects(),
+            &[
+                EntryDefect::CurrencyImbalance {
+                    currency: "hours".to_string(),
+                    sum: 100,
+                },
+                EntryDefect::CurrencyImbalance {
+                    currency: "kwh".to_string(),
+                    sum: 7,
+                },
+            ],
+            "findings must be ordered by currency, not by hash iteration order"
+        );
+    }
+
+    /// A balanced currency alongside an imbalanced one is still not coverage.
+    #[test]
+    fn a_partially_balanced_entry_reports_the_defect_and_the_currency_it_did_balance() {
+        let report = inspect_entry(&entry(&[("hours", 60, 0), ("hours", 0, 60), ("kwh", 7, 0)]));
+
+        assert!(!report.is_valid());
+        assert_eq!(
+            report
+                .currencies_balanced()
+                .iter()
+                .cloned()
+                .collect::<Vec<_>>(),
+            vec!["hours".to_string()],
+        );
+    }
+
+    /// The i128 trap, pinned at the owner.
+    ///
+    /// These deltas cancel in any wider accumulator. Under checked `i64` the
+    /// running total overflows and the entry is refused, which is what the
+    /// ledger does on append.
+    #[test]
+    fn a_running_total_that_overflows_i64_is_a_defect_not_a_zero_sum() {
+        let report = inspect_entry(&entry(&[
+            ("hours", i64::MAX, 0),
+            ("hours", 1, 0),
+            ("hours", 0, i64::MAX),
+            ("hours", 0, 1),
+        ]));
+
+        assert!(matches!(
+            report.defects(),
+            [EntryDefect::CurrencyOverflow { currency, .. }] if currency == "hours"
+        ));
+        assert!(
+            report.currencies_balanced().is_empty(),
+            "the sum never completed, so the currency was not balanced"
+        );
+    }
+
+    /// A single delta whose own `debit - credit` cannot be computed.
+    #[test]
+    fn a_delta_whose_net_change_overflows_is_a_defect() {
+        let report = inspect_entry(&entry(&[("hours", i64::MIN, 1)]));
+
+        assert!(
+            matches!(report.defects(), [EntryDefect::DeltaOverflow { .. }]),
+            "got {:?}",
+            report.defects()
+        );
+    }
+
+    /// Overflow keeps its own error class through the conversion.
+    ///
+    /// The append path distinguishes "these numbers do not add up" from "these
+    /// numbers cannot be added"; folding both into `InvalidEntry` while moving
+    /// the code would be a silent narrowing.
+    #[test]
+    fn overflow_converts_to_arithmetic_overflow_and_imbalance_to_invalid_entry() {
+        assert!(matches!(
+            LedgerError::from(EntryDefect::CurrencyOverflow {
+                currency: "hours".to_string(),
+                running: 1,
+                change: 2,
+            }),
+            LedgerError::ArithmeticOverflow(_)
+        ));
+        assert!(matches!(
+            LedgerError::from(EntryDefect::DeltaOverflow {
+                detail: "x".to_string()
+            }),
+            LedgerError::ArithmeticOverflow(_)
+        ));
+        assert!(matches!(
+            LedgerError::from(EntryDefect::NoAccountDeltas),
+            LedgerError::InvalidEntry(_)
+        ));
+        assert!(matches!(
+            LedgerError::from(EntryDefect::CurrencyImbalance {
+                currency: "hours".to_string(),
+                sum: 60,
+            }),
+            LedgerError::InvalidEntry(_)
+        ));
+    }
+
+    #[test]
+    fn into_result_surfaces_the_first_defect_and_otherwise_the_balanced_set() {
+        assert_eq!(
+            inspect_entry(&entry(&[])).into_result(),
+            Err(EntryDefect::NoAccountDeltas)
+        );
+        assert_eq!(
+            inspect_entry(&entry(&[("hours", 60, 0), ("hours", 0, 60)]))
+                .into_result()
+                .unwrap()
+                .iter()
+                .cloned()
+                .collect::<Vec<_>>(),
+            vec!["hours".to_string()],
+        );
+    }
+}

--- a/icn/crates/icn-ledger/src/entry_validation.rs
+++ b/icn/crates/icn-ledger/src/entry_validation.rs
@@ -2,7 +2,8 @@
 //!
 //! # Why this is its own module
 //!
-//! [`Ledger::validate_entry`](crate::Ledger) answers two different questions in
+//! `Ledger::validate_entry` (a private method on [`Ledger`](crate::Ledger), so it
+//! cannot be linked directly) answers two different questions in
 //! one method:
 //!
 //! 1. **Is this entry well formed on its own terms?** It carries at least one
@@ -38,7 +39,7 @@
 //! # Scope of this ownership, stated exactly
 //!
 //! This module is the owner for the two consumers named above:
-//! [`Ledger::validate_entry`](crate::Ledger) on the append path, and `icnctl
+//! `Ledger::validate_entry` on the append path, and `icnctl
 //! verify-backup` on a restored journal. It is **not** yet the owner for entry
 //! *construction*: [`crate::entry::JournalEntryBuilder::build`] still applies its
 //! own `validate_double_entry` and `validate_positive_amounts`, and those diverge
@@ -224,6 +225,19 @@ pub fn inspect_entry(entry: &JournalEntry) -> EntryIntrinsics {
     for delta in &entry.accounts {
         let change = match delta.net_change() {
             Ok(change) => change,
+            // Take the INNER detail, not the formatted error.
+            //
+            // `net_change` already returns `LedgerError::ArithmeticOverflow`, whose
+            // Display is `"arithmetic overflow: {0}"`. Storing `e.to_string()` here
+            // and then re-wrapping this defect through `From<EntryDefect> for
+            // LedgerError` applied that prefix a second and third time, so the
+            // append path reported "arithmetic overflow: arithmetic overflow:
+            // arithmetic overflow in net_change: ...". A verifier whose subject is
+            // operator-message truth does not get to stutter.
+            Err(LedgerError::ArithmeticOverflow(detail)) => {
+                out.defects.push(EntryDefect::DeltaOverflow { detail });
+                return out;
+            }
             Err(e) => {
                 out.defects.push(EntryDefect::DeltaOverflow {
                     detail: e.to_string(),
@@ -413,6 +427,37 @@ mod tests {
             matches!(report.defects(), [EntryDefect::DeltaOverflow { .. }]),
             "got {:?}",
             report.defects()
+        );
+    }
+
+    /// The overflow detail is carried once, not re-wrapped at every layer.
+    ///
+    /// `net_change` returns `LedgerError::ArithmeticOverflow`, whose Display already
+    /// prefixes `"arithmetic overflow: "`. Storing the formatted error and then
+    /// converting the defect back into a `LedgerError` applied that prefix three
+    /// times over. Pinned because the whole point of this change is that the
+    /// message an operator reads is exactly true, and a stuttering one is not.
+    #[test]
+    fn a_delta_overflow_message_is_not_prefixed_twice() {
+        let report = inspect_entry(&entry(&[("hours", i64::MIN, 1)]));
+        let [EntryDefect::DeltaOverflow { detail }] = report.defects() else {
+            panic!(
+                "expected exactly one DeltaOverflow, got {:?}",
+                report.defects()
+            );
+        };
+        assert!(
+            !detail.starts_with("arithmetic overflow: "),
+            "the defect must carry the inner detail, not the formatted error: {detail}"
+        );
+        let rendered = LedgerError::from(EntryDefect::DeltaOverflow {
+            detail: detail.clone(),
+        })
+        .to_string();
+        assert_eq!(
+            rendered.matches("arithmetic overflow").count(),
+            2,
+            "exactly one wrapper prefix plus the inner net_change text: {rendered}"
         );
     }
 

--- a/icn/crates/icn-ledger/src/ledger.rs
+++ b/icn/crates/icn-ledger/src/ledger.rs
@@ -2887,20 +2887,48 @@ impl Ledger {
     /// Get archived entries for a specific rollback timestamp
     /// Validate a journal entry before accepting it
     ///
-    /// This validates:
-    /// - Entry has at least one account delta
+    /// **Entry-intrinsic** rules — at least one account delta, and
+    /// Σ debits == Σ credits per currency under checked `i64` — are owned by
+    /// [`crate::entry_validation`] and delegated to below. They depend on the
+    /// entry value alone, so a backup verifier can and does apply the same
+    /// owner to a restored journal (icn#2736).
+    ///
+    /// **Ledger-state** rules stay here, because they are not properties of an
+    /// entry at all:
     /// - Author and affected accounts are not frozen (Issue #25)
-    /// - Double-entry invariants (Σ debits == Σ credits per currency)
     /// - Credit limits are respected
+    /// - Progressive POPLevel balance and velocity limits (Issue #336)
+    ///
+    /// These read mutable ledger state and `SystemTime::now()`, so they answer
+    /// "may this entry be appended to *this* ledger, *now*?" — a question that
+    /// has no meaning for an archived journal, and one an offline verifier
+    /// would answer wrongly, rejecting entries that were valid when appended.
     ///
     /// Note: Parent validation (Merkle-DAG links) is done separately in
     /// `append_entry_internal` with different behavior for local vs sync operations
     /// (Issue #499: hybrid causal ordering).
     fn validate_entry(&mut self, entry: &JournalEntry) -> Result<()> {
-        // Check that entry has at least one account delta
-        if entry.accounts.is_empty() {
-            anyhow::bail!("Entry has no account deltas");
-        }
+        // Entry-intrinsic validity — at least one account delta, and the
+        // per-currency double-entry invariant under checked `i64` — is owned by
+        // `crate::entry_validation`, not by this method.
+        //
+        // It lives there because this method cannot be the owner: it is
+        // `&mut self` and the checks below it read live ledger state and the
+        // wall clock, so nothing outside an initialised `Ledger` can call it.
+        // `icnctl verify-backup --verify-ledger` needs exactly the entry-intrinsic
+        // half against a journal restored from a backup, and with no seam to call
+        // it re-derived the rule instead. That copy diverged twice before anyone
+        // noticed (icn#2717) and was already missing this method's very first
+        // check. Both callers now consult one owner (icn#2736).
+        //
+        // ORDER NOTE: the double-entry check now runs before the freeze check
+        // rather than after it. The set of entries this method ACCEPTS is
+        // unchanged — both are rejection gates and neither is skipped — but an
+        // entry that is both imbalanced and authored by a frozen DID now reports
+        // the imbalance rather than the freeze.
+        crate::entry_validation::inspect_entry(entry)
+            .into_result()
+            .map_err(LedgerError::from)?;
 
         // Check for frozen members (Issue #25)
         // Both the author and all affected accounts must not be frozen
@@ -2917,26 +2945,6 @@ impl Ledger {
                     "Account {} is frozen and cannot participate in transactions",
                     delta.account_id
                 );
-            }
-        }
-
-        // Check double-entry invariant per currency
-        let mut currency_sums: HashMap<String, i64> = HashMap::new();
-        for delta in &entry.accounts {
-            let sum = currency_sums.entry(delta.currency.clone()).or_insert(0);
-            let change = delta.net_change()?;
-            *sum = sum.checked_add(change).ok_or_else(|| {
-                LedgerError::ArithmeticOverflow(format!(
-                    "overflow in double-entry check: {sum} + {change} for currency {}",
-                    delta.currency
-                ))
-            })?;
-        }
-
-        // All currencies must sum to zero (double-entry)
-        for (currency, sum) in currency_sums {
-            if sum != 0 {
-                anyhow::bail!("Currency {currency} does not balance (sum = {sum})");
             }
         }
 

--- a/icn/crates/icn-ledger/src/lib.rs
+++ b/icn/crates/icn-ledger/src/lib.rs
@@ -58,6 +58,7 @@ pub mod credit_policy;
 pub mod dispute;
 pub mod dynamic_limits;
 pub mod entry;
+pub mod entry_validation;
 #[allow(missing_docs)]
 pub mod error;
 pub mod events;
@@ -93,6 +94,7 @@ pub use dynamic_limits::{
     AccountLimitState, DynamicCreditLimitManager, DynamicLimitConfig, LimitChangeEvent,
     LimitChangeReason,
 };
+pub use entry_validation::{inspect_entry, EntryDefect, EntryIntrinsics};
 pub use error::{LedgerError, Result};
 pub use fork_resolution::{
     Fork, ForkDetector, ForkResolution, ForkResolutionStrategy, ForkResolver,


### PR DESCRIPTION
Closes #2736.

`icnctl verify-backup --verify-ledger` mirrored one rule out of `Ledger::validate_entry` instead of calling it. This gives that rule an owner in `icn-ledger` and makes both the append path and the backup verifier consult it.

## The duplicated mechanism

`verify_ledger_in_backup` decoded each row as a `JournalEntry` and then re-derived the double-entry rule locally: its own `HashMap<String, i64>`, its own accumulation, its own zero test. `Ledger::validate_entry` did the same thing 4000 lines away in another crate. Nothing tied them together, so they drifted — twice, both found on #2734 and both fixed there:

| | `Ledger::validate_entry` | `verify_ledger_in_backup`, before #2717 |
|---|---|---|
| scope | sums per **entry** | summed across the **whole journal** |
| arithmetic | checked **i64**, overflow rejects | widened **i128**, cannot overflow |

Each let the command print `✓ Double-entry invariant verified` for a journal the ledger would have refused on append. A third divergence was already latent and is the one reproduced below.

## The divergence reproduced on main

`614e26575c06501f80ce81a9e46e48c0b141386e`, real archive through the real operator path. A `JournalEntry` with `accounts: []` decodes cleanly and satisfies a per-currency balance check **vacuously** — there is nothing to sum:

```
[Extra] Verifying ledger integrity...
  Found 1 ledger entries
  ✓ 1 entries read; none carried a currency delta, so no balance was computed

✓ BACKUP VERIFICATION PASSED

Verified: archive integrity and the N2-A principal audit of the
restored tree. 1 ledger entries carried no currency delta,
so no double-entry balance was computed.
```

`validate_entry` rejects that row on its **first line** — *"Entry has no account deltas"* — before the balance block is reached. #2717 responded by narrowing the claim, which was right for its contract and is why this is a separate issue. The check itself belongs to the owner.

## Design

Direct delegation to `Ledger::validate_entry` is **architecturally unsafe**, so this takes the second branch the acceptance contract allows and extracts a side-effect-free owner. The method mixes two questions:

1. **Is this entry well formed on its own terms?** Non-empty `accounts`; per-currency Σ debits == Σ credits under checked `i64`. A function of the entry *value*.
2. **May this entry be appended to *this* ledger, *now*?** Freeze state; credit limits; progressive POPLevel limits. These read `&mut self`, live balances, trust scores and `SystemTime::now()`.

Class 2 is not merely awkward to call from a verifier — it is **wrong** to call there. A credit limit is computed against the balance the ledger holds now and the wall clock now, so re-evaluating an archived journal against today's limits would reject entries that were valid when appended: a false-rejection engine. The freeze list and credit policy are daemon-construction state the ledger store does not even carry.

So class 1 moves to `icn_ledger::entry_validation` (new module, ~240 lines with its own unit tests). `Ledger::validate_entry` delegates to it; `verify_ledger_in_backup` calls the same function. Ownership stays in `icn-ledger`; `icnctl` consumes it and recreates nothing.

**Stated exactly:** this is the owner for those two consumers, and **not yet** for entry *construction*. `JournalEntryBuilder::build()` keeps a third copy of the double-entry rule which accumulates with unchecked `+=` rather than `checked_add`, compares Σdebits to Σcredits rather than summing `net_change`, and does not reject an empty `accounts` array. Pre-existing, out of scope, filed as **#2741** — and the module doc now says so rather than implying an ownership that did not land.

`inspect_entry` returns evidence rather than a bare verdict — the balanced currency set plus every defect — because a caller reporting to an operator must be able to say *which* currencies it actually balanced. Inferring "the invariant holds" from the absence of an error is the overclaim this command keeps making.

**One behaviour change inside `validate_entry`, stated rather than hidden:** the double-entry check now runs *before* the freeze check rather than after. The set of entries the method **accepts is unchanged** — both are rejection gates and neither is skipped — but an entry that is both imbalanced and authored by a frozen DID now reports the imbalance rather than the freeze. All 493 `icn-ledger` unit tests pass unchanged.

## Why read-only verification is preserved

By construction: the owner is a free function over `&JournalEntry`. It opens nothing, locks nothing, reads no clock. This PR adds **no store access at all** — it replaces in-process logic operating on rows that were already decoded. The `assert_backup_carried_a_ledger` → `enforce_n2a_gate` → `SledStore::open` ordering #2717 established is untouched.

## Restored-tree identity: measured, and it is not what the issue assumed

Acceptance criterion 2 asked for the restored tree to be byte-for-byte unchanged. **That is false on `main` today and is not reachable through the current store API.** Measured by extracting a real archive, taking a recursive content identity (path set + SHA-256 of every file), driving the tree through the handler's own sequence, and re-taking it:

| Path | Before | After |
|---|---|---|
| `store/ledger/db` | 646 bytes | **524287 bytes**, different hash |
| `store/ledger/snap.0000000000000286` | absent | **created** |
| `n2a-startup-gate.json` | absent | **created** |

Two causes, neither reachable by this refactor: `SledStore::open` is `sled::open`, which has no read-only mode; and `n2a_startup_gate::enforce` writes its receipt into the directory it audits. Filed as **#2739** with the full measurement.

What *is* true, and is now pinned:

- `[3/4] Verifying checksum` runs **before** `[Extra] Verifying ledger integrity`, so the checksum is taken over the pristine extraction and no verdict is self-corrupted.
- The operator's data directory and the archive file are byte-for-byte unchanged after a real run.
- The journal rows survive: a second open returns byte-identical rows, which still decode and still pass the ledger's validation.
- The mutation surface is **exactly** the three paths above, enforced by an explicit permitlist (`is_known_verification_side_effect`). Any write outside it fails the test.

That is deliberately not a weakened restatement of "unchanged" — it is the precise statement, and it fails on any new write.

## Producer/consumer evidence

The producer (`icn-ledger`) is exercised directly by 9 new unit tests. The consumer (`icnctl`) is exercised end-to-end through the **real binary** and the **real handler** — `backup` → tar → `verify-backup --verify-ledger` → restore → ledger — never a substitute command. Producer success alone would not show the verifier sees the verdict; mutation **M4** below closes that by proving the verifier acts on it.

## New discriminating tests

- `an_entry_with_no_account_deltas_is_refused_rather_than_certified` — **fails on `main`** (exits 0 with the banner above), passes only once the owner is consulted. This is the observable purchase of the delegation.
- `verification_touches_nothing_outside_its_known_side_effect_surface` — the read-only proof described above.
- 9 unit tests on the owner, including the empty-accounts defect, deterministic multi-currency defect ordering, the `i128` trap, and that overflow keeps its `ArithmeticOverflow` error class through the conversion.

The existing two-arm `success_without_a_computed_balance_…` test was restructured, not deleted: its empty-ledger arm survives as `an_empty_ledger_does_not_claim_the_invariant_was_verified`; its empty-accounts arm is now a **failure** case and moved to the test above. Three negative assertions that would have gone vacuous when the output text changed were repointed at the live strings.

## Mutation evidence

Baseline 17/17 green. Each behaviour mutated **individually**, the named test required to fail, then restored and the baseline required to go green again before the next case. All eight killed; 8/8 anchors matched exactly once, 8/8 restores re-verified green, no residue.

| # | Behaviour mutated | Mutation applied | Test required to fail | Result |
|---|---|---|---|---|
| M1 | owner rejects an entry with no account deltas | drop the `NoAccountDeltas` defect | `an_entry_with_no_account_deltas_is_refused_rather_than_certified` | **KILLED** |
| M2 | owner reports a currency that does not sum to zero | record it as balanced instead | `two_rows_whose_imbalances_cancel_are_not_reported_as_verified` | **KILLED** |
| M3 | accumulator is checked `i64` | `checked_add` → `saturating_add` | `a_row_whose_running_total_overflows_i64_is_not_reported_as_verified` | **KILLED** |
| M4 | verifier acts on the owner's verdict | `if intrinsics.is_valid()` → `if true` | `an_imbalanced_ledger_in_a_real_archive_is_not_reported_as_verified` | **KILLED** |
| M5 | summary states the widened claim | drop "at least one account delta" | `a_balanced_ledger_is_verified_and_reported_as_actually_inspected` | **KILLED** |
| M6 | read-only test is not vacuous | permitlist always `false` | `verification_touches_nothing_outside_its_known_side_effect_surface` | **KILLED** |
| M7 | not-verified enumeration is complete | drop `amount signs,` from the line | `a_balanced_ledger_is_verified_and_reported_as_actually_inspected` | **KILLED** |
| M8 | delta-overflow detail is not double-prefixed | guard the new match arm with `if false` | `entry_validation::tests::a_delta_overflow_message_is_not_prefixed_twice` | **KILLED** |

M6 is the non-vacuity check on the read-only test itself: making the permitlist reject everything must fail the test, proving it really observes the side effects it permits rather than comparing nothing.

The first run of this harness produced **contaminated results** and is worth recording. It restored files with `shutil.copy2`, which preserves the original mtime, so the restored source became *older* than the artifact built from the mutant: cargo rebuilt nothing and the next mutation was tested against the previous one's binary. The harness now stamps the mtime on restore **and re-runs the test after every restore, requiring it to go green again** — a "KILLED" that residue could explain is not evidence.

## Exact claims now made

Under `--verify-ledger`, on success:

- the archive contained a ledger at the canonical path, and the verifier did not create or complete it;
- the rows are decodable by this binary as `JournalEntry`;
- **every entry is valid under `icn_ledger::entry_validation`** — it carries at least one account delta, and per currency Σ debits == Σ credits under checked `i64`;
- the N2-A principal audit passes over the restored tree;
- all of those fail closed;
- the output names exactly these.

## Explicit non-claims

- **Amount signs are not checked here, and delegation did not add such a check.** `Ledger::validate_entry` has none — its checks are non-empty accounts, freeze, balance, credit limits, progressive limits (`ledger.rs:2899-3101`). But `icn-ledger` *does* own a sign check, `entry::validate_positive_amounts` (`entry.rs:269`), reached through `JournalEntryBuilder::build()`. So "valid under icn-ledger's own entry validation" is **not** the crate's union, and the output says so: `amount signs` stays named in the not-verified enumeration, pinned by assertion and by mutation **M7**. (My first pass dropped it on the mistaken premise that no such check existed; caught in FULL review, fixed in `c1f9a396f`, corrected on #2736.)
- Content hashes, signatures, provenance and parent existence: not verified.
- Freeze state, credit limits, progressive limits: **deliberately** not verified, for the false-rejection reason above. The output says so.
- The restored tree is **not** byte-for-byte unchanged — see #2739.
- No change to the ledger's validation semantics, and no backup format change.

## Follow-up debt

- **#2739** (filed here) — verification writes to the tree it inspects; sled has no read-only open and the N2-A gate writes its receipt into the audited directory.
- **#2732** — telling a genuinely empty ledger from one that could not be read as written. Untouched.
- **#2741** (filed from this review) — `JournalEntryBuilder` keeps a third copy of the double-entry rule, with unchecked arithmetic and no empty-entry check, plus the sign check that makes "icn-ledger's entry validation" ambiguous.
- **#2735** — whole-journal materialisation in backup verification. Untouched; this PR does not change the memory profile.

## Review

One bounded **FULL** generation against `855882ed4`: 1 BLOCKER, 2 FOLLOW_UP, 0 QUESTION, 6 NOT_A_FINDING.

- **BLOCKER** — the not-verified enumeration silently dropped `amount signs`. Fixed in `c1f9a396f`, pinned by assertion and mutation M7. Detail in the non-claims above.
- **FOLLOW_UP** — `JournalEntryBuilder`'s third copy of the rule → **#2741**; module doc narrowed in the same commit so this PR stops implying ownership it does not have.
- **FOLLOW_UP** — the read-only test proves its *restored tree* claim by re-enacting the handler's sequence in-process rather than observing `handle_verify_backup_command`, because the command destroys its own temp dir. Stated in the test's doc comment and here; belongs with **#2739**, which will make it observable.

One bounded **DELTA** generation against `855882ed4..c1f9a396f`: 0 BLOCKER, 0 FOLLOW_UP, 1 QUESTION (whether #2741 covers the builder's debug-panic-on-overflow — it does, explicitly, in its acceptance criteria), 5 NOT_A_FINDING.

Automated review raised two further findings, both fixed in `5f91c9fc5` and both worth having in a PR about message truth: `LedgerError::ArithmeticOverflow` is `#[error("arithmetic overflow: {0}")]`, so storing the formatted error as the defect detail and re-wrapping it printed the prefix **three times** — now carried once, pinned by test and by mutation **M8**; and a rustdoc link labelled `Ledger::validate_entry` while targeting the type, which cannot be fixed by retargeting because the method is private, so the label is now plain code with the reason stated. Both threads resolved.

## Verification

`cargo fmt --all --check`, `cargo clippy -p icn-ledger -p icnctl --all-targets -- -D warnings`, `cargo test -p icn-ledger -p icnctl` — all clean. Docs: `docs/architecture/n2-a-migration-gate.md` recorded the previous claim contract, including "empty-entry rejection" as *not performed*; updated to match, since that is the fact that changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
