### PR TITLE
fix(ci): stop one security gate failure from skipping the others (#2579)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -599,17 +599,50 @@ jobs:
           cargo install cargo-audit --locked
           cargo install cargo-deny --locked
 
+      # Each gate runs independently and reports its own outcome. Before this,
+      # `cargo audit` exiting non-zero ended the job, so neither cargo-deny gate
+      # ran — an advisory failure silently took the licenses gate with it.
+      # continue-on-error keeps a step from ending the job; the aggregation step
+      # below is what actually fails.
       - name: Run cargo-audit
+        id: audit
+        continue-on-error: true
         run: cargo audit
         working-directory: ./icn
 
       - name: Run cargo-deny advisories check
+        id: deny_advisories
+        continue-on-error: true
         run: cargo deny check advisories
         working-directory: ./icn
 
       - name: Run cargo-deny licenses check
+        id: deny_licenses
+        continue-on-error: true
         run: cargo deny check licenses
         working-directory: ./icn
+
+      # The real gate. Runs even when an earlier step failed, so a single run
+      # reports every security result rather than only the first failure.
+      - name: Security gate result
+        if: always()
+        env:
+          AUDIT: ${{ steps.audit.outcome }}
+          DENY_ADVISORIES: ${{ steps.deny_advisories.outcome }}
+          DENY_LICENSES: ${{ steps.deny_licenses.outcome }}
+        run: |
+          echo "cargo audit ..................... ${AUDIT}"
+          echo "cargo deny check advisories ..... ${DENY_ADVISORIES}"
+          echo "cargo deny check licenses ....... ${DENY_LICENSES}"
+          failed=0
+          for result in "${AUDIT}" "${DENY_ADVISORIES}" "${DENY_LICENSES}"; do
+            [ "${result}" = "success" ] || failed=1
+          done
+          if [ "${failed}" -ne 0 ]; then
+            echo "::error::One or more security gates failed. Every gate above ran independently; fix each non-success result."
+            exit 1
+          fi
+          echo "All security gates passed."
 
   build:
     name: Build Release
@@ -681,9 +714,15 @@ jobs:
       # incl. docs-only — examples/ are not covered by tsc (rootDir: src). Needs
       # only python3 (preinstalled). See sdk/typescript/check_sdk_doc_terms.py and
       # docs/adr/ADR-0006.
+      #
+      # Independent of the build/typecheck/test chain below: a vocabulary nit in
+      # an example must not skip `npm run build`, `typecheck:examples` and
+      # `npm test` on a required check. continue-on-error records the outcome
+      # without ending the job; the gate at the end of this job is what fails.
       - name: SDK docs use canonical ICN ledger primitives (no pay/balance/escrow as current)
+        id: sdk_doc_terms
+        continue-on-error: true
         run: python3 check_sdk_doc_terms.py --sdk-root .
-        continue-on-error: false
 
       - name: Free disk space
         if: needs.changes.outputs.docs_only != 'true' || needs.changes.outputs.has_rust == 'true'
@@ -717,6 +756,20 @@ jobs:
         if: needs.changes.outputs.docs_only != 'true' || needs.changes.outputs.has_rust == 'true'
         # All SDK tests use mockFetch — no gateway required. Gate is blocking.
         run: npm test
+
+      # Fails the job on a docs-vocabulary violation. Runs with always() so the
+      # vocabulary result is reported even when the build/test chain above has
+      # already failed — one run, both signals.
+      - name: SDK gate result
+        if: always()
+        env:
+          DOC_TERMS: ${{ steps.sdk_doc_terms.outcome }}
+        run: |
+          echo "SDK docs vocabulary ..... ${DOC_TERMS}"
+          if [ "${DOC_TERMS}" != "success" ]; then
+            echo "::error::SDK docs/examples use non-canonical ledger vocabulary. See sdk/typescript/check_sdk_doc_terms.py and docs/adr/ADR-0006."
+            exit 1
+          fi
 
   web-ui:
     name: Web UI

--- a/.github/workflows/security-audit.yml
+++ b/.github/workflows/security-audit.yml
@@ -16,6 +16,7 @@ jobs:
   security-audit:
     name: Security Audit
     runs-on: ubuntu-latest
+    timeout-minutes: 45
     # Job-level elevation: the "Create issue on failure" step (github-script
     # → issues.create / createComment) needs issues:write. Kept here, not at
     # workflow level, so the top-level contents:read default stays minimal.
@@ -37,11 +38,20 @@ jobs:
           cargo install cargo-deny --locked
           cargo install cargo-outdated --locked
 
+      # Each gate runs independently and reports its own outcome. Before this,
+      # `cargo audit` exiting non-zero ended the job, so `cargo deny check`
+      # never ran at all — the deny gates were silently skipped for every week
+      # the audit was red (2026-08-17 onward). continue-on-error keeps the step
+      # from ending the job; the aggregation step below is what actually fails.
       - name: Run cargo-audit
+        id: audit
+        continue-on-error: true
         run: cargo audit
         working-directory: ./icn
 
       - name: Run cargo-deny full check
+        id: deny
+        continue-on-error: true
         run: cargo deny check
         working-directory: ./icn
 
@@ -49,6 +59,27 @@ jobs:
         run: cargo outdated --workspace --depth 1
         working-directory: ./icn
         continue-on-error: true  # Informational only
+
+      # The real gate. Runs even when an earlier step failed, so a single run
+      # reports the full set of security results rather than only the first
+      # failure. Any non-success outcome fails the job.
+      - name: Security gate result
+        if: always()
+        env:
+          AUDIT: ${{ steps.audit.outcome }}
+          DENY: ${{ steps.deny.outcome }}
+        run: |
+          echo "cargo audit ......... ${AUDIT}"
+          echo "cargo deny check .... ${DENY}"
+          failed=0
+          for result in "${AUDIT}" "${DENY}"; do
+            [ "${result}" = "success" ] || failed=1
+          done
+          if [ "${failed}" -ne 0 ]; then
+            echo "::error::One or more security gates failed. Every gate above ran independently; fix each non-success result."
+            exit 1
+          fi
+          echo "All security gates passed."
 
       - name: Create issue on failure
         if: failure()


### PR DESCRIPTION
## Delivery

- **Delivery lane**: FAST (CI configuration only; no product code)
- **Acceptance contract**: no security or vocabulary gate can be silently skipped because an independent gate ahead of it failed. Every gate reports its own outcome in a single run, and a non-success outcome still fails the job.
- **Explicit non-goals**: does not fix the advisories themselves (tracked separately), does not change what any gate checks, does not touch `deny.toml`, does not add or remove a required check.

## Problem

`cargo audit` and the `cargo deny` gates were consecutive hard-failing steps in one job. A non-zero `cargo audit` ended the job, so **`cargo deny check` never ran**.

This is not hypothetical. Weekly Security Audit run history:

| Run | Date | Result |
|---|---|---|
| 34117812997 | 2026-09-07 | failure |
| 33393583034 | 2026-08-31 | failure |
| 32699280621 | 2026-08-24 | failure |
| 32003388976 | 2026-08-17 | failure |
| 31366688260 | 2026-08-10 | success |

Five consecutive weeks red, on two advisories:

- `RUSTSEC-2026-0258` — h2 unbounded empty DATA frames
- `RUSTSEC-2026-0269` — wasmtime filesystem sandbox escape via trailing slashes, **CVSS 8.8 high**

For that entire window the deny gates (bans, licenses, sources) were **not run** — neither passing nor failing. A licence regression or a banned transitive crate introduced in those five weeks would have reached `main` with no signal at all. The audit failure did not merely report a problem; it disabled the adjacent controls.

The same masking existed on the **required** `TypeScript SDK` check: `check_sdk_doc_terms.py` hard-failed ahead of `npm run build`, `npm run typecheck:examples` and `npm test`. A vocabulary nit in an example file skipped the build **and the entire SDK test suite**, on a check that gates merge.

## Change

Each independent gate gets an `id:` and `continue-on-error: true`, and a final aggregation step with `if: always()` fails the job when any recorded outcome is not `success`.

- `.github/workflows/security-audit.yml` — `cargo audit` + `cargo deny check` now independent; job bounded at `timeout-minutes: 45` (it previously inherited the 6h default while running three `cargo install` builds).
- `.github/workflows/ci.yml` (`security` job) — `cargo audit` + `cargo deny check advisories` + `cargo deny check licenses` now independent.
- `.github/workflows/ci.yml` (`sdk` job) — the docs-vocabulary check is now independent of the build/typecheck/test chain and gated at the end of the job. The build chain itself stays sequential, because those steps genuinely depend on each other.

## The trap this avoids

`continue-on-error: true` sets a step's `conclusion` to `success` while leaving `outcome` at the true result. **The aggregation therefore reads `outcome`.** Reading `conclusion` would make the gate pass unconditionally — silently disarming the very check being repaired, which is a strictly worse failure than the one being fixed.

Aggregation truth table, executed under `bash` (GitHub Actions `run:` default):

| audit | deny/advisories | deny/licenses | gate |
|---|---|---|---|
| success | success | success | **PASS** |
| failure | success | success | FAIL |
| success | failure | success | FAIL |
| success | success | failure | FAIL |
| failure | failure | failure | FAIL |
| success | success | skipped | FAIL |
| success | success | cancelled | FAIL |

`skipped` and `cancelled` fail closed.

## Verification

- Both workflow files parse (`yaml.safe_load`).
- Aggregation logic executed against the seven-case truth table above; passes only on all-success.
- No required check is added, removed, or renamed — branch protection contexts are untouched.

## Invariants

- **adversarial-by-default** — strengthened: a gate can no longer be disabled as a side effect of an unrelated failure.
- **determinism** — unchanged; no gate's inputs or checks are modified.
- kernel/app boundaries, canonical encodings, no-panics — not touched (CI configuration only).

Refs #2579 — **does not close it.**

#2579's specific ask is the disposition of `RUSTSEC-2026-0253` (`lru`, unsound
`LruCache::pop()`), which was failing `cargo deny check advisories` while
`cargo audit` still *passed*. That advisory is untouched here, so this PR must
not auto-close the issue.

What this PR does contribute to #2579 is its third listed option — "splitting
advisories into an informational job so a red advisory is visible without being
indistinguishable from a broken gate" — and it repairs a failure mode #2579 did
not anticipate: since it was filed the situation **inverted**. `cargo audit`
now fails first (h2, wasmtime), which means `cargo deny check advisories` — the
gate #2579 is actually about — stopped running at all. So #2579's own finding
has been invisible for weeks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

