### PR TITLE
fix(cli): let init-coop's first run take its passphrase from the environment (#2727)

### DIFF
--- a/icn/Cargo.lock
+++ b/icn/Cargo.lock
@@ -4004,6 +4004,7 @@ dependencies = [
  "icn-store",
  "icn-trust",
  "image",
+ "libc",
  "qrcode",
  "rand 0.9.4",
  "rand_core 0.6.4",

--- a/icn/bins/icnctl/Cargo.toml
+++ b/icn/bins/icnctl/Cargo.toml
@@ -67,6 +67,11 @@ utoipa = { version = "5.4.0", features = ["yaml"] }
 
 [dev-dependencies]
 tempfile = "3.24"
+# `init_coop_first_run_passphrase_test` needs `setsid(2)` to detach the child's
+# controlling terminal. Without it, `rpassword` opens `/dev/tty` — which is
+# inherited independently of stdin — and a passphrase test blocks forever on the
+# developer's own terminal. Already in the lock file via other crates.
+libc = "0.2"
 actix-web = "4"
 actix-web-httpauth = "0.8"
 actix-rt = "2"

--- a/icn/bins/icnctl/src/main.rs
+++ b/icn/bins/icnctl/src/main.rs
@@ -8453,22 +8453,29 @@ async fn handle_init_coop_command(
         println!("Step 1: Creating new identity");
         std::fs::create_dir_all(data_dir).context("Failed to create data directory")?;
 
-        print!("Choose a passphrase: ");
-        io::stdout().flush()?;
-        let passphrase1 = rpassword::read_password()?;
-
-        print!("Confirm passphrase: ");
-        io::stdout().flush()?;
-        let passphrase2 = rpassword::read_password()?;
-
-        if passphrase1 != passphrase2 {
-            bail!("Passphrases do not match");
-        }
-        if passphrase1.len() < 8 {
+        // Sourced through the shared helper, so `ICN_KEYSTORE_PASSPHRASE` and
+        // the legacy `ICN_PASSPHRASE` work here exactly as they already do on
+        // the existing-identity branch above and in `id init` (#2727). This
+        // branch used to call `rpassword` directly, which made the one command
+        // intended for first-run setup the one command that could not be run
+        // without a terminal.
+        //
+        // On the environment arm the helper returns the configured value
+        // without asking for a second entry, so its "passphrases do not match"
+        // check is vacuous there *by construction* — confirming a variable
+        // against itself would prove nothing. A human at a terminal is still
+        // prompted twice and still rejected on a mismatch.
+        //
+        // The minimum length is enforced HERE rather than inside the helper on
+        // purpose. `id init` shares that helper and has deliberately never
+        // imposed a minimum, so moving this rule down would quietly change an
+        // unrelated command's contract. Checking the returned value — instead
+        // of the prompt's input — is what keeps the rule binding on the
+        // environment arm as well as the interactive one.
+        let passphrase = Zeroizing::new(confirm_passphrase()?);
+        if passphrase.len() < 8 {
             bail!("Passphrase must be at least 8 characters");
         }
-
-        let passphrase = Zeroizing::new(passphrase1.into_bytes());
 
         // Initialize keystore (generates keypair internally)
         let keystore = AgeKeyStore::init(&keystore_path, &passphrase)?;

--- a/icn/bins/icnctl/tests/init_coop_first_run_passphrase_test.rs
+++ b/icn/bins/icnctl/tests/init_coop_first_run_passphrase_test.rs
@@ -347,14 +347,22 @@ fn without_a_passphrase_in_the_environment_first_run_still_requires_interactive_
         "the wizard must actually ask for a passphrase; if this prompt is \
          absent the interactive path was skipped rather than attempted:\n{text}"
     );
-    // ENXIO — "No such device or address" — is `rpassword` failing to open
-    // `/dev/tty` because `init_coop_command` put the child in its own session.
-    // Kept alongside the prompt assertion because it pins *where* the failure
-    // came from, but it is deliberately the weaker of the two: it renders
-    // through `strerror`, so it is the half that could in principle move under
-    // a different libc or a sandbox with no `/dev/tty` node.
+    // ENXIO is `rpassword` failing to open `/dev/tty`, because
+    // `init_coop_command` put the child in its own session. Kept alongside the
+    // prompt assertion because it pins *where* the failure came from: it is the
+    // assertion that fails if the `setsid` call is ever dropped, which the
+    // prompt check alone would not catch.
+    //
+    // Both spellings are listed because this renders through `strerror`, which
+    // is platform-specific: glibc gives "No such device or address" and Darwin
+    // gives "Device not configured" for the same errno. No CI job runs this
+    // test on macOS today — `release.yml` only builds there — but
+    // `cargo test -p icnctl` on a macOS workstation would otherwise fail on
+    // message text alone, which is a property of the assertion rather than of
+    // the code under test.
+    const ENXIO_MESSAGES: [&str; 2] = ["No such device or address", "Device not configured"];
     assert!(
-        text.contains("No such device or address"),
+        ENXIO_MESSAGES.iter().any(|m| text.contains(m)),
         "the wizard must fail because it had no terminal to prompt on; any \
          other failure means this test is no longer observing the interactive \
          path:\n{text}"

--- a/icn/bins/icnctl/tests/init_coop_first_run_passphrase_test.rs
+++ b/icn/bins/icnctl/tests/init_coop_first_run_passphrase_test.rs
@@ -108,7 +108,14 @@ fn init_coop_command(data_dir: &Path) -> Command {
         .env_remove("http_proxy")
         .env_remove("https_proxy")
         .env_remove("all_proxy")
-        .env("NO_PROXY", "*")
+        // `127.0.0.1` first, and it is not decoration: hyper-util's matcher
+        // dispatches on whether the host parses as an IP address, and consults
+        // only the IP list when it does. A bare `*` parses as neither an
+        // address nor a network, so it lands in the *domain* list and would
+        // never be reached for this gateway — the entry that does the work here
+        // is the literal address. The removals above are the real gate; this is
+        // the belt to their braces.
+        .env("NO_PROXY", "127.0.0.1,localhost,*")
         .env("ICN_GATEWAY", "http://127.0.0.1:1")
         .env("ICN_LOCALE", "en")
         .arg("--data-dir")
@@ -125,12 +132,19 @@ fn init_coop_command(data_dir: &Path) -> Command {
     {
         use std::os::unix::process::CommandExt;
         // SAFETY: `pre_exec` runs between `fork` and `exec`, where only
-        // async-signal-safe work is permitted. `setsid` is a bare syscall: it
-        // allocates nothing, takes no locks, and touches no inherited runtime
-        // state. It cannot fail in a freshly forked child — that child is never
-        // already a process-group leader — but the error is propagated rather
-        // than ignored, so a future change that breaks the assumption surfaces
-        // as a spawn failure instead of a silent hang.
+        // async-signal-safe work is permitted. Both operations in this closure
+        // qualify, and that has to be true of *each* of them, not just the
+        // interesting one:
+        //   * `setsid` is a bare syscall — it allocates nothing, takes no
+        //     locks, and touches no inherited runtime state. It cannot fail in
+        //     a freshly forked child, which is never already a process-group
+        //     leader, but the error is propagated rather than ignored so a
+        //     future change that breaks that assumption surfaces as a spawn
+        //     failure instead of a silent hang.
+        //   * `Error::last_os_error` reads the thread-local `errno` and packs
+        //     it into a non-allocating representation. This is *not* a general
+        //     licence to construct `io::Error` here — anything that allocates
+        //     or formats would be unsound in this position.
         unsafe {
             cmd.pre_exec(|| {
                 if libc::setsid() == -1 {
@@ -324,16 +338,26 @@ fn without_a_passphrase_in_the_environment_first_run_still_requires_interactive_
         "with no passphrase available and no terminal, the wizard must fail \
          rather than proceed with an unspecified passphrase:\n{text}"
     );
+    // The prompt itself is the environment-independent half of the
+    // discriminator: `read_passphrase` prints it and flushes stdout *before*
+    // calling into `rpassword`, so it is guaranteed to be captured. A fix that
+    // substituted a default passphrase would never emit it.
+    assert!(
+        text.contains("Enter passphrase"),
+        "the wizard must actually ask for a passphrase; if this prompt is \
+         absent the interactive path was skipped rather than attempted:\n{text}"
+    );
     // ENXIO — "No such device or address" — is `rpassword` failing to open
     // `/dev/tty` because `init_coop_command` put the child in its own session.
-    // Asserting on it, rather than only on the exit status, is what makes this
-    // test discriminate: a fix that substituted a default passphrase would
-    // still have to *ask* first, and would no longer fail this way.
+    // Kept alongside the prompt assertion because it pins *where* the failure
+    // came from, but it is deliberately the weaker of the two: it renders
+    // through `strerror`, so it is the half that could in principle move under
+    // a different libc or a sandbox with no `/dev/tty` node.
     assert!(
         text.contains("No such device or address"),
-        "the wizard must fail because it tried to prompt a human and had no \
-         terminal to do it on; any other failure means this test is no longer \
-         observing the interactive path:\n{text}"
+        "the wizard must fail because it had no terminal to prompt on; any \
+         other failure means this test is no longer observing the interactive \
+         path:\n{text}"
     );
     assert!(
         !keystore_path(dir.path()).exists(),

--- a/icn/bins/icnctl/tests/init_coop_first_run_passphrase_test.rs
+++ b/icn/bins/icnctl/tests/init_coop_first_run_passphrase_test.rs
@@ -1,0 +1,287 @@
+//! `init-coop`'s first run must be automatable through the environment (#2727).
+//!
+//! `icnctl init-coop` sourced its passphrase two different ways depending on a
+//! condition the operator does not control. The **existing-identity** branch
+//! called `read_passphrase`, which honours `ICN_KEYSTORE_PASSPHRASE` (then the
+//! legacy `ICN_PASSPHRASE`) before prompting. The **new-identity** branch —
+//! the one that runs on the machine `init-coop` exists to set up — called
+//! `rpassword::read_password()` directly, twice, so it ignored the environment
+//! entirely and demanded a TTY:
+//!
+//! ```text
+//! Step 1: Creating new identity
+//! Choose a passphrase: Error: No such device or address (os error 6)
+//! ```
+//!
+//! That made the documented first-run wizard the one `icnctl` path that could
+//! not be scripted, blocking unattended provisioning and any end-to-end test of
+//! the wizard's later steps.
+//!
+//! **Why these tests drive the real binary.** The defect is that a *process*
+//! with no controlling terminal cannot get past step 1. An in-process unit test
+//! calling a helper cannot observe that: it would have to fake the very thing
+//! under test. So each test spawns the real `icnctl`, gives it a genuinely
+//! fresh data directory with no keystore, closes stdin, and asserts on what the
+//! process did.
+//!
+//! **Why the obvious fix is dangerous, and what pins it here.** Replacing the
+//! prompt block with `confirm_passphrase()` fixes automation but silently
+//! deletes the branch's inline `passphrase.len() < 8` rejection, because
+//! `confirm_passphrase()` carries no minimum-length rule of its own (`id init`
+//! deliberately has none). `a_short_environment_passphrase_is_rejected_on_first_run`
+//! is the test that fails if that check is dropped, and it drives the
+//! environment arm specifically — the arm a length rule enforced only around
+//! the interactive prompt would miss.
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
+use std::path::{Path, PathBuf};
+use std::process::{Command, Output, Stdio};
+
+use tempfile::TempDir;
+
+fn icnctl_bin() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_icnctl"))
+}
+
+/// Where `init-coop` writes the keystore it creates.
+///
+/// Spelled out rather than resolved through the binary's own helper on purpose:
+/// a test that asked the code under test where it put the file would agree with
+/// it by construction, including when both are wrong.
+fn keystore_path(data_dir: &Path) -> PathBuf {
+    data_dir.join("identity.age")
+}
+
+/// At least 8 bytes, so it clears the minimum-length rule under test.
+const PASSPHRASE: &str = "icn-2727-first-run-passphrase";
+
+/// The legacy variable's value, deliberately different from `PASSPHRASE` so a
+/// precedence claim can be checked by which one actually unlocks the keystore.
+const LEGACY_PASSPHRASE: &str = "icn-2727-legacy-passphrase";
+
+/// Seven bytes: one short of the branch's `len() < 8` rejection.
+const SHORT_PASSPHRASE: &str = "sevenby";
+
+/// An `init-coop` invocation with every ambient influence neutralised.
+///
+/// Three separate hazards are closed here, and none of them is tidiness:
+///
+/// * **stdin is closed** (`Stdio::null`). The claim under test is "this works
+///   with no TTY". A test that inherited the developer's terminal would pass on
+///   the defect whenever it was run by hand.
+/// * **The gateway is pointed at a port nothing can serve, and `ICN_TOKEN` is
+///   removed.** Step 4 probes `$ICN_GATEWAY/v1/health` (default
+///   `localhost:8080`) and, if a token is present, POSTs a governance domain to
+///   it. Without this a developer or runner with a live gateway would have this
+///   test create real governance state on it. This is the pattern established
+///   for this path in #2726, and it is a safety boundary, not cleanup.
+/// * **Both passphrase variables are cleared before the caller sets any.** The
+///   tests that assert on the *absence* of a passphrase are only meaningful if
+///   the ambient environment cannot supply one.
+///
+/// `ICN_LOCALE` is pinned so a developer's locale cannot change the strings the
+/// assertions read.
+fn init_coop_command(data_dir: &Path) -> Command {
+    let mut cmd = Command::new(icnctl_bin());
+    cmd.stdin(Stdio::null())
+        .env_remove("ICN_KEYSTORE_PASSPHRASE")
+        .env_remove("ICN_PASSPHRASE")
+        .env_remove("ICN_TOKEN")
+        .env("ICN_GATEWAY", "http://127.0.0.1:1")
+        .env("ICN_LOCALE", "en")
+        .arg("--data-dir")
+        .arg(data_dir)
+        .args([
+            "init-coop",
+            "--name",
+            "First Run Coop",
+            "--yes",
+            "--no-start",
+        ]);
+    cmd
+}
+
+fn combined(out: &Output) -> String {
+    format!(
+        "{}{}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr)
+    )
+}
+
+/// Guard shared by every test here: prove the run really took the *new
+/// identity* branch.
+///
+/// Without this, a run that silently found an existing keystore would exercise
+/// the already-working `read_passphrase` branch and pass while proving nothing
+/// about the defect.
+fn assert_took_new_identity_branch(text: &str) {
+    assert!(
+        text.contains("Step 1: Creating new identity"),
+        "these tests are only about the new-identity branch; this run did not \
+         take it:\n{text}"
+    );
+}
+
+/// C6 + C1: the whole defect, end to end.
+///
+/// Fails on the pre-fix baseline at `Choose a passphrase:` with
+/// `No such device or address (os error 6)`, because the branch never consults
+/// the environment.
+#[test]
+fn init_coop_completes_first_run_with_only_the_keystore_passphrase_in_the_environment() {
+    let dir = TempDir::new().unwrap();
+    assert!(
+        !keystore_path(dir.path()).exists(),
+        "fixture must start with no identity, or it tests the wrong branch"
+    );
+
+    let out = init_coop_command(dir.path())
+        .env("ICN_KEYSTORE_PASSPHRASE", PASSPHRASE)
+        .output()
+        .unwrap();
+    let text = combined(&out);
+
+    assert_took_new_identity_branch(&text);
+    assert!(
+        out.status.success(),
+        "first-run `init-coop` must complete with the passphrase supplied \
+         through ICN_KEYSTORE_PASSPHRASE and no TTY:\n{text}"
+    );
+    assert!(
+        keystore_path(dir.path()).exists(),
+        "the wizard reported success but wrote no keystore at {}:\n{text}",
+        keystore_path(dir.path()).display()
+    );
+}
+
+/// C2, on the arm that actually loses the rule.
+///
+/// The minimum-length rejection lives inline in the branch being replaced, not
+/// in `confirm_passphrase()`. A fix that swaps the block for the helper and
+/// stops there deletes it, and a short *environment* value would then create a
+/// keystore. This test is what makes that regression visible.
+#[test]
+fn a_short_environment_passphrase_is_rejected_on_first_run() {
+    let dir = TempDir::new().unwrap();
+
+    let out = init_coop_command(dir.path())
+        .env("ICN_KEYSTORE_PASSPHRASE", SHORT_PASSPHRASE)
+        .output()
+        .unwrap();
+    let text = combined(&out);
+
+    assert_took_new_identity_branch(&text);
+    assert!(
+        !out.status.success(),
+        "a {}-byte passphrase must be rejected, not accepted because the \
+         confirmation step was non-interactive:\n{text}",
+        SHORT_PASSPHRASE.len()
+    );
+    assert!(
+        text.contains("at least 8 characters"),
+        "the failure must be the minimum-length rule, not an incidental error \
+         such as a missing TTY — otherwise this test would pass on a build \
+         that had dropped the rule entirely:\n{text}"
+    );
+    assert!(
+        !keystore_path(dir.path()).exists(),
+        "a rejected passphrase must not leave a keystore behind at {}:\n{text}",
+        keystore_path(dir.path()).display()
+    );
+}
+
+/// C1, legacy arm: `ICN_PASSPHRASE` keeps working on its own.
+#[test]
+fn the_legacy_passphrase_variable_still_drives_first_run() {
+    let dir = TempDir::new().unwrap();
+
+    let out = init_coop_command(dir.path())
+        .env("ICN_PASSPHRASE", LEGACY_PASSPHRASE)
+        .output()
+        .unwrap();
+    let text = combined(&out);
+
+    assert_took_new_identity_branch(&text);
+    assert!(
+        out.status.success(),
+        "the legacy ICN_PASSPHRASE must still drive an unattended first run:\n{text}"
+    );
+    assert!(keystore_path(dir.path()).exists(), "no keystore:\n{text}");
+}
+
+/// C1, precedence: `ICN_KEYSTORE_PASSPHRASE` wins over the legacy variable.
+///
+/// Checked by *which value opens the keystore afterwards*, not by reading the
+/// helper's source. The second run takes the existing-identity branch, whose
+/// sourcing was never in doubt, so it is a fair oracle for what the first run
+/// actually used.
+#[test]
+fn the_keystore_passphrase_variable_takes_precedence_over_the_legacy_one() {
+    let dir = TempDir::new().unwrap();
+
+    let first = init_coop_command(dir.path())
+        .env("ICN_KEYSTORE_PASSPHRASE", PASSPHRASE)
+        .env("ICN_PASSPHRASE", LEGACY_PASSPHRASE)
+        .output()
+        .unwrap();
+    let text = combined(&first);
+    assert_took_new_identity_branch(&text);
+    assert!(first.status.success(), "first run failed:\n{text}");
+
+    let with_preferred = init_coop_command(dir.path())
+        .env("ICN_KEYSTORE_PASSPHRASE", PASSPHRASE)
+        .output()
+        .unwrap();
+    assert!(
+        combined(&with_preferred).contains("Step 1: Using existing identity"),
+        "the second run should have found the keystore the first one wrote"
+    );
+    assert!(
+        with_preferred.status.success(),
+        "the keystore must open with the ICN_KEYSTORE_PASSPHRASE value, which \
+         is the one that should have created it:\n{}",
+        combined(&with_preferred)
+    );
+
+    let with_legacy = init_coop_command(dir.path())
+        .env("ICN_PASSPHRASE", LEGACY_PASSPHRASE)
+        .output()
+        .unwrap();
+    assert!(
+        !with_legacy.status.success(),
+        "the legacy value must NOT open a keystore created while \
+         ICN_KEYSTORE_PASSPHRASE was set — if it does, precedence inverted:\n{}",
+        combined(&with_legacy)
+    );
+}
+
+/// C5: automation must not relax the human path.
+///
+/// With no passphrase in the environment the wizard must still try to obtain
+/// one interactively and fail when it cannot, rather than inventing a default,
+/// accepting an empty value, or skipping keystore creation. `rpassword` reads
+/// the terminal directly, so a test process without one cannot drive the
+/// prompt-and-confirm exchange itself; what this pins is that the interactive
+/// path is still *taken*, and that no keystore is ever created without a
+/// passphrase.
+#[test]
+fn without_a_passphrase_in_the_environment_first_run_still_requires_interactive_entry() {
+    let dir = TempDir::new().unwrap();
+
+    let out = init_coop_command(dir.path()).output().unwrap();
+    let text = combined(&out);
+
+    assert_took_new_identity_branch(&text);
+    assert!(
+        !out.status.success(),
+        "with no passphrase available and no terminal, the wizard must fail \
+         rather than proceed with an unspecified passphrase:\n{text}"
+    );
+    assert!(
+        !keystore_path(dir.path()).exists(),
+        "no keystore may be created when no passphrase was ever supplied; \
+         found one at {}:\n{text}",
+        keystore_path(dir.path()).display()
+    );
+}

--- a/icn/bins/icnctl/tests/init_coop_first_run_passphrase_test.rs
+++ b/icn/bins/icnctl/tests/init_coop_first_run_passphrase_test.rs
@@ -20,9 +20,10 @@
 //! **Why these tests drive the real binary.** The defect is that a *process*
 //! with no controlling terminal cannot get past step 1. An in-process unit test
 //! calling a helper cannot observe that: it would have to fake the very thing
-//! under test. So each test spawns the real `icnctl`, gives it a genuinely
-//! fresh data directory with no keystore, closes stdin, and asserts on what the
-//! process did.
+//! under test. So each test spawns the real `icnctl` in its own session, gives
+//! it a genuinely fresh data directory with no keystore, and asserts on what
+//! the process did. See `init_coop_command` for why the session — not the
+//! closed stdin — is what removes the terminal.
 //!
 //! **Why the obvious fix is dangerous, and what pins it here.** Replacing the
 //! prompt block with `confirm_passphrase()` fixes automation but silently
@@ -64,20 +65,34 @@ const SHORT_PASSPHRASE: &str = "sevenby";
 
 /// An `init-coop` invocation with every ambient influence neutralised.
 ///
-/// Three separate hazards are closed here, and none of them is tidiness:
+/// Four separate hazards are closed here, and none of them is tidiness:
 ///
-/// * **stdin is closed** (`Stdio::null`). The claim under test is "this works
-///   with no TTY". A test that inherited the developer's terminal would pass on
-///   the defect whenever it was run by hand.
-/// * **The gateway is pointed at a port nothing can serve, and `ICN_TOKEN` is
-///   removed.** Step 4 probes `$ICN_GATEWAY/v1/health` (default
-///   `localhost:8080`) and, if a token is present, POSTs a governance domain to
-///   it. Without this a developer or runner with a live gateway would have this
-///   test create real governance state on it. This is the pattern established
-///   for this path in #2726, and it is a safety boundary, not cleanup.
+/// * **The child is given its own session, so it has no controlling terminal.**
+///   This is the one that matters, and closing stdin is *not* a substitute for
+///   it. `rpassword` does not read stdin: on Unix it opens the literal path
+///   `/dev/tty`, which the kernel resolves through the process's controlling
+///   terminal — inherited across `fork`/`exec` no matter what fd 0 is. So
+///   `Stdio::null()` alone leaves a test run from a real terminal free to grab
+///   that terminal, put it in raw mode and block forever on the prompt, with
+///   `cargo test` imposing no timeout. `setsid(2)` detaches it, which makes
+///   "no TTY" a property this fixture *establishes* rather than one it happens
+///   to inherit from a CI runner. Verified: with a pty present and stdin at
+///   `/dev/null`, the pre-`setsid` fixture hung at `Enter passphrase:`.
+/// * **The gateway is pointed at a port nothing can serve, `ICN_TOKEN` is
+///   removed, and proxy variables are cleared.** Step 4 probes
+///   `$ICN_GATEWAY/v1/health` (default `localhost:8080`) and, if a token is
+///   present, POSTs a governance domain to it. `ICN_TOKEN`'s removal is the
+///   real gate — the wizard skips live domain creation without it — but
+///   `reqwest` auto-detects `HTTP_PROXY`/`HTTPS_PROXY`/`ALL_PROXY` and does not
+///   implicitly bypass loopback, so on a proxied runner even the health probe
+///   could leave the machine. This is the #2726 pattern plus that gap. It is a
+///   safety boundary, not cleanup.
 /// * **Both passphrase variables are cleared before the caller sets any.** The
 ///   tests that assert on the *absence* of a passphrase are only meaningful if
 ///   the ambient environment cannot supply one.
+/// * **stdin is closed.** Not load-bearing for `rpassword`, per above, but it
+///   keeps the wizard's own `io::stdin().read_line` prompts from consuming a
+///   developer's keystrokes.
 ///
 /// `ICN_LOCALE` is pinned so a developer's locale cannot change the strings the
 /// assertions read.
@@ -87,6 +102,13 @@ fn init_coop_command(data_dir: &Path) -> Command {
         .env_remove("ICN_KEYSTORE_PASSPHRASE")
         .env_remove("ICN_PASSPHRASE")
         .env_remove("ICN_TOKEN")
+        .env_remove("HTTP_PROXY")
+        .env_remove("HTTPS_PROXY")
+        .env_remove("ALL_PROXY")
+        .env_remove("http_proxy")
+        .env_remove("https_proxy")
+        .env_remove("all_proxy")
+        .env("NO_PROXY", "*")
         .env("ICN_GATEWAY", "http://127.0.0.1:1")
         .env("ICN_LOCALE", "en")
         .arg("--data-dir")
@@ -98,6 +120,27 @@ fn init_coop_command(data_dir: &Path) -> Command {
             "--yes",
             "--no-start",
         ]);
+
+    #[cfg(unix)]
+    {
+        use std::os::unix::process::CommandExt;
+        // SAFETY: `pre_exec` runs between `fork` and `exec`, where only
+        // async-signal-safe work is permitted. `setsid` is a bare syscall: it
+        // allocates nothing, takes no locks, and touches no inherited runtime
+        // state. It cannot fail in a freshly forked child — that child is never
+        // already a process-group leader — but the error is propagated rather
+        // than ignored, so a future change that breaks the assumption surfaces
+        // as a spawn failure instead of a silent hang.
+        unsafe {
+            cmd.pre_exec(|| {
+                if libc::setsid() == -1 {
+                    return Err(std::io::Error::last_os_error());
+                }
+                Ok(())
+            });
+        }
+    }
+
     cmd
 }
 
@@ -260,11 +303,14 @@ fn the_keystore_passphrase_variable_takes_precedence_over_the_legacy_one() {
 ///
 /// With no passphrase in the environment the wizard must still try to obtain
 /// one interactively and fail when it cannot, rather than inventing a default,
-/// accepting an empty value, or skipping keystore creation. `rpassword` reads
-/// the terminal directly, so a test process without one cannot drive the
-/// prompt-and-confirm exchange itself; what this pins is that the interactive
-/// path is still *taken*, and that no keystore is ever created without a
-/// passphrase.
+/// accepting an empty value, or skipping keystore creation.
+///
+/// `rpassword` reads `/dev/tty`, so a test cannot drive the prompt-and-confirm
+/// exchange itself without a pty; the mismatch rejection is therefore covered
+/// structurally (it lives in `confirm_passphrase`) rather than here. What this
+/// pins is that the interactive path is still *taken* — asserted through the
+/// terminal-open failure, which is what distinguishes "blocked trying to ask a
+/// human" from "quietly used a default".
 #[test]
 fn without_a_passphrase_in_the_environment_first_run_still_requires_interactive_entry() {
     let dir = TempDir::new().unwrap();
@@ -277,6 +323,17 @@ fn without_a_passphrase_in_the_environment_first_run_still_requires_interactive_
         !out.status.success(),
         "with no passphrase available and no terminal, the wizard must fail \
          rather than proceed with an unspecified passphrase:\n{text}"
+    );
+    // ENXIO — "No such device or address" — is `rpassword` failing to open
+    // `/dev/tty` because `init_coop_command` put the child in its own session.
+    // Asserting on it, rather than only on the exit status, is what makes this
+    // test discriminate: a fix that substituted a default passphrase would
+    // still have to *ask* first, and would no longer fail this way.
+    assert!(
+        text.contains("No such device or address"),
+        "the wizard must fail because it tried to prompt a human and had no \
+         terminal to do it on; any other failure means this test is no longer \
+         observing the interactive path:\n{text}"
     );
     assert!(
         !keystore_path(dir.path()).exists(),

--- a/icn/bins/icnctl/tests/init_coop_trust_path_test.rs
+++ b/icn/bins/icnctl/tests/init_coop_trust_path_test.rs
@@ -54,12 +54,11 @@ const PASSPHRASE: &str = "m4d-2718-fixture-passphrase";
 /// Create the keystore first, so `init-coop` takes its *existing identity*
 /// branch.
 ///
-/// The wizard's new-identity branch calls `rpassword` directly instead of the
-/// crate's `read_passphrase`/`confirm_passphrase` helpers, so it ignores
-/// `ICN_KEYSTORE_PASSPHRASE` and cannot run unattended. That is a separate
-/// defect from the one under test here and is recorded rather than fixed; this
-/// fixture sidesteps it by provisioning the identity through `id init`, which
-/// does honour the variable.
+/// That branch is the one these tests are about, so the identity is still
+/// provisioned up front rather than left to the wizard. It is no longer a
+/// workaround: the new-identity branch ignored `ICN_KEYSTORE_PASSPHRASE` and
+/// could not run unattended when this fixture was written, and that defect is
+/// fixed (#2727) and covered by `init_coop_first_run_passphrase_test`.
 fn init_identity(data_dir: &Path) -> Output {
     Command::new(icnctl_bin())
         .env("ICN_KEYSTORE_PASSPHRASE", PASSPHRASE)


### PR DESCRIPTION
<!-- ICN-DELIVERY-LIFECYCLE:BEGIN -->
```
ICN DELIVERY LIFECYCLE
State:                FROZEN
Lane:                 #2727 -- init-coop first-run passphrase from the environment
Acceptance contract:  C1-C6 in #2727: canonical env sourcing via the existing helper family;
                      minimum length preserved on BOTH the env and interactive arms;
                      env confirmation stated truthfully (vacuous by construction);
                      Zeroizing preserved to AgeKeyStore::init; interactive prompt +
                      confirmation + mismatch rejection unchanged; real first-run E2E test
                      that fails on the pre-fix baseline.
Review generation:    FULL closed (1 BLOCKER, fixed). DELTA gen 2 clean. DELTA gen 3 clean.
                      Automated: Copilot approval-recommended; 2 Codex threads resolved.
Freeze head:          b4bd1f2e7faa324bc5be467158dfc9ff88087ba9
Known blockers:       none
Follow-up ledger:     #2743 (orphaned cli.prompts.choose_passphrase locale key; verified
                      already dead at merge base ae8fc47d, so pre-existing debt)
```
<!-- ICN-DELIVERY-LIFECYCLE:END -->

Closes #2727.

## The defect

`icnctl init-coop` sourced its passphrase two different ways depending on a condition the operator does not control.

The **existing-identity** branch called `read_passphrase`, which honours `ICN_KEYSTORE_PASSPHRASE`, then the legacy `ICN_PASSPHRASE`, then prompts. The **new-identity** branch — the one that runs on the machine `init-coop` exists to set up — called `rpassword::read_password()` directly, twice. So it ignored the environment entirely and demanded a terminal.

Reproduced on the pre-fix baseline with the real binary, a genuinely fresh data directory, `ICN_KEYSTORE_PASSPHRASE` set and stdin closed:

```
Step 1: Creating new identity
Choose a passphrase: Error: No such device or address (os error 6)
```

Exit 1, no keystore written. That made the documented first-run wizard the one `icnctl` path that could not be scripted, blocking unattended provisioning, container/appliance bootstrap, and any end-to-end test of the wizard's later steps. Reachability is ordinary: any first-run automation hits it. `--yes` does not help — it covers the confirmation prompt, not the passphrase.

## Why the obvious fix is unsafe

Swapping the block for `confirm_passphrase()?` and stopping there fixes automation and **silently deletes an existing validation rule**.

The only minimum-length enforcement on this path is the inline `passphrase1.len() < 8` check *inside the branch being replaced*. `confirm_passphrase()` carries no length rule of its own, and that is deliberate: `id init` shares that helper and has never imposed a minimum. So

- dropping the check lets a short **environment** value create a keystore, and
- moving the check *into* the helper would quietly tighten `id init`'s contract — a non-goal of this issue.

## The change

Six lines of code in `handle_init_coop_command`:

```rust
let passphrase = Zeroizing::new(confirm_passphrase()?);
if passphrase.len() < 8 {
    bail!("Passphrase must be at least 8 characters");
}
```

The length rule stays at this call site, and is checked on the **returned value** rather than around the prompt — which is what keeps it binding on the environment arm as well as the interactive one. A rule placed next to the prompt would only ever see interactive input.

`String::len()` and `Vec<u8>::len()` are both byte counts, so the rule is preserved exactly, including its behaviour on multi-byte characters.

## Behaviour preserved

| Contract | How it is preserved |
|---|---|
| **C1** env sourcing | Uses `confirm_passphrase()`, the same helper family as every other path. No third parser added. Precedence untouched. |
| **C2** minimum length | Enforced on the returned value, so it binds on **both** arms. |
| **C3** env confirmation | On the env arm the helper returns the value without a second entry, so "passphrases do not match" is vacuous there **by construction**. Stated as such in the code comment; no second confirmation is claimed. |
| **C4** zeroization | `Zeroizing<Vec<u8>>` still reaches `AgeKeyStore::init`. Now applied one step *earlier*, so a passphrase rejected for length is zeroized on the way out too — previously it was not. |
| **C5** interactive path | Unchanged and not relaxed: a human at a TTY with no env var is still prompted twice and still rejected on mismatch, inside the helper. |

## Evidence

New end-to-end test file `bins/icnctl/tests/init_coop_first_run_passphrase_test.rs` (5 tests). Each drives the **real `icnctl` binary** against a fresh data directory with no keystore and `stdin` closed — the defect is that a *process with no controlling terminal* cannot get past step 1, which an in-process unit test cannot observe without faking the thing under test.

**Baseline (pre-fix) run — 4 of 5 fail, all with the defect signature** `Choose a passphrase: Error: No such device or address (os error 6)`:

| Test | Baseline | Post-fix |
|---|---|---|
| `init_coop_completes_first_run_with_only_the_keystore_passphrase_in_the_environment` | FAILED | ok |
| `a_short_environment_passphrase_is_rejected_on_first_run` | FAILED | ok |
| `the_legacy_passphrase_variable_still_drives_first_run` | FAILED | ok |
| `the_keystore_passphrase_variable_takes_precedence_over_the_legacy_one` | FAILED | ok |
| `without_a_passphrase_in_the_environment_first_run_still_requires_interactive_entry` | ok | ok |

The fifth passes on baseline by design — it is a **preservation** guard for C5, not a discriminator for the defect. Its discriminating power is established by mutation instead (M4 below).

### Mutation testing

Discipline per mutation: baseline green → mutate one behaviour → anchor matched exactly once → source hash actually changed → run the **named** test → require it to fail → restore → prove source pristine by hash → re-run the same test → require green.

| # | Mutation | Named test | Verdict |
|---|---|---|---|
| M2 | delete the `len() < 8` check (i.e. the naïve helper swap) | `a_short_environment_passphrase_is_rejected_on_first_run` | **KILLED** |
| M4 | fall back to a canned passphrase when the helper errors | `without_a_passphrase_in_the_environment_first_run_still_requires_interactive_entry` | **KILLED** |
| M6 | invert `ICN_KEYSTORE_PASSPHRASE` / `ICN_PASSPHRASE` precedence | `the_keystore_passphrase_variable_takes_precedence_over_the_legacy_one` | **KILLED** |
| M5 | remove the `Zeroizing` wrapper | (C4) | **SURVIVED — reported, not hidden** |

**M5 survived, and that is reported rather than papered over.** `AgeKeyStore::init` takes `&[u8]`; both `&Zeroizing<Vec<u8>>` and `&Vec<u8>` reach it by deref coercion, so removing the wrapper compiles and is invisible to any behavioural test. Rather than fabricate a test that does not discriminate, C4 rests on compiler-checked type evidence — a deliberate type-mismatch probe reports the binding as:

```
expected `()`, found `Zeroizing<Vec<u8>>`
```

with `AgeKeyStore::init` expecting `&[u8]`. The owned value living across the call is therefore the `Zeroizing`, which zeroizes on drop. `confirm_passphrase()` returns by value and is *moved* into the wrapper, so no un-zeroized copy survives at the call site.

### Fixture isolation

Treated as a security boundary. Every invocation:

- **puts the child in its own session via `setsid(2)`**, so it has no controlling terminal. This is the load-bearing one. `rpassword` does not read stdin — on Unix it opens the literal path `/dev/tty`, which the kernel resolves through the *controlling terminal*, inherited across `fork`/`exec` regardless of fd 0. `Stdio::null()` alone establishes nothing (see *Correction* below);
- pins `ICN_GATEWAY=http://127.0.0.1:1`, removes `ICN_TOKEN`, and clears `HTTP_PROXY`/`HTTPS_PROXY`/`ALL_PROXY` with `NO_PROXY=*`. `ICN_TOKEN`'s removal is the real gate on governance writes, but `reqwest` auto-detects system proxies and does not implicitly bypass loopback, so on a proxied runner even the health probe could leave the machine;
- clears **both** passphrase variables before setting any, so the tests asserting on their *absence* are meaningful;
- pins `ICN_LOCALE` so a developer's locale cannot move the asserted strings.

I inventoried every `env::var` reachable inside `handle_init_coop_command`: only `ICN_GATEWAY` and `ICN_TOKEN` reach the network. `ICN_GATEWAY_JWT_SECRET` is read solely by `mint_local_trusted_token` (`--local-mint`), which this wizard never calls — so no token-minting path is reachable from the fixture.

## Correction — fixture isolation was wrong in the first revision

The FULL review caught a real defect in my own test fixture, and it is worth stating plainly rather than burying.

The first revision claimed `Stdio::null()` gave the tests a no-TTY environment. It does not. `rpassword` 7.5.4 opens `/dev/tty`, which is resolved from the process's controlling terminal and inherited independently of stdin. The suite passed only because this machine and GitHub's runners happen to have **no controlling terminal** — the property the tests rely on was inherited from the environment, not established by the fixture.

Consequence, confirmed empirically before fixing: under `script` (which allocates a pty) with stdin at `/dev/null`, the wizard **hung** at `Enter passphrase:` until killed. Run from an interactive shell, `cargo test -p icnctl` — the repository's own mandated post-change verification — would have blocked forever on the developer's terminal with echo and canonical mode disabled.

That is exactly the failure mode this lane's evidence standard exists to catch: *a verification result is evidence about what the verifier actually inspected.* My green run was evidence about a machine without a controlling terminal, not about the property I claimed.

Fixed in `bac28e96b`:

- `setsid(2)` via `pre_exec`, so no controlling terminal exists by construction and `/dev/tty` fails with ENXIO everywhere;
- the C5 test now asserts on that ENXIO failure rather than only on exit status, which is what distinguishes "blocked trying to ask a human" from "quietly used a default";
- the doc comments that stated the false mechanism are corrected.

Discriminating evidence for the fix itself: removing the `setsid` block makes the C5 test **fail** under a pty; restored to a byte-compared pristine copy, it passes again. Under a real pty all 5 tests now pass in ~6s.

## Local verification

Run from `icn/`, all against the final pristine source (hash-verified after the last mutation restore):

- `cargo fmt --all --check` — clean
- `cargo clippy -p icnctl --all-targets --all-features -- -D warnings` — 0 errors, 0 warnings
- `cargo test -p icnctl` — **145 passed, 0 failed** across all 14 test binaries

Scope is one package (`icnctl`, confirmed via `cargo metadata`); all three changed files live in it. This is a scoped result and is not a claim about workspace health.

## Also in this PR

`init_coop_trust_path_test.rs` carried a comment stating this defect was "recorded rather than fixed" and that the fixture sidesteps it. That is no longer true, so the comment is corrected. The `id init` provisioning stays — those tests are about the existing-identity branch and should keep taking it.

## Non-goals

- No change to which variables are consulted, or their precedence.
- No change to keystore format, `AgeKeyStore`, or `icnd`'s side.
- No new passphrase-strength policy — C2 preserves what exists, it does not raise it.
- Not #2487 (passphrase *mismatch* against an existing keystore).
- Not #2725 (`data_dir` disagreement).

## Follow-up filed, not folded in

#2743 — `cli.prompts.choose_passphrase` is an orphaned locale key in `en.yaml`/`es.yaml`. Verified dead at the merge base too (the old code printed a raw literal, never the i18n lookup), so it is pre-existing debt that this PR merely makes visible. Filed rather than fixed here.

## Known follow-up debt (not fixed here)

Inside `confirm_passphrase()` the intermediate `Vec<u8>` values are not zeroized, and `rpassword` hands back a plain `String`. That is pre-existing on every path that uses the helper, is unchanged by this PR, and belongs to whoever owns helper-level zeroization rather than to #2727.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

