### PR TITLE
fix(ci): require a trusted author before a comment can start a secret-bearing job

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -12,12 +12,26 @@ on:
 
 jobs:
   claude:
+    # Each trigger requires BOTH the @claude mention and a trusted author. These
+    # events fire for any account that can comment on or open an issue, and this
+    # job is handed CLAUDE_CODE_OAUTH_TOKEN and id-token: write. The association
+    # is supplied by GitHub from repository membership; nothing in the comment
+    # body can influence it. Same guard as opencode.yml.
     if: |
-      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
-      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
-      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
-      (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
+      (github.event_name == 'issue_comment' &&
+        contains(github.event.comment.body, '@claude') &&
+        contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association)) ||
+      (github.event_name == 'pull_request_review_comment' &&
+        contains(github.event.comment.body, '@claude') &&
+        contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association)) ||
+      (github.event_name == 'pull_request_review' &&
+        contains(github.event.review.body, '@claude') &&
+        contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.review.author_association)) ||
+      (github.event_name == 'issues' &&
+        (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')) &&
+        contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.issue.author_association))
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     permissions:
       contents: read
       pull-requests: read

--- a/.github/workflows/opencode.yml
+++ b/.github/workflows/opencode.yml
@@ -8,12 +8,24 @@ on:
 
 jobs:
   opencode:
+    # Two independent conditions, both required.
+    #
+    # 1. The comment asks for opencode.
+    # 2. The commenter is trusted. `issue_comment` fires for ANY account that can
+    #    comment, including a drive-by on a public issue. Without this clause an
+    #    arbitrary commenter starts a job that is handed OPENAI_API_KEY and
+    #    id-token: write. author_association is evaluated by GitHub from repo
+    #    membership, not from anything the comment body can influence.
     if: |
-      contains(github.event.comment.body, ' /oc') ||
-      startsWith(github.event.comment.body, '/oc') ||
-      contains(github.event.comment.body, ' /opencode') ||
-      startsWith(github.event.comment.body, '/opencode')
+      (
+        contains(github.event.comment.body, ' /oc') ||
+        startsWith(github.event.comment.body, '/oc') ||
+        contains(github.event.comment.body, ' /opencode') ||
+        startsWith(github.event.comment.body, '/opencode')
+      ) &&
+      contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association)
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     permissions:
       id-token: write
       contents: read
@@ -25,8 +37,12 @@ jobs:
         with:
           persist-credentials: false
 
+      # Pinned to the commit the mutable `latest` tag pointed at on 2026-09-10.
+      # A tag can be repointed by the upstream owner at any time, so `@latest`
+      # let third-party code change under a job holding OPENAI_API_KEY without
+      # any change landing in this repository. Bump deliberately.
       - name: Run opencode
-        uses: anomalyco/opencode/github@latest
+        uses: anomalyco/opencode/github@2c14fc5586fe0b88e5c04732d2e846769cc35671 # latest as of 2026-09-10
         env:
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
         with:


### PR DESCRIPTION
## Delivery

- **Delivery lane**: FAST (CI configuration only; no product code)
- **Acceptance contract**: a comment from an account outside the repository cannot start a job that holds repository secrets, and the third-party action handling a secret is referenced by an immutable commit.
- **Explicit non-goals**: does not change what either bot does once invoked, does not rotate any secret, does not alter `permissions:` scopes, does not remove either integration.

> **Flagged explicitly per the auth-path rule.** This PR *closes* a path reachable by an untrusted caller. It does not open one. Reviewers should confirm the `if:` clauses below can only ever narrow who triggers these jobs.

## Problem

Both workflows trigger on `issue_comment`, which fires for **any** account that can comment — including a drive-by comment on a public issue. Neither job checked the commenter's relationship to the repository.

| Workflow | Trigger reachable by | Secrets in scope |
|---|---|---|
| `opencode.yml` | any commenter | `OPENAI_API_KEY`, `id-token: write` |
| `claude.yml` | any commenter / issue opener | `CLAUDE_CODE_OAUTH_TOKEN`, `id-token: write`, `actions: read` |

`opencode.yml` compounded this with a second, independent problem:

```yaml
uses: anomalyco/opencode/github@latest
```

`latest` here is a **mutable tag**, not a release — verified via
`gh api repos/anomalyco/opencode/git/ref/tags/latest`. The upstream owner can repoint it at any commit at any time. Third-party code executing against `OPENAI_API_KEY` could therefore change with no commit landing in this repository and no review here.

## Change

**1. Trusted-author requirement on both workflows.**

```yaml
contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association)
```

`author_association` is computed by GitHub from repository membership. It is **not** attacker-controlled: nothing in the comment body — the same input that triggers the job — can influence it. `claude.yml` applies the equivalent check per trigger, reading `github.event.review.author_association` for `pull_request_review` and `github.event.issue.author_association` for `issues`.

Behaviour for maintainers is unchanged. `CONTRIBUTOR`, `FIRST_TIME_CONTRIBUTOR` and `NONE` no longer trigger either bot.

**2. Commit pin.** `anomalyco/opencode/github@2c14fc5586fe0b88e5c04732d2e846769cc35671` — the exact commit `latest` resolved to on 2026-09-10, so current behaviour is preserved while future changes must be deliberate.

**3. `timeout-minutes: 30`** on both jobs; each previously inherited the 6h default.

## Verification

- Both files parse (`yaml.safe_load`).
- Pinned SHA confirmed to be the current target of the `latest` tag, so this is a no-op for behaviour today.
- Only secret *names* appear in the diff; no secret value is read, printed, or moved.
- `permissions:` blocks are untouched — this PR narrows *who can trigger*, not what the job may do.

## Invariants

- **adversarial-by-default** — strengthened on the CI surface: the trigger is now authenticated by repository membership rather than open to any commenter.
- determinism, canonical encodings, no-panics, kernel/app boundaries — not touched (CI configuration only).

## Follow-up worth a maintainer decision

`claude.yml` grants `id-token: write`. Neither integration obviously needs OIDC token minting; if it does not, dropping it is a further reduction. Not changed here because it is behavioural, not a clear defect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
