### PR TITLE
fix(cli): stop verify-backup reporting an unreadable ledger as an empty one (#2732)

### DIFF
--- a/docs/architecture/n2-a-migration-gate.md
+++ b/docs/architecture/n2-a-migration-gate.md
@@ -1335,8 +1335,9 @@ every §11 disposition are untouched, and no readiness classification moves.
   clock, so an offline verifier applying them would reject entries that were valid when appended.
   **The bare branch's checks are unchanged — only its claim narrowed.** The `--verify-ledger` branch
   did change what it checks, and the bullet below records how: it resolves the canonical ledger path,
-  refuses an absent or partial database before the gate can create one, refuses a database sled
-  could not recover as written (icn#2732), decodes rows as `JournalEntry`, and asks the ledger's own
+  refuses an absent or partial database before the gate can create one, refuses a database sled REPLACED rather than
+  recovered (icn#2732 — a bounded claim: it is not a whole-database integrity check, and does not
+  establish that every row a backup once held is still readable), decodes rows as `JournalEntry`, and asks the ledger's own
   validator whether each one is valid. The recovery refusal has to run before the gate for the same
   reason the presence refusal does, one layer down: `sled::open` replaces a database it cannot parse
   with a fresh empty one, and its `was_recovered()` signal is false only on the FIRST open — the

--- a/docs/architecture/n2-a-migration-gate.md
+++ b/docs/architecture/n2-a-migration-gate.md
@@ -1335,8 +1335,13 @@ every §11 disposition are untouched, and no readiness classification moves.
   clock, so an offline verifier applying them would reject entries that were valid when appended.
   **The bare branch's checks are unchanged — only its claim narrowed.** The `--verify-ledger` branch
   did change what it checks, and the bullet below records how: it resolves the canonical ledger path,
-  refuses an absent or partial database before the gate can create one, decodes rows as
-  `JournalEntry`, and asks the ledger's own validator whether each one is valid. Widening what the *bare* command verifies would change what it means and is
+  refuses an absent or partial database before the gate can create one, refuses a database sled
+  could not recover as written (icn#2732), decodes rows as `JournalEntry`, and asks the ledger's own
+  validator whether each one is valid. The recovery refusal has to run before the gate for the same
+  reason the presence refusal does, one layer down: `sled::open` replaces a database it cannot parse
+  with a fresh empty one, and its `was_recovered()` signal is false only on the FIRST open — the
+  gate's own open would persist the repair and leave the corruption to be certified as
+  `✓ Ledger empty`. Widening what the *bare* command verifies would change what it means and is
   still not done here.
 - **A pre-existing `verify-backup` path bug, found while placing that gate. FIXED by icn#2717.**
   `verify_ledger_in_backup` looked for `<restore_dir>/ledger`, but `backup` archives the data

--- a/icn/bins/icnctl/src/main.rs
+++ b/icn/bins/icnctl/src/main.rs
@@ -6867,6 +6867,69 @@ fn handle_verify_backup_command(input: &Path, verify_ledger: bool) -> Result<()>
     Ok(())
 }
 
+/// Refuse a ledger path that leaves the extracted tree, before anything follows it.
+///
+/// The archive is untrusted input — judging it is this command's entire job — and
+/// `Path::exists`, `Path::is_file` and `sled::open` all FOLLOW symlinks. A
+/// crafted archive carrying `store/ledger` as a symlink to a sled database
+/// elsewhere on the machine therefore reads as a present, complete ledger:
+/// `calculate_dir_checksum` walks with `follow_links(false)` and hashes only
+/// `is_file()` entries, so the symlink is skipped and the checksum matches; the
+/// marker checks below follow it and find `conf` and `db`; and the recovery open
+/// then opens the external database. `sled::open` writes — it grows the backing
+/// file, may write a snapshot, and rewrites the configuration — so verification
+/// would mutate a database outside the directory it extracted, on nothing more
+/// than an operator running `verify-backup` on a hostile file.
+///
+/// Reproduced before this check existed: the victim database's `db` was rewritten
+/// and a `snap.*` appeared, on an archive whose only payload was the symlink.
+///
+/// `enforce_n2a_gate` already refuses symlinks — `find_sled_roots` uses
+/// `file_type()`, which does not follow them, and errors rather than skipping
+/// (`icn/crates/icn-store/src/did_collision_scan.rs:1463`). That refusal was
+/// enough while the gate held the FIRST open of the extracted tree. icn#2732 had
+/// to move an open in front of the gate to catch sled's recovery signal before
+/// the gate's own open destroys it, and that reordering stepped the new open past
+/// this guard. Moving a check earlier also moves it past whatever used to protect
+/// it, so the guard has to move with it.
+///
+/// Every component from the extraction root down is checked with
+/// `symlink_metadata`, which does not follow, because a link anywhere along the
+/// path escapes just as effectively as one at the leaf. A component that does not
+/// exist is not this function's business — absence is the presence check's
+/// verdict to give, and giving it here would produce two different messages for
+/// one condition.
+fn assert_ledger_path_is_contained(restore_dir: &Path, ledger_db_path: &Path) -> Result<()> {
+    let relative = ledger_db_path
+        .strip_prefix(restore_dir)
+        .context("ledger path is not under the extraction root")?;
+
+    let mut walked = restore_dir.to_path_buf();
+    for component in relative.components() {
+        walked.push(component);
+        let metadata = match std::fs::symlink_metadata(&walked) {
+            Ok(metadata) => metadata,
+            // Absent: let `assert_backup_carried_a_ledger` say so.
+            Err(_) => return Ok(()),
+        };
+        if metadata.file_type().is_symlink() {
+            bail!(
+                "FAILED: this backup places a symbolic link at {}, inside the path \
+                 its ledger database must occupy. Ledger verification was NOT \
+                 performed, and nothing was opened.\n\
+                 \n\
+                 A link there would make verification read — and, because \
+                 `sled::open` writes, MODIFY — a database outside the archive being \
+                 verified, while reporting the result as though it came from the \
+                 backup. A backup written by `icnctl backup` never contains one.",
+                walked.display()
+            );
+        }
+    }
+
+    Ok(())
+}
+
 /// Prove the ARCHIVE carried a ledger database, before anything opens the tree.
 ///
 /// Must be called before `enforce_n2a_gate`. The gate discovers sled roots by the
@@ -6884,6 +6947,9 @@ fn handle_verify_backup_command(input: &Path, verify_ledger: bool) -> Result<()>
 /// before the gate (icn#2732).
 fn assert_backup_carried_a_ledger(restore_dir: &Path) -> Result<()> {
     let ledger_db_path = icn_core::config::ledger_store_path(restore_dir);
+
+    // Containment FIRST, because every check below this line follows symlinks.
+    assert_ledger_path_is_contained(restore_dir, &ledger_db_path)?;
 
     if !ledger_db_path.exists() {
         bail!(
@@ -6946,6 +7012,15 @@ fn assert_backup_carried_a_ledger(restore_dir: &Path) -> Result<()> {
 /// ledger" from "this backup's ledger could not be inspected as written", which
 /// is the distinction icn#2732 exists to restore. Those are very different facts
 /// for an operator holding a backup they may need to restore.
+///
+/// What the signal establishes is bounded, and the bound is worth stating.
+/// `was_recovered()` answers whether sled RECOVERED the database or REPLACED it.
+/// It is not a whole-database integrity check and this refusal does not claim to
+/// be one: it cannot establish that every row a backup once held is still
+/// readable. Deciding that needs a count or manifest recorded when the backup was
+/// taken and cross-checked here, which is a backup-format change icn#2732
+/// deliberately does not make. What is closed here is the specific false
+/// conclusion that a replaced database is an empty one.
 ///
 /// What the signal does NOT establish is the CAUSE. A truncated copy, a failed
 /// transfer, tampering, and a ledger whose first writes were never durably

--- a/icn/bins/icnctl/src/main.rs
+++ b/icn/bins/icnctl/src/main.rs
@@ -6797,6 +6797,13 @@ fn handle_verify_backup_command(input: &Path, verify_ledger: bool) -> Result<()>
         // database, and a presence check running afterwards would find one and
         // certify it. The evidence has to be taken from the extracted tree first.
         assert_backup_carried_a_ledger(restore_dir)?;
+        // Then prove the database can be READ AS WRITTEN, still before the gate.
+        // `sled::open` recovers a damaged `db` into a fresh empty database rather
+        // than failing, and its own `was_recovered()` signal is only false on the
+        // FIRST open — the gate's open would persist the repair and turn the
+        // signal true, leaving a corrupt ledger to be certified as `✓ Ledger
+        // empty` (#2732).
+        assert_ledger_recovered_as_written(restore_dir)?;
         enforce_n2a_gate(restore_dir, "backup verification")?;
         ledger_check = Some(verify_ledger_in_backup(restore_dir)?);
     }
@@ -6870,9 +6877,11 @@ fn handle_verify_backup_command(input: &Path, verify_ledger: bool) -> Result<()>
 ///
 /// A live sled database directory holds `conf`, `db` and `blobs`; requiring `db`
 /// as well as `conf` is what distinguishes a restored database from an
-/// interrupted initialisation. This cannot detect a `db` that is present but
-/// unreadable — sled recovers such a directory into an empty database with only a
-/// warning, which needs a different mechanism and is owned by icn#2732.
+/// interrupted initialisation. This deliberately stays a pure filesystem check
+/// and opens nothing. It therefore cannot detect a `db` that is present but
+/// unreadable — sled recovers such a directory into an empty database — which is
+/// why [`assert_ledger_recovered_as_written`] runs immediately after it and
+/// before the gate (icn#2732).
 fn assert_backup_carried_a_ledger(restore_dir: &Path) -> Result<()> {
     let ledger_db_path = icn_core::config::ledger_store_path(restore_dir);
 
@@ -6904,6 +6913,94 @@ fn assert_backup_carried_a_ledger(restore_dir: &Path) -> Result<()> {
                 marker
             );
         }
+    }
+
+    Ok(())
+}
+
+/// Prove the archive's ledger database was read AS WRITTEN, not silently replaced.
+///
+/// Ordering is load-bearing in BOTH directions, and neither neighbour is
+/// interchangeable with this one.
+///
+/// **After [`assert_backup_carried_a_ledger`]**, because this opens the database
+/// and that check must stay a pure filesystem check: a directory holding `conf`
+/// but no `db` has to bail before anything performs a creating open, or the open
+/// manufactures the database the caller was about to certify (icn#2717).
+///
+/// **Before `enforce_n2a_gate`**, because the evidence is destroyed by being
+/// observed. `sled::open` is a CREATING open with no read-only mode: handed a
+/// `db` it cannot parse it does not fail, it allocates a fresh meta page and
+/// returns an empty database, and the journal scan then honestly reports zero
+/// rows. `Db::was_recovered()` is `false` for exactly that case — sled clears it
+/// when it has to allocate `META_PID` or `COUNTER_PID` instead of recovering
+/// them. But that allocation is PERSISTED, so the *second* open of the same
+/// damaged directory legitimately recovers what the first one created and
+/// reports `true`. Measured on a backup whose ledger `db` was truncated: open 1
+/// `false`, open 2 `true`, open 3 `true`. `enforce_n2a_gate` opens every sled
+/// root it discovers, so a check placed after it reads `true` and certifies the
+/// corruption. This must be the FIRST open of the extracted tree.
+///
+/// A genuinely empty but readable ledger reports `true` — it has a meta page to
+/// recover — so the signal separates "this backup holds an honestly empty
+/// ledger" from "this backup's ledger could not be inspected as written", which
+/// is the distinction icn#2732 exists to restore. Those are very different facts
+/// for an operator holding a backup they may need to restore.
+///
+/// This is a mechanism, not a reading of sled's log output. The warning sled
+/// prints on a damaged configuration is human-oriented text with no stability
+/// guarantee; `was_recovered()` is the library's own answer to the question
+/// being asked.
+///
+/// The checksum in `backup_metadata.json` cannot substitute for this: it is
+/// computed over the data directory at backup time, so a ledger already damaged
+/// when the backup was taken checksums consistently and passes.
+///
+/// The store is dropped before returning — sled holds an exclusive flock and the
+/// gate's own open comes next.
+fn assert_ledger_recovered_as_written(restore_dir: &Path) -> Result<()> {
+    use icn_store::SledStore;
+
+    let ledger_db_path = icn_core::config::ledger_store_path(restore_dir);
+
+    // An open that fails outright is also "could not be inspected as written",
+    // and saying so here names the check the operator asked for. Without this the
+    // same damage surfaced as an N2-A startup-gate refusal, which is true but
+    // sends the reader looking for a principal-collision problem they do not have.
+    let store = SledStore::open(&ledger_db_path).with_context(|| {
+        format!(
+            "FAILED: the ledger database in this backup at {} could not be opened, \
+             so nothing in it could be verified. Ledger verification was NOT \
+             performed.\n\
+             \n\
+             The archive carries a ledger directory, so this is damage to the \
+             database itself — a truncated or partially written copy, a failed \
+             transfer, or tampering — not a node that never had a ledger.",
+            ledger_db_path.display()
+        )
+    })?;
+    let recovered = store.db().was_recovered();
+    drop(store);
+
+    if !recovered {
+        bail!(
+            "FAILED: the ledger database in this backup could not be read as \
+             written. sled did not recover the database at {}; it initialised a \
+             new, empty one in its place, so a scan of it would report this \
+             backup's ledger as empty no matter what the backup actually \
+             contained. Ledger verification was NOT performed.\n\
+             \n\
+             Both `conf` and `db` are present in the archive, so this is damage to \
+             the database itself — a truncated or partially written copy, a failed \
+             transfer, or tampering — not a node that never had a ledger. The \
+             backup's own checksum cannot catch this: it is computed over the data \
+             directory at backup time, so a ledger that was already damaged when \
+             the backup was taken checksums consistently and passes.\n\
+             \n\
+             How many entries the ledger held is not recoverable from this \
+             archive; treat the backup as unrestorable rather than as empty.",
+            ledger_db_path.display()
+        );
     }
 
     Ok(())

--- a/icn/bins/icnctl/src/main.rs
+++ b/icn/bins/icnctl/src/main.rs
@@ -6947,6 +6947,12 @@ fn assert_backup_carried_a_ledger(restore_dir: &Path) -> Result<()> {
 /// is the distinction icn#2732 exists to restore. Those are very different facts
 /// for an operator holding a backup they may need to restore.
 ///
+/// What the signal does NOT establish is the CAUSE. A truncated copy, a failed
+/// transfer, tampering, and a ledger whose first writes were never durably
+/// flushed are byte-indistinguishable here, and the message must not pick one of
+/// them. It reports what was established — the database was replaced rather than
+/// recovered — and declines to name why.
+///
 /// This is a mechanism, not a reading of sled's log output. The warning sled
 /// prints on a damaged configuration is human-oriented text with no stability
 /// guarantee; `was_recovered()` is the library's own answer to the question
@@ -6990,15 +6996,18 @@ fn assert_ledger_recovered_as_written(restore_dir: &Path) -> Result<()> {
              backup's ledger as empty no matter what the backup actually \
              contained. Ledger verification was NOT performed.\n\
              \n\
-             Both `conf` and `db` are present in the archive, so this is damage to \
-             the database itself — a truncated or partially written copy, a failed \
-             transfer, or tampering — not a node that never had a ledger. The \
-             backup's own checksum cannot catch this: it is computed over the data \
-             directory at backup time, so a ledger that was already damaged when \
-             the backup was taken checksums consistently and passes.\n\
+             Both `conf` and `db` are present, so this is not a backup that never \
+             carried a ledger. What it is cannot be narrowed further from the \
+             archive alone: a truncated or partially written copy, a failed \
+             transfer, tampering, and a ledger whose first writes were never \
+             durably flushed all leave bytes sled reports the same way. The \
+             backup's own checksum cannot distinguish them either — it is computed \
+             over the data directory at backup time, so a ledger already damaged \
+             when the backup was taken checksums consistently and passes.\n\
              \n\
-             How many entries the ledger held is not recoverable from this \
-             archive; treat the backup as unrestorable rather than as empty.",
+             What this backup's ledger held is therefore not established by this \
+             archive. It may have held nothing; it may have held entries that \
+             cannot be recovered. Do not rely on it as an empty ledger.",
             ledger_db_path.display()
         );
     }

--- a/icn/bins/icnctl/src/main.rs
+++ b/icn/bins/icnctl/src/main.rs
@@ -6973,15 +6973,34 @@ fn assert_ledger_recovered_as_written(restore_dir: &Path) -> Result<()> {
     // and saying so here names the check the operator asked for. Without this the
     // same damage surfaced as an N2-A startup-gate refusal, which is true but
     // sends the reader looking for a principal-collision problem they do not have.
+    //
+    // This branch is the REALISTIC one, not the exotic one. A ledger that has
+    // been opened more than once carries a `snap.*`, and with a snapshot present
+    // sled reports damage as `Corruption` instead of recovering into an empty
+    // database — so any node that has ever restarted arrives here rather than at
+    // the `was_recovered()` refusal below.
+    //
+    // It therefore names a cause even less than that refusal may.
+    // `SledStore::open` is a bare `sled::open`, so this context attaches to every
+    // `sled::Error` — a permission failure, ENOSPC, a descriptor limit or another
+    // process holding the flock reach it exactly as damaged bytes do. Telling an
+    // operator their backup may have been tampered with because the file was not
+    // readable would be a fabricated conclusion. Say what happened, and let
+    // sled's own error say why through the cause chain below.
     let store = SledStore::open(&ledger_db_path).with_context(|| {
         format!(
             "FAILED: the ledger database in this backup at {} could not be opened, \
              so nothing in it could be verified. Ledger verification was NOT \
              performed.\n\
              \n\
-             The archive carries a ledger directory, so this is damage to the \
-             database itself — a truncated or partially written copy, a failed \
-             transfer, or tampering — not a node that never had a ledger.",
+             The archive carried both `conf` and `db`, so this is not the \
+             missing-ledger case. What stopped the open is not narrowed here: \
+             sled's own error is reported below, and the possibilities include \
+             damaged contents as well as conditions that say nothing about the \
+             archive at all, such as a permission problem or another process \
+             holding the database lock.\n\
+             \n\
+             Do not rely on this backup as an empty ledger.",
             ledger_db_path.display()
         )
     })?;
@@ -6996,8 +7015,8 @@ fn assert_ledger_recovered_as_written(restore_dir: &Path) -> Result<()> {
              backup's ledger as empty no matter what the backup actually \
              contained. Ledger verification was NOT performed.\n\
              \n\
-             Both `conf` and `db` are present, so this is not a backup that never \
-             carried a ledger. What it is cannot be narrowed further from the \
+             The archive carried both `conf` and `db`, so this is not the \
+             missing-ledger case. What it IS cannot be narrowed further from the \
              archive alone: a truncated or partially written copy, a failed \
              transfer, tampering, and a ledger whose first writes were never \
              durably flushed all leave bytes sled reports the same way. The \

--- a/icn/bins/icnctl/src/main.rs
+++ b/icn/bins/icnctl/src/main.rs
@@ -6899,6 +6899,16 @@ fn handle_verify_backup_command(input: &Path, verify_ledger: bool) -> Result<()>
 /// exist is not this function's business — absence is the presence check's
 /// verdict to give, and giving it here would produce two different messages for
 /// one condition.
+///
+/// The path alone is NOT enough, and a first version of this check that stopped
+/// there was still escapable. An archive can keep `store/ledger` a real directory
+/// and make its CHILDREN links: `conf`, `db`, or anything under `blobs/`. The
+/// marker checks follow those with `is_file()`, and `sled::open` opens exactly
+/// those paths — reproduced, with the external database's `db` rewritten through
+/// a symlinked child while the directory itself was genuinely local. So the whole
+/// subtree is walked, no-follow, and any link anywhere in it is refused. sled
+/// decides for itself which files under this directory to open; the safe
+/// assumption is all of them.
 fn assert_ledger_path_is_contained(restore_dir: &Path, ledger_db_path: &Path) -> Result<()> {
     let relative = ledger_db_path
         .strip_prefix(restore_dir)
@@ -6923,6 +6933,27 @@ fn assert_ledger_path_is_contained(restore_dir: &Path, ledger_db_path: &Path) ->
                  verified, while reporting the result as though it came from the \
                  backup. A backup written by `icnctl backup` never contains one.",
                 walked.display()
+            );
+        }
+    }
+
+    // The directory is local. Everything sled may open UNDER it must be too.
+    for entry in walkdir::WalkDir::new(ledger_db_path)
+        .follow_links(false)
+        .into_iter()
+        .filter_map(|entry| entry.ok())
+    {
+        if entry.file_type().is_symlink() {
+            bail!(
+                "FAILED: this backup places a symbolic link at {}, inside its \
+                 ledger database directory. Ledger verification was NOT performed, \
+                 and nothing was opened.\n\
+                 \n\
+                 The directory itself is local, but sled opens the files inside it \
+                 — and writes to them — so a link there reaches outside the archive \
+                 exactly as a linked directory would. A backup written by \
+                 `icnctl backup` never contains one.",
+                entry.path().display()
             );
         }
     }

--- a/icn/bins/icnctl/tests/verify_backup_ledger_test.rs
+++ b/icn/bins/icnctl/tests/verify_backup_ledger_test.rs
@@ -1255,7 +1255,7 @@ fn verification_touches_nothing_outside_its_known_side_effect_surface() {
         let store = SledStore::open(&restored_ledger).expect("could not open restored ledger");
         assert!(
             store.db().was_recovered(),
-            "a healthy restored ledger must report as recovered, or the handler              would refuse this archive"
+            "a healthy restored ledger must report as recovered, or the handler would refuse this archive"
         );
     }
 
@@ -1447,11 +1447,27 @@ fn assert_not_certified_as_empty(text: &str, status_ok: bool) {
         "and must say the requested verification did not happen, rather than \
          reporting a result it never obtained:\n{text}"
     );
-    // Say only what the evidence supports. Nothing in the archive records how
-    // many rows the ledger held, so the message must not imply a count.
+    // Say only what the evidence supports, in two directions.
+    //
+    // Nothing in the archive records how many rows the ledger held, so the
+    // message must not imply a count.
     assert!(
-        flat.contains("not recoverable from this archive"),
+        flat.contains("not established by this archive"),
         "the message must not imply the original contents are known:\n{text}"
+    );
+    assert!(
+        flat.contains("Do not rely on it as an empty ledger"),
+        "and it must give the operator the one instruction the evidence does \
+         support:\n{text}"
+    );
+    // Nor may it assert a CAUSE. `was_recovered() == false` is equally consistent
+    // with a truncated copy, a failed transfer, tampering, and a ledger whose
+    // first writes were never durably flushed — sled cannot tell them apart, so
+    // neither may this message. An earlier draft asserted damage or tampering
+    // outright, which is the same overclaiming this whole change exists to stop.
+    assert!(
+        flat.contains("cannot be narrowed further"),
+        "the message must say plainly that the cause is not established:\n{text}"
     );
 }
 
@@ -1585,5 +1601,83 @@ fn a_genuinely_empty_readable_ledger_still_verifies() {
     assert!(
         flattened(&text).contains("Ledger empty (no entries)"),
         "and it must still be reported as empty:\n{text}"
+    );
+}
+
+/// A restarted node's ledger takes the OTHER refusal branch, and must also refuse.
+///
+/// The two damage tests above build a ledger that has been opened exactly once —
+/// `seed_ledger` opens a fresh directory, writes, flushes and drops. sled writes
+/// a `snap.*` only when a later open advances the stable LSN, so a first-ever
+/// open leaves `conf`, `db` and `blobs` and no snapshot. That is the shape of a
+/// node that has never restarted.
+///
+/// A real node's ledger carries a `snap.*` after its second start, and with a
+/// snapshot present the same truncation makes `sled::open` return `Corruption`
+/// instead of silently recovering — so production damage reaches
+/// `assert_ledger_recovered_as_written`'s OPEN-FAILED branch, not its
+/// `was_recovered()` branch. Both are refusals, but only one of them was covered,
+/// and "a corrupt ledger is never reported as empty" is a claim about both.
+///
+/// This test reopens the seeded ledger once before damaging it, which is the
+/// cheapest faithful stand-in for a restart.
+#[test]
+fn a_restarted_nodes_ledger_damaged_the_same_way_is_also_refused() {
+    let dir = TempDir::new().unwrap();
+    let data_dir = dir.path().join("data");
+    let archive = dir.path().join("restarted.tar");
+
+    init_identity(&data_dir);
+    seed_ledger(&data_dir, &[("hours", 60, 0), ("hours", 0, 60)]);
+
+    // The "restart": a second open, which is what writes the snapshot.
+    {
+        let store = SledStore::open(ledger_dir(&data_dir)).expect("fixture: could not reopen");
+        store.db().flush().expect("fixture: could not flush");
+    }
+    let snapshots: Vec<_> = std::fs::read_dir(ledger_dir(&data_dir))
+        .unwrap()
+        .filter_map(|e| e.ok())
+        .map(|e| e.file_name().to_string_lossy().into_owned())
+        .filter(|n| n.starts_with("snap."))
+        .collect();
+    assert!(
+        !snapshots.is_empty(),
+        "fixture: a restarted ledger must carry a snapshot, or this test builds \
+         the same shape as the two above and covers nothing new"
+    );
+
+    std::fs::write(ledger_dir(&data_dir).join("db"), b"").expect("fixture: could not truncate db");
+    make_backup(&data_dir, &archive);
+
+    let out = verify(&archive, true);
+    let text = combined(&out);
+    let flat = flattened(&text);
+
+    assert!(
+        !out.status.success(),
+        "a restarted node's damaged ledger must not verify:\n{text}"
+    );
+    // The claim under test is the same one, on the branch the other tests miss.
+    assert!(
+        !flat.contains("Ledger empty"),
+        "an unreadable ledger must never be reported as an empty one, on either \
+         refusal branch:\n{text}"
+    );
+    assert!(
+        !flat.contains("BACKUP VERIFICATION PASSED"),
+        "and the run must not end in a success banner:\n{text}"
+    );
+    assert!(
+        flat.contains("Ledger verification was NOT performed"),
+        "and it must say the requested verification did not happen:\n{text}"
+    );
+    // This shape reaches the open-failed branch, whose wording differs from the
+    // recovery branch. Asserting the distinct wording is what proves the two are
+    // actually different code paths rather than one path reached twice.
+    assert!(
+        flat.contains("could not be opened"),
+        "a snapshot-bearing ledger fails at OPEN, so the message must be the \
+         open-failed one rather than the recovery one:\n{text}"
     );
 }

--- a/icn/bins/icnctl/tests/verify_backup_ledger_test.rs
+++ b/icn/bins/icnctl/tests/verify_backup_ledger_test.rs
@@ -1420,6 +1420,39 @@ fn a_backup_whose_ledger_was_damaged_before_it_was_taken(
     archive
 }
 
+/// A refusal may not tell the operator WHY, because nothing here establishes why.
+///
+/// A presence check on the hedge is not enough on its own: a future edit that
+/// re-added `— a truncated or partially written copy, a failed transfer, or
+/// tampering —` *alongside* "cannot be narrowed further" would satisfy the hedge
+/// assertion and still deliver the fabricated conclusion. The regression to guard
+/// is the reappearance of a cause, so this asserts its ABSENCE.
+///
+/// `was_recovered() == false` is equally consistent with a truncated copy, a
+/// failed transfer, tampering, and a ledger whose first writes were never durably
+/// flushed; sled cannot tell those apart, so neither may the message. The
+/// open-failed branch is looser still — it attaches to every `sled::Error`,
+/// including a permission problem or flock contention that says nothing about the
+/// archive.
+///
+/// NAMING the possibilities is allowed; ASSERTING one is not. A message that
+/// lists what it cannot distinguish is telling the operator something true and
+/// useful, and the current wording does exactly that. So the forbidden strings
+/// are the assertive constructions only — the flat claim, and the disjunction
+/// that closed the original overclaim — rather than the individual causes, which
+/// legitimately appear in the "cannot be narrowed further" enumeration. A
+/// forbidden-word list over the causes themselves was tried first and failed the
+/// honest wording, which is the distinction this comment exists to keep.
+fn assert_names_no_cause(flat: &str, text: &str) {
+    for forbidden in ["or tampering", "damage to the database itself"] {
+        assert!(
+            !flat.contains(forbidden),
+            "the refusal must not assert a cause it cannot establish, but it \
+             contains {forbidden:?}:\n{text}"
+        );
+    }
+}
+
 /// The assertions both damage cases share.
 fn assert_not_certified_as_empty(text: &str, status_ok: bool) {
     let flat = flattened(text);
@@ -1460,15 +1493,12 @@ fn assert_not_certified_as_empty(text: &str, status_ok: bool) {
         "and it must give the operator the one instruction the evidence does \
          support:\n{text}"
     );
-    // Nor may it assert a CAUSE. `was_recovered() == false` is equally consistent
-    // with a truncated copy, a failed transfer, tampering, and a ledger whose
-    // first writes were never durably flushed — sled cannot tell them apart, so
-    // neither may this message. An earlier draft asserted damage or tampering
-    // outright, which is the same overclaiming this whole change exists to stop.
+    // Nor may it assert a CAUSE.
     assert!(
         flat.contains("cannot be narrowed further"),
         "the message must say plainly that the cause is not established:\n{text}"
     );
+    assert_names_no_cause(&flat, text);
 }
 
 /// A ledger `db` truncated in transfer must not be certified as an empty ledger.
@@ -1680,4 +1710,7 @@ fn a_restarted_nodes_ledger_damaged_the_same_way_is_also_refused() {
         "a snapshot-bearing ledger fails at OPEN, so the message must be the \
          open-failed one rather than the recovery one:\n{text}"
     );
+    // This branch attaches to every `sled::Error`, not only corruption, so it may
+    // name a cause even less than the recovery branch may.
+    assert_names_no_cause(&flat, &text);
 }

--- a/icn/bins/icnctl/tests/verify_backup_ledger_test.rs
+++ b/icn/bins/icnctl/tests/verify_backup_ledger_test.rs
@@ -1182,9 +1182,12 @@ fn is_known_verification_side_effect(path: &str) -> bool {
 ///    property an operator actually relies on and it holds exactly.
 /// 2. **The restored tree's mutation surface is bounded and known.** The archive
 ///    is extracted here and driven through the *same* sequence the handler drives
-///    — `n2a_startup_gate::enforce`, then `SledStore::open` and a journal scan —
-///    with a full content identity taken either side. Every difference must be on
-///    the permitlist above, and nothing may disappear.
+///    — the pre-gate recovery open (#2732), then `n2a_startup_gate::enforce`,
+///    then `SledStore::open` and a journal scan — with a full content identity
+///    taken either side. Every difference must be on the permitlist above, and
+///    nothing may disappear. The recovery open is part of the sequence precisely
+///    because it must come first; replicating the handler in the wrong order
+///    would make this test's claim about a run the handler never performs.
 /// 3. **The journal's contents survive.** The rows read back are exactly the row
 ///    the fixture wrote, and reading them a second time returns the same bytes.
 ///    So the side effects above are confined to sled's container: the evidence
@@ -1243,6 +1246,18 @@ fn verification_touches_nothing_outside_its_known_side_effect_surface() {
     );
 
     let before = tree_identity(&restore);
+
+    // The handler's FIRST open: the #2732 recovery check. It adds no new path to
+    // the permitlist because it opens the same sled root the scan below opens —
+    // but it does open it, and this test exists to notice if that ever stops
+    // being true.
+    {
+        let store = SledStore::open(&restored_ledger).expect("could not open restored ledger");
+        assert!(
+            store.db().was_recovered(),
+            "a healthy restored ledger must report as recovered, or the handler              would refuse this archive"
+        );
+    }
 
     icn_store::n2a_startup_gate::enforce(&restore, std::time::SystemTime::now())
         .expect("the N2-A gate must accept this tree");
@@ -1312,5 +1327,263 @@ fn verification_touches_nothing_outside_its_known_side_effect_surface() {
     assert!(
         icn_ledger::entry_validation::inspect_entry(&entry).is_valid(),
         "and it must still be valid under the ledger's own entry validation"
+    );
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// icn#2732 — a ledger that could not be read as written must not be reported as
+// an empty one.
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Copy a tree so the fixture's contents can be PROVED without perturbing the
+/// artifact under test.
+///
+/// This helper exists because of a trap that produced a false CLEAR while these
+/// tests were being written. `SledStore::open` writes a snapshot, and with a
+/// snapshot present sled *errors* on a damaged `db` instead of silently
+/// recovering from it. So a fixture that proved its own row count by opening the
+/// database it was about to damage changed which sled code path the damage took,
+/// and the run came back fail-closed — the defect masked by the act of
+/// establishing the precondition. Count on a copy; damage the original.
+fn copy_tree(src: &Path, dst: &Path) {
+    std::fs::create_dir_all(dst).expect("fixture: could not create copy target");
+    for entry in std::fs::read_dir(src).expect("fixture: could not read source tree") {
+        let entry = entry.expect("fixture: could not read directory entry");
+        let to = dst.join(entry.file_name());
+        if entry
+            .file_type()
+            .expect("fixture: could not stat entry")
+            .is_dir()
+        {
+            copy_tree(&entry.path(), &to);
+        } else {
+            std::fs::copy(entry.path(), &to).expect("fixture: could not copy file");
+        }
+    }
+}
+
+/// Prove, without touching `data_dir`, that its ledger really holds `expected`
+/// journal rows.
+fn assert_ledger_holds_rows_without_touching_it(dir: &TempDir, data_dir: &Path, expected: usize) {
+    let witness = dir.path().join(format!(
+        "witness-{}",
+        data_dir.file_name().unwrap().to_string_lossy()
+    ));
+    copy_tree(data_dir, &witness);
+    let store = SledStore::open(ledger_dir(&witness)).expect("fixture: could not open the witness");
+    let rows = store
+        .scan(b"ledger:journal:")
+        .expect("fixture: could not scan the witness");
+    assert_eq!(
+        rows.len(),
+        expected,
+        "fixture: the ledger must really hold {expected} row(s) before it is \
+         damaged, or the assertions below are about an already-empty ledger and \
+         discriminate nothing"
+    );
+}
+
+/// The shared shape of both damage cases.
+///
+/// A backup taken from a data directory whose ledger database was ALREADY
+/// damaged. The checksum in `backup_metadata.json` is computed over the data
+/// directory at backup time, so the damage is inside the checksummed bytes and
+/// the archive verifies as intact — which is exactly why the checksum cannot
+/// stand in for reading the ledger.
+fn a_backup_whose_ledger_was_damaged_before_it_was_taken(
+    dir: &TempDir,
+    name: &str,
+    damage: impl Fn(&Path),
+) -> PathBuf {
+    let data_dir = dir.path().join(name);
+    let archive = dir.path().join(format!("{name}.tar"));
+
+    init_identity(&data_dir);
+    seed_ledger(&data_dir, &[("hours", 60, 0), ("hours", 0, 60)]);
+    assert_ledger_holds_rows_without_touching_it(dir, &data_dir, 1);
+
+    damage(&ledger_dir(&data_dir));
+
+    // The presence proof #2717 established still passes: this is not a missing
+    // ledger, it is an unreadable one. Both markers are still files.
+    assert!(
+        ledger_dir(&data_dir).join("conf").is_file() && ledger_dir(&data_dir).join("db").is_file(),
+        "fixture: the damage must leave a directory that still LOOKS like a sled \
+         database, or this exercises #2717's presence check instead of #2732"
+    );
+
+    make_backup(&data_dir, &archive);
+    assert!(
+        archive_contains_ledger(&archive),
+        "fixture: the archive must carry the ledger directory"
+    );
+    archive
+}
+
+/// The assertions both damage cases share.
+fn assert_not_certified_as_empty(text: &str, status_ok: bool) {
+    let flat = flattened(text);
+    assert!(
+        !status_ok,
+        "a ledger that could not be read as written must not verify:\n{text}"
+    );
+    // THE defect, stated exactly: this pairing is the operator-visible false
+    // conclusion #2732 exists to stop.
+    assert!(
+        !flat.contains("Ledger empty"),
+        "an unreadable ledger must never be reported as an empty one:\n{text}"
+    );
+    assert!(
+        !flat.contains("BACKUP VERIFICATION PASSED"),
+        "and the run must not end in a success banner:\n{text}"
+    );
+    assert!(
+        flat.contains("could not be read as written"),
+        "the failure must name what actually happened — the database was replaced, \
+         not read:\n{text}"
+    );
+    assert!(
+        flat.contains("Ledger verification was NOT performed"),
+        "and must say the requested verification did not happen, rather than \
+         reporting a result it never obtained:\n{text}"
+    );
+    // Say only what the evidence supports. Nothing in the archive records how
+    // many rows the ledger held, so the message must not imply a count.
+    assert!(
+        flat.contains("not recoverable from this archive"),
+        "the message must not imply the original contents are known:\n{text}"
+    );
+}
+
+/// A ledger `db` truncated in transfer must not be certified as an empty ledger.
+///
+/// This is the mechanism icn#2732 names. `sled::open` has no read-only mode and
+/// no fail-closed mode: given a `db` it cannot parse it allocates a fresh meta
+/// page and hands back an EMPTY database. The journal scan then honestly finds
+/// zero rows, and the verifier — faithfully reporting what the layer below gave
+/// it — printed `✓ Ledger empty (no entries)` and `✓ BACKUP VERIFICATION PASSED`
+/// for a backup that in fact held journal rows nobody could read.
+///
+/// Against `main` before the fix this test fails on the `Ledger empty` assertion
+/// with exit status 0, which is the discrimination it is here to make.
+#[test]
+fn a_truncated_ledger_database_is_not_reported_as_an_empty_one() {
+    let dir = TempDir::new().unwrap();
+    let archive = a_backup_whose_ledger_was_damaged_before_it_was_taken(&dir, "truncated", |lp| {
+        // An interrupted copy: the file is still there, and holds nothing.
+        std::fs::write(lp.join("db"), b"").expect("fixture: could not truncate db");
+    });
+
+    let out = verify(&archive, true);
+    assert_not_certified_as_empty(&combined(&out), out.status.success());
+}
+
+/// The same conclusion must not survive same-length damage either.
+///
+/// Truncation is one shape of a partial write; a `db` overwritten in place with
+/// zeroes is another, and it defeats any check that reasons about file SIZE
+/// rather than about whether the database was recovered. Both must fail, and for
+/// the same stated reason.
+#[test]
+fn a_ledger_database_overwritten_in_place_is_not_reported_as_an_empty_one() {
+    let dir = TempDir::new().unwrap();
+    let archive = a_backup_whose_ledger_was_damaged_before_it_was_taken(&dir, "zeroed", |lp| {
+        let len = std::fs::metadata(lp.join("db"))
+            .expect("fixture: could not stat db")
+            .len() as usize;
+        std::fs::write(lp.join("db"), vec![0u8; len]).expect("fixture: could not zero db");
+    });
+
+    let out = verify(&archive, true);
+    assert_not_certified_as_empty(&combined(&out), out.status.success());
+}
+
+/// The signal exists only at the FIRST open, and that is why the check is placed
+/// where it is.
+///
+/// `Db::was_recovered()` is false when sled had to allocate the meta page rather
+/// than recover it — but the allocation is persisted, so the next open of the
+/// same damaged directory legitimately recovers what the previous one created.
+/// `enforce_n2a_gate` opens every sled root it finds. A recovery check placed
+/// after the gate would therefore read `true` on a corrupt ledger and certify it,
+/// which is the same class of ordering bug #2717 fixed for the presence check.
+///
+/// This test pins the property the ordering depends on, so that if a future sled
+/// upgrade makes the signal survive (or stop being produced at all) this fails
+/// rather than the ordering silently becoming decorative.
+#[test]
+fn sleds_recovery_signal_is_destroyed_by_the_first_open() {
+    let dir = TempDir::new().unwrap();
+    let data_dir = dir.path().join("data");
+    init_identity(&data_dir);
+    seed_ledger(&data_dir, &[("hours", 60, 0), ("hours", 0, 60)]);
+    let lp = ledger_dir(&data_dir);
+    std::fs::write(lp.join("db"), b"").expect("fixture: could not truncate db");
+
+    let signal = |p: &Path| {
+        let store = SledStore::open(p).expect("could not open ledger");
+        let recovered = store.db().was_recovered();
+        let rows = store
+            .scan(b"ledger:journal:")
+            .expect("could not scan")
+            .len();
+        (recovered, rows)
+    };
+
+    let (first, rows_first) = signal(&lp);
+    let (second, _) = signal(&lp);
+
+    assert!(
+        !first,
+        "sled must report a damaged database as NOT recovered on the first open, \
+         or there is no mechanism to place before the gate"
+    );
+    assert_eq!(
+        rows_first, 0,
+        "and the fresh database it substituted must scan as empty — that is the \
+         false conclusion being prevented"
+    );
+    assert!(
+        second,
+        "the second open must report `recovered`, because the first open \
+         PERSISTED the meta page it allocated. This is why the check cannot run \
+         after `enforce_n2a_gate`, which opens every sled root it discovers"
+    );
+}
+
+/// A readable ledger that is genuinely empty must keep its meaning.
+///
+/// The whole point of icn#2732 is to separate two facts, not to collapse them in
+/// the other direction. A database sled really did recover, which really has no
+/// journal rows, must still report `✓ Ledger empty` and still pass — otherwise
+/// the fix has simply moved the false conclusion.
+///
+/// Complements `an_empty_ledger_does_not_claim_the_invariant_was_verified`, which
+/// pins the same case's summary wording; this one pins that the new recovery
+/// check does not reject it.
+#[test]
+fn a_genuinely_empty_readable_ledger_still_verifies() {
+    let dir = TempDir::new().unwrap();
+    let data_dir = dir.path().join("data");
+    let archive = dir.path().join("backup.tar");
+
+    init_identity(&data_dir);
+    let path = ledger_dir(&data_dir);
+    std::fs::create_dir_all(&path).unwrap();
+    let store = SledStore::open(&path).unwrap();
+    store.db().flush().unwrap();
+    drop(store);
+    make_backup(&data_dir, &archive);
+
+    let out = verify(&archive, true);
+    let text = combined(&out);
+    assert!(
+        out.status.success(),
+        "an honestly empty ledger must still verify — the recovery check must not \
+         reject a database sled actually recovered:\n{text}"
+    );
+    assert!(
+        flattened(&text).contains("Ledger empty (no entries)"),
+        "and it must still be reported as empty:\n{text}"
     );
 }

--- a/icn/bins/icnctl/tests/verify_backup_ledger_test.rs
+++ b/icn/bins/icnctl/tests/verify_backup_ledger_test.rs
@@ -1746,6 +1746,35 @@ fn a_restarted_nodes_ledger_damaged_the_same_way_is_also_refused() {
 /// whether bytes outside the extraction root changed.
 #[test]
 fn a_symlinked_ledger_cannot_make_verification_write_outside_the_archive() {
+    crafted_symlink_archive_must_not_touch_the_victim(SymlinkShape::WholeDirectory);
+}
+
+/// The same escape one level down, which the first containment fix did not close.
+///
+/// An archive can keep `store/ledger` a genuinely local directory and make its
+/// CHILDREN links instead. A path-only containment check walks to the directory
+/// and stops, so it sees nothing wrong — but the presence check then follows
+/// `conf` and `db` with `is_file()`, and `sled::open` opens exactly those paths
+/// and writes to them.
+///
+/// Reproduced against the path-only check: the victim's `db` was rewritten
+/// through a symlinked child while the ledger directory itself was local. sled
+/// decides which files under its directory to open, so containment walks the
+/// whole subtree rather than guessing at a list of names.
+#[test]
+fn a_symlinked_ledger_child_cannot_make_verification_write_outside_the_archive() {
+    crafted_symlink_archive_must_not_touch_the_victim(SymlinkShape::ChildrenOnly);
+}
+
+/// Where the crafted archive puts its link.
+enum SymlinkShape {
+    /// `store/ledger` is itself a link to the victim directory.
+    WholeDirectory,
+    /// `store/ledger` is a real directory whose `conf`/`db` link to the victim's.
+    ChildrenOnly,
+}
+
+fn crafted_symlink_archive_must_not_touch_the_victim(shape: SymlinkShape) {
     let dir = TempDir::new().unwrap();
 
     // A real sled database that has nothing to do with any backup.
@@ -1798,14 +1827,42 @@ fn a_symlinked_ledger_cannot_make_verification_write_outside_the_archive() {
                     .expect("fixture: could not append file");
             }
         }
-        let mut header = tar::Header::new_gnu();
-        header.set_entry_type(tar::EntryType::Symlink);
-        header.set_size(0);
-        header.set_mode(0o777);
-        header.set_cksum();
-        builder
-            .append_link(&mut header, "store/ledger", &victim)
-            .expect("fixture: could not append the symlink");
+        match shape {
+            SymlinkShape::WholeDirectory => {
+                let mut header = tar::Header::new_gnu();
+                header.set_entry_type(tar::EntryType::Symlink);
+                header.set_size(0);
+                header.set_mode(0o777);
+                header.set_cksum();
+                builder
+                    .append_link(&mut header, "store/ledger", &victim)
+                    .expect("fixture: could not append the symlink");
+            }
+            SymlinkShape::ChildrenOnly => {
+                let mut dir_header = tar::Header::new_gnu();
+                dir_header.set_entry_type(tar::EntryType::Directory);
+                dir_header.set_size(0);
+                dir_header.set_mode(0o755);
+                dir_header.set_cksum();
+                builder
+                    .append_data(&mut dir_header, "store/ledger/", std::io::empty())
+                    .expect("fixture: could not append the ledger directory");
+                for marker in ["conf", "db"] {
+                    let mut header = tar::Header::new_gnu();
+                    header.set_entry_type(tar::EntryType::Symlink);
+                    header.set_size(0);
+                    header.set_mode(0o777);
+                    header.set_cksum();
+                    builder
+                        .append_link(
+                            &mut header,
+                            format!("store/ledger/{marker}"),
+                            victim.join(marker),
+                        )
+                        .expect("fixture: could not append the child symlink");
+                }
+            }
+        }
         builder
             .finish()
             .expect("fixture: could not finish the archive");

--- a/icn/bins/icnctl/tests/verify_backup_ledger_test.rs
+++ b/icn/bins/icnctl/tests/verify_backup_ledger_test.rs
@@ -1714,3 +1714,126 @@ fn a_restarted_nodes_ledger_damaged_the_same_way_is_also_refused() {
     // name a cause even less than the recovery branch may.
     assert_names_no_cause(&flat, &text);
 }
+
+/// A crafted archive must not make verification write outside what it extracted.
+///
+/// The archive is untrusted input, so a `store/ledger` that is a *symlink* to a
+/// sled database elsewhere on the machine has to be refused before anything
+/// follows it. Every gate in front of the ledger open follows symlinks or ignores
+/// them:
+///
+/// - `calculate_dir_checksum` walks with `follow_links(false)` and hashes only
+///   `is_file()` entries, so a symlink is skipped and the checksum still matches;
+/// - `Path::exists` and `Path::is_file` in the presence check follow it, and find
+///   a complete `conf`/`db` pair;
+/// - `sled::open` follows it too, and **writes** — it grows the backing file, may
+///   write a snapshot, and rewrites the configuration.
+///
+/// `enforce_n2a_gate` does refuse symlinks (`find_sled_roots` uses `file_type()`,
+/// which does not follow, and errors rather than skipping). That was sufficient
+/// while the gate held the first open of the extracted tree. icn#2732 moved an
+/// open in front of the gate — it has to, or sled's recovery signal is already
+/// gone — and that reordering stepped the new open past the gate's guard.
+///
+/// Measured with the guard removed: the external database's `db` was rewritten
+/// and a `snap.*` was created, from nothing but an operator running
+/// `verify-backup` on a hostile file. The refusal must therefore come before the
+/// open, not from the gate after it.
+///
+/// The assertion is on the VICTIM, not on the exit status. The command already
+/// failed in the end either way — the gate caught it — so a status assertion
+/// passes whether or not the escape happened. What distinguishes the two is
+/// whether bytes outside the extraction root changed.
+#[test]
+fn a_symlinked_ledger_cannot_make_verification_write_outside_the_archive() {
+    let dir = TempDir::new().unwrap();
+
+    // A real sled database that has nothing to do with any backup.
+    let victim = dir.path().join("victim-ledger");
+    std::fs::create_dir_all(&victim).unwrap();
+    {
+        let store = SledStore::open(&victim).expect("fixture: could not create the victim");
+        store
+            .put(b"ledger:journal:victim", b"{}")
+            .expect("fixture: could not write to the victim");
+        store
+            .db()
+            .flush()
+            .expect("fixture: could not flush the victim");
+    }
+    let victim_before = tree_identity(&victim);
+    assert!(
+        !victim_before.is_empty(),
+        "fixture: the victim must hold files, or 'unchanged' proves nothing"
+    );
+
+    // A legitimate ledger-less backup, so `backup_metadata.json` carries a real
+    // checksum that the crafted tree below genuinely satisfies.
+    let data_dir = dir.path().join("data");
+    init_identity(&data_dir);
+    let honest = dir.path().join("honest.tar");
+    make_backup(&data_dir, &honest);
+
+    let stage = dir.path().join("stage");
+    std::fs::create_dir_all(&stage).unwrap();
+    tar::Archive::new(std::fs::File::open(&honest).unwrap())
+        .unpack(&stage)
+        .expect("fixture: could not extract the honest archive");
+
+    // The craft: the same payload, plus a symlink where the ledger belongs.
+    let crafted = dir.path().join("crafted.tar");
+    {
+        let mut builder = tar::Builder::new(std::fs::File::create(&crafted).unwrap());
+        builder.follow_symlinks(false);
+        for entry in walkdir::WalkDir::new(&stage)
+            .follow_links(false)
+            .sort_by_file_name()
+            .into_iter()
+            .filter_map(|e| e.ok())
+        {
+            if entry.file_type().is_file() {
+                let rel = entry.path().strip_prefix(&stage).unwrap();
+                builder
+                    .append_path_with_name(entry.path(), rel)
+                    .expect("fixture: could not append file");
+            }
+        }
+        let mut header = tar::Header::new_gnu();
+        header.set_entry_type(tar::EntryType::Symlink);
+        header.set_size(0);
+        header.set_mode(0o777);
+        header.set_cksum();
+        builder
+            .append_link(&mut header, "store/ledger", &victim)
+            .expect("fixture: could not append the symlink");
+        builder
+            .finish()
+            .expect("fixture: could not finish the archive");
+    }
+
+    let out = verify(&crafted, true);
+    let text = combined(&out);
+
+    // The property. Everything else here is scaffolding for it.
+    assert_eq!(
+        tree_identity(&victim),
+        victim_before,
+        "verifying a crafted archive must not touch a database outside it:\n{text}"
+    );
+
+    assert!(
+        !out.status.success(),
+        "and the crafted archive must not verify:\n{text}"
+    );
+    let flat = flattened(&text);
+    assert!(
+        flat.contains("symbolic link"),
+        "the refusal must name what was actually wrong with the archive, so an \
+         operator is not sent looking for a principal collision:\n{text}"
+    );
+    assert!(
+        flat.contains("nothing was opened"),
+        "and must say that no database was opened, which is the property that \
+         distinguishes this refusal from the gate catching it afterwards:\n{text}"
+    );
+}


### PR DESCRIPTION
Closes #2732.

## The defect, as an operator sees it

`sled::open` has no read-only mode and no fail-closed mode. Handed a `db` it cannot parse it does not fail — it allocates a fresh meta page and returns an **empty** database. The journal scan then honestly finds zero rows, and `verify-backup --verify-ledger`, faithfully reporting what the layer below handed it, certified a backup that held real journal rows:

```
[3/4] Verifying checksum...
  ✓ Checksum verified: 5ecb694d5e3e610d1a6e858a70861b0e892790fd04f8c5bddfab31738564d08d
[Extra] Verifying ledger integrity...
  Found 0 ledger entries
  ✓ Ledger empty (no entries)
═══════════════════════════════════════
✓ BACKUP VERIFICATION PASSED
═══════════════════════════════════════
Verified: archive integrity and the N2-A principal audit of the
restored tree. The ledger contains no entries, so no entry was
validated and no double-entry balance was computed.
```

That is captured from `main` at `f00c81a29`, from the test added here, against a backup whose ledger held a valid journal entry. Note the summary also credits the N2-A principal audit — over a database nothing ever read.

The archive checksum cannot catch this: it is computed over the data directory **at backup time**, so a ledger already damaged when the backup was taken checksums consistently and passes.

## Correction to the issue's reproduction recipe

#2732 says to corrupt the sled `conf`. **That no longer reproduces on `main`** — it fails closed through the N2-A gate's own open. The live triggers are damage to `db` itself, and both are covered here:

| damage | pre-fix result |
|---|---|
| `db` truncated to zero bytes | exit 0, `✓ Ledger empty`, `PASSED` |
| `db` overwritten in place with zeroes | exit 0, `✓ Ledger empty`, `PASSED` |
| `conf` garbage | exit 1 — already fails closed |
| `conf` truncated to zero | exit 0, `Found 2 ledger entries` — sled recovered the config from defaults and read the real rows |

**Two shapes, two branches.** A ledger opened only once carries no `snap.*`, and `sled::open` silently recovers damage into an empty database — the `was_recovered()` branch. A ledger that has been reopened (any restarted node) carries a snapshot, and the same damage makes `sled::open` return `Corruption` — the open-failed branch. Both refuse and neither prints `✓ Ledger empty`, and there is a test for each.

## The mechanism, and why the placement is the whole fix

`Db::was_recovered()` is `false` exactly when sled had to allocate `META_PID`/`COUNTER_PID` instead of recovering them. It is the library's own answer to the question being asked — not a reading of its human-oriented warning text, which has no stability guarantee.

**The signal is destroyed by being observed.** The allocation is persisted, so the second open of the same damaged directory legitimately recovers what the first one created. Measured on a truncated ledger:

```
open 1 → was_recovered = false, 0 rows
open 2 → was_recovered = true,  0 rows
open 3 → was_recovered = true,  0 rows
```

`enforce_n2a_gate` opens every sled root it discovers. So the check must run **before** it — and **after** `assert_backup_carried_a_ledger`, which stays a pure filesystem check so a `conf`-without-`db` directory still bails before anything performs a creating open (#2717). This is the same ordering hazard #2717 documented, one layer down.

A mutation moving the call after the gate was applied and **killed by both damage tests**, which fail with the original `✓ Ledger empty` / `PASSED` output. The ordering is load-bearing and the tests pin it.

## Scope held narrow

No backup format change. No store manifest. No row count in `backup_metadata.json`. No change to `SledStore` recovery semantics for the daemon. No widening to other stores in the restored tree. This is about what the *verifier* is entitled to claim.

The recovery-signal approach also covers **archives that already exist**, which a metadata row-count could not.

## Acceptance criteria

- [x] A corrupt/unreadable ledger cannot be reported as `✓ Ledger empty` followed by successful verification
- [x] A genuinely empty but readable ledger keeps its correct semantics (`a_genuinely_empty_readable_ledger_still_verifies`)
- [x] An absent ledger under `--verify-ledger` still fails closed (#2717 tests unchanged and passing)
- [x] Unparseable ledger rows still fail (unchanged and passing)
- [x] Bare `verify-backup` does not claim ledger verification it did not perform (unchanged and passing)
- [x] The tests discriminate against the pre-fix baseline — 2 fail on `main`, 0 after
- [x] Operator output says only what the evidence establishes: it declines to imply a row count **and declines to name a cause** — a never-durably-flushed ledger is byte-identical to a truncated one, so the message says the cause cannot be narrowed rather than asserting tampering
- [x] No change to daemon recovery behaviour

## Verification

- baseline (fix reverted, tests present): `19 passed; 3 failed` — exactly the three damage tests
- post-fix: `cargo test -p icnctl --test verify_backup_ledger_test` → `24 passed; 0 failed`
- ordering mutant (call moved after the gate): `19 passed; 2 failed` — mutant killed, with the original `✓ Ledger empty` / `PASSED` output restored
- `cargo test -p icnctl` → all 14 test binaries pass (one known sled flock flake in `coop_entity_backfill_test`, on `store/cooperative` which this change does not touch; green on re-run)
- `cargo fmt --all --check` clean; `cargo clippy --all-targets -p icnctl` clean

## Invariants

- **adversarial-by-default** — strengthened: a damaged artifact now fails closed instead of being certified
- **determinism** — unaffected; the check reads a library signal, no clock, no ordering dependence
- **canonical-encodings** — unaffected
- **no-panics** — no new panics; both failure paths are `bail!`/`Result`
- **kernel/app boundaries** — unaffected; the change is confined to the `icnctl` binary

## A containment regression this branch introduced, found in review

Moving an open in front of `enforce_n2a_gate` — which this change must do, or sled's recovery signal is already gone — stepped that open past the gate's symlink refusal. A crafted archive carrying `store/ledger` as a **symlink** to a sled database elsewhere on the machine passed every gate in front of it: `calculate_dir_checksum` walks with `follow_links(false)` and hashes only `is_file()` entries, so the symlink is skipped and the checksum matches; `.exists()`/`.is_file()` follow it and find a complete `conf`/`db` pair; `sled::open` follows it too, and writes.

Reproduced, measured on the victim rather than on the exit status — the gate still refused afterwards, so the verdict was never wrong; the damage was the write:

| | victim database |
|---|---|
| with the new open | `db` rewritten, `snap.*` created |
| with the new open removed | byte-identical |

Fixed in `8fd887792` with a no-follow `symlink_metadata` containment check on every component from the extraction root down, placed above every symlink-following check.

**That fix was itself incomplete**, and a second review pass caught it: an archive can keep `store/ledger` a genuinely local directory and link its *children* instead. Reproduced the same way — the victim's `db` rewritten through a symlinked `conf`/`db` — and fixed in `facf1f966` by walking the whole ledger subtree no-follow. Deliberately not a list of marker names: sled decides which files under its directory to open, so enumerating them would be a denylist over another library's implementation detail.

Both placements are covered and the child case discriminates — removing the subtree walk fails it while the other 23 tests pass.

**Moving a check earlier also moves it past whatever used to protect it.** That is the general lesson and it is recorded in the code.

## What this change does NOT establish

`was_recovered()` answers whether sled RECOVERED the database or REPLACED it. It is not a whole-database integrity check, and the wording no longer implies otherwise: it cannot establish that every row a backup once held is still readable. Deciding that needs a count recorded at backup time and cross-checked here — the backup-format change #2732 deliberately does not make.

A review finding proposed that `was_recovered() == true` can coexist with silently lost rows. **It does, and it is now filed as #2746.** My first fourteen damage shapes zero-filled bytes *in place* and found nothing; the shape that reproduces is **truncating** the file to a partial length, which I had not tried. 100 rows, `db` 2,404,107 bytes: truncated to 80% → `was_recovered() == true`, scan returns 80 rows without error, and the command prints `Found 80 ledger entries` / `✓ BACKUP VERIFICATION PASSED` for a backup that held 100.

Not fixed here, deliberately:

- it is a **different false conclusion** — *incomplete reported as complete*, where sled genuinely recovered what survived and `was_recovered()` is `true`, versus #2732's *unreadable reported as empty*, where sled replaced the database and it is `false`;
- it is **pre-existing and unaffected by this PR** — with `assert_ledger_recovered_as_written` removed the output is byte-identical, because this check never fires there;
- closing it needs **backup-time evidence**: nothing in a damaged archive records how many rows it should hold, and every artifact-only candidate fails (the flag is true by construction, a fallible full scan completes without error, `db` length has no reference, and the checksum is computed over the damage). That is the `backup_metadata.json` row count #2732's non-goals park.

## Review

FULL review of `79488d7e9`: 0 BLOCKER, 4 FOLLOW_UP — all applied in `62d26a532`. DELTA review of those: 0 BLOCKER, 3 FOLLOW_UP — all applied in `e4b5ce2fd`, including that the sibling refusal still asserted the cause just removed from its twin. Three P1 findings from automated review addressed across `8fd887792` and `facf1f966` — two real containment escapes this branch introduced, and one bounded claim narrowed. All threads answered and resolved.

## Follow-up not taken here

The failure message names the *temporary extraction* path rather than the archive, matching the existing sibling messages from #2717. Worth fixing for all of them together rather than diverging one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
