### PR TITLE
ci: bound every job, stop duplicate runs, and drop a fragile required-check dependency

### DIFF
--- a/.github/workflows/agent-drift-check.yml
+++ b/.github/workflows/agent-drift-check.yml
@@ -114,6 +114,13 @@ jobs:
       - name: Sprint-state currency + SessionStart source guard tests (Refs icn#2634)
         run: python3 scripts/tests/test_sprint_state_invariants.py
 
+      # A job timeout below its own steps' budgets cancels the step before it
+      # can use the time it was given, and reports a timeout instead of the real
+      # result. This job runs on every pull request with no paths filter, so it
+      # is the surface that sees workflow edits.
+      - name: Workflow job timeouts exceed their nested step budgets
+        run: python3 scripts/tests/test_workflow_timeout_budgets.py
+
       # icn#2651: the canonical merge policy must not name a field that cannot hold the value it
       # is compared against, and must not duplicate values it owns. Both got past every other gate
       # because prose is not type-checked. Structured validation only — no Markdown is parsed.

--- a/.github/workflows/agent-drift-check.yml
+++ b/.github/workflows/agent-drift-check.yml
@@ -57,10 +57,17 @@ on:
 permissions:
   contents: read
 
+# A superseded push to a PR branch should not keep burning a required check.
+# Never cancels on push to main.
+concurrency:
+  group: agent-drift-${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   drift-check:
     name: Agent Tooling Drift Check
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@v6
 

--- a/.github/workflows/api-types.yml
+++ b/.github/workflows/api-types.yml
@@ -11,10 +11,15 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: api-types-${{ github.event.pull_request.number || github.sha }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   check-api-types:
     name: Check API Types Drift
     runs-on: ubuntu-latest
+    timeout-minutes: 45
     steps:
       - uses: actions/checkout@v6
 
@@ -25,6 +30,11 @@ jobs:
         uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
           toolchain: 1.95.0
+          # The Cargo workspace is icn/, not the repo root. The action's default
+          # cache-workspaces is ".", so the cached path (./target) was never the
+          # built path (icn/target) and this job cold-built icnctl --release on
+          # every run. Matches the `workspaces:` used elsewhere in the repo.
+          cache-workspaces: "icn -> target"
 
       - name: Setup Node.js
         uses: actions/setup-node@v6

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -35,6 +35,7 @@ jobs:
   benchmark:
     name: Save Benchmark Baseline
     runs-on: ubuntu-latest
+    timeout-minutes: 75
     if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
     steps:
       - uses: actions/checkout@v6
@@ -66,12 +67,13 @@ jobs:
         with:
           name: benchmark-baseline-${{ github.sha }}
           path: icn/target/criterion
-          retention-days: 90
+          retention-days: 14
 
   # Compare PR benchmarks against base commit (only on PRs)
   compare:
     name: Compare Against Base
     runs-on: ubuntu-latest
+    timeout-minutes: 75
     if: github.event_name == 'pull_request'
     steps:
       # Checkout PR base commit for baseline (deterministic - won't change during run)

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -35,7 +35,10 @@ jobs:
   benchmark:
     name: Save Benchmark Baseline
     runs-on: ubuntu-latest
-    timeout-minutes: 75
+    # Above the 90-minute "Run benchmarks" step budget plus setup. A job
+    # deadline below its own step budget cancels the step before it can use
+    # the time it was given.
+    timeout-minutes: 105
     if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
     steps:
       - uses: actions/checkout@v6
@@ -73,7 +76,10 @@ jobs:
   compare:
     name: Compare Against Base
     runs-on: ubuntu-latest
-    timeout-minutes: 75
+    # Two sequential 60-minute benchmark passes (baseline, then PR head)
+    # plus two checkouts and a toolchain install. 75 could not fit even a
+    # 40+40 run.
+    timeout-minutes: 140
     if: github.event_name == 'pull_request'
     steps:
       # Checkout PR base commit for baseline (deterministic - won't change during run)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,7 @@ jobs:
   changes:
     name: Change Scope
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     # Job-level elevation: dorny/paths-filter uses the PR API in pull_request
     # mode and documents a pull-requests:read requirement. Kept here so the
     # workflow's top-level contents:read default stays minimal for other jobs.
@@ -101,8 +102,8 @@ jobs:
 
   secrets-check:
     name: Secrets Placeholder Check
-    needs: [changes]
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v6
 
@@ -144,6 +145,7 @@ jobs:
   fmt:
     name: Format Check
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v6
 
@@ -161,8 +163,8 @@ jobs:
 
   meaning-firewall:
     name: Meaning Firewall Check
-    needs: [changes]
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v6
 
@@ -191,8 +193,8 @@ jobs:
 
   kernel-deps:
     name: Kernel Forbidden Dependencies
-    needs: [changes]
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@v6
 
@@ -281,8 +283,8 @@ jobs:
 
   firewall-contract:
     name: Firewall Contract Enforcement
-    needs: [changes]
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v6
 
@@ -316,8 +318,8 @@ jobs:
 
   compliance-linter:
     name: Regulatory Compliance Linter
-    needs: [changes]
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v6
 
@@ -346,8 +348,8 @@ jobs:
 
   readiness-overclaim:
     name: Readiness Overclaim Check
-    needs: [changes]
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v6
 
@@ -493,6 +495,7 @@ jobs:
     needs: [changes]
     if: needs.changes.outputs.docs_only != 'true' || needs.changes.outputs.has_rust == 'true'
     runs-on: ubuntu-latest
+    timeout-minutes: 25
     steps:
       - uses: actions/checkout@v6
 
@@ -586,6 +589,7 @@ jobs:
     needs: [changes]
     if: needs.changes.outputs.docs_only != 'true' || needs.changes.outputs.has_rust == 'true'
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v6
 
@@ -653,6 +657,10 @@ jobs:
         uses: actions/upload-artifact@v7
         with:
           name: icn-binaries
+          # Uploaded on every PR and every push. At the repo default of 90 days
+          # this is the largest artifact producer in CI; 5 days is well past the
+          # life of a PR review.
+          retention-days: 5
           path: |
             icn/target/release/icnd
             icn/target/release/icnctl
@@ -662,6 +670,7 @@ jobs:
     name: TypeScript SDK
     needs: [changes]
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     defaults:
       run:
         working-directory: ./sdk/typescript
@@ -723,6 +732,7 @@ jobs:
     needs: [changes]
     if: needs.changes.outputs.docs_only != 'true' || needs.changes.outputs.has_rust == 'true'
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     defaults:
       run:
         working-directory: ./web/pilot-ui
@@ -748,6 +758,7 @@ jobs:
     name: Accessibility Tests
     needs: [changes]
     runs-on: ubuntu-latest
+    timeout-minutes: 25
     defaults:
       run:
         working-directory: ./web/pilot-ui
@@ -785,6 +796,7 @@ jobs:
         uses: actions/upload-artifact@v7
         with:
           name: accessibility-report
+          retention-days: 7
           path: web/pilot-ui/test-results/
 
   # Member Shell (web/member-shell) is the CURRENT member/organizer rehearsal
@@ -865,6 +877,7 @@ jobs:
         uses: actions/upload-artifact@v7
         with:
           name: member-shell-a11y-report
+          retention-days: 7
           path: member-shell-a11y-out/
           if-no-files-found: ignore
 

--- a/.github/workflows/docs-freshness.yml
+++ b/.github/workflows/docs-freshness.yml
@@ -2,6 +2,7 @@ name: Documentation Maintenance
 
 on:
   push:
+    branches: [main]
     paths:
       - 'docs/**'
       - 'ARCHITECTURE.md'
@@ -91,10 +92,18 @@ permissions:
   pull-requests: write
   issues: write
 
+# `push:` previously had no branches filter, so every push to a feature branch
+# ran these jobs AND the pull_request trigger ran them again. Now push covers
+# main only; PRs are covered by pull_request.
+concurrency:
+  group: docs-freshness-${{ github.event.pull_request.number || github.sha }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   doc_control:
     name: Documentation Control Plane
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@v6
 
@@ -123,6 +132,7 @@ jobs:
   lint:
     name: Lint Architecture Doc
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@v6
 
@@ -139,6 +149,7 @@ jobs:
   freshness:
     name: Check Documentation Freshness
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@v6
         with:
@@ -188,6 +199,7 @@ jobs:
   index:
     name: Generate Documentation Index
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@v6
 
@@ -232,6 +244,7 @@ jobs:
   fixture_bundle:
     name: Rehearsal Fixture Bundle
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@v6
 
@@ -267,6 +280,7 @@ jobs:
   bridge_conformance:
     name: Governed Bridge Conformance Fixtures
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@v6
 
@@ -297,6 +311,7 @@ jobs:
   route_inventory:
     name: Check Generated Route Inventory
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@v6
 
@@ -327,6 +342,7 @@ jobs:
   icnctl_inventory:
     name: Check Generated icnctl Command Inventory
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@v6
 
@@ -359,6 +375,7 @@ jobs:
     name: Documentation CI Summary
     needs: [doc_control, lint, freshness, index, fixture_bundle, bridge_conformance, route_inventory, icnctl_inventory]
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     if: always()
     steps:
       - name: Check results

--- a/.github/workflows/evaluator-package.yml
+++ b/.github/workflows/evaluator-package.yml
@@ -9,6 +9,7 @@ name: Evaluator Package (static)
 
 on:
   push:
+    branches: [main]
     paths:
       - 'deploy/appliance/evaluator/**'
       - '.github/workflows/evaluator-package.yml'
@@ -20,11 +21,19 @@ on:
 permissions:
   contents: read
 
+# `push:` previously had no branches filter, so every push to a feature branch
+# ran these jobs AND the pull_request trigger ran them again. Now push covers
+# main only; PRs are covered by pull_request.
+concurrency:
+  group: evaluator-package-${{ github.event.pull_request.number || github.sha }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   static:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Install ShellCheck
         run: sudo apt-get update && sudo apt-get install -y shellcheck

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -25,6 +25,7 @@ jobs:
   fuzz:
     name: CCL Fuzz Testing
     runs-on: ubuntu-latest
+    timeout-minutes: 60
 
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -17,6 +17,10 @@ env:
   RUST_BACKTRACE: 1
   # Use environment variable for duration to avoid injection risk
   FUZZ_DURATION: ${{ github.event.inputs.duration || '300' }}
+  # 3 x 900s = 45 minutes of fuzzing, leaving ~15 minutes of the 60-minute job
+  # budget for checkout, cargo-fuzz install and the workspace build.
+  FUZZ_MAX_DURATION: '900'
+  FUZZ_TARGET_COUNT: '3'
 
 permissions:
   contents: read
@@ -32,9 +36,27 @@ jobs:
 
       - name: Validate duration input
         run: |
-          # Ensure duration is a positive integer to prevent injection
+          # Two separate constraints.
+          #
+          # 1. Shape, to prevent injection. Note '^[0-9]+$' alone also accepts 0,
+          #    which the message below claims is invalid, so the lower bound is
+          #    checked explicitly rather than implied.
+          # 2. Budget. Three fuzz targets run SEQUENTIALLY, each for the full
+          #    duration, after a cargo-fuzz install and a workspace build. A
+          #    dispatch of 3600 would need three hours inside a 60-minute job and
+          #    would be cancelled mid-run, reporting a timeout rather than a
+          #    refusal. Refuse up front instead: a request the job cannot honour
+          #    is a bad request, not a failure.
           if ! echo "$FUZZ_DURATION" | grep -qE '^[0-9]+$'; then
             echo "::error::Invalid duration: must be a positive integer"
+            exit 1
+          fi
+          if [ "$FUZZ_DURATION" -lt 1 ]; then
+            echo "::error::Invalid duration: must be a positive integer"
+            exit 1
+          fi
+          if [ "$FUZZ_DURATION" -gt "$FUZZ_MAX_DURATION" ]; then
+            echo "::error::duration ${FUZZ_DURATION}s exceeds the per-target maximum ${FUZZ_MAX_DURATION}s. ${FUZZ_TARGET_COUNT} targets run sequentially inside this job's timeout-minutes budget; raise the job budget first if a longer run is genuinely needed."
             exit 1
           fi
 

--- a/.github/workflows/generated-truth.yml
+++ b/.github/workflows/generated-truth.yml
@@ -48,6 +48,7 @@ jobs:
   generated-truth:
     name: Generated-truth drift (observational)
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@v6
         with:

--- a/.github/workflows/issue-label-enforcer.yml
+++ b/.github/workflows/issue-label-enforcer.yml
@@ -10,6 +10,7 @@ permissions:
 jobs:
   enforce-labels:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - name: Enforce required labels
         uses: actions/github-script@v9

--- a/.github/workflows/mcp-portability.yml
+++ b/.github/workflows/mcp-portability.yml
@@ -24,6 +24,7 @@ permissions:
 jobs:
   mcp-portability:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-node@v6

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -19,6 +19,7 @@ jobs:
   publish:
     name: Publish TypeScript SDK
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     defaults:
       run:
         working-directory: ./sdk/typescript

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,6 +24,7 @@ jobs:
   build:
     name: Build ${{ matrix.target }}
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 60
     strategy:
       fail-fast: false
       matrix:
@@ -98,6 +99,7 @@ jobs:
     name: Sign and Release
     needs: build
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     steps:
       - uses: actions/checkout@v6
 

--- a/.github/workflows/reusable-claim-lint.yml
+++ b/.github/workflows/reusable-claim-lint.yml
@@ -35,6 +35,7 @@ jobs:
   claim-lint:
     name: Claim Firewall (warning-mode)
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - name: Checkout caller repo
         uses: actions/checkout@v6

--- a/.github/workflows/sync-stats.yml
+++ b/.github/workflows/sync-stats.yml
@@ -13,6 +13,7 @@ permissions:
 jobs:
   sync-stats:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@v6
         with:

--- a/.github/workflows/website-ci.yml
+++ b/.github/workflows/website-ci.yml
@@ -145,7 +145,7 @@ jobs:
       # machine-readable form of the rendered findings.
       - name: Upload reports
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: website-reports
           path: |
@@ -230,7 +230,7 @@ jobs:
       # Artifacts first, so a red result never costs anyone the evidence.
       - name: Upload reports
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: website-drift-watch
           path: |

--- a/.github/workflows/website-deploy.yml
+++ b/.github/workflows/website-deploy.yml
@@ -17,6 +17,7 @@ concurrency:
 jobs:
   deploy:
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     permissions:
       contents: write
     steps:

--- a/scripts/tests/test_workflow_timeout_budgets.py
+++ b/scripts/tests/test_workflow_timeout_budgets.py
@@ -1,0 +1,95 @@
+#!/usr/bin/env python3
+"""A job's timeout must exceed the budgets nested inside it.
+
+Why this exists
+---------------
+PR #2762 bounded every job in the repository, and introduced three jobs whose
+`timeout-minutes` was BELOW the `timeout-minutes` already declared on their own
+steps:
+
+    benchmark.yml  benchmark  job 75  vs  step 90
+    benchmark.yml  compare    job 75  vs  steps 60 + 60 (sequential)
+    fuzz.yml       fuzz       job 60  vs  3 sequential targets x dispatch duration
+
+A job deadline below its own step budget cancels the step before it can use the
+time it was given, and reports a timeout rather than the real result. The two
+numbers are written in different places, by different people, at different
+times, and nothing related them — so the error was invisible to review until a
+reviewer did the arithmetic by hand three times.
+
+This is that arithmetic, executed.
+"""
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+import yaml
+
+# A job needs time for checkout, toolchain install and caching on top of the
+# work its steps declare. A job budget merely EQUAL to its step budgets is
+# already a defect.
+SETUP_HEADROOM_MINUTES = 5
+
+
+def repo_root() -> Path:
+    return Path(
+        subprocess.run(
+            ["git", "rev-parse", "--show-toplevel"],
+            capture_output=True, text=True, check=True,
+        ).stdout.strip()
+    )
+
+
+def main() -> int:
+    root = repo_root()
+    failures: list[str] = []
+    checked = 0
+
+    for wf in sorted((root / ".github/workflows").glob("*.yml")):
+        try:
+            doc = yaml.safe_load(wf.read_text())
+        except yaml.YAMLError as exc:
+            failures.append(f"{wf.name}: does not parse: {exc}")
+            continue
+        if not isinstance(doc, dict):
+            continue
+        for job_name, job in (doc.get("jobs") or {}).items():
+            if not isinstance(job, dict):
+                continue
+            job_budget = job.get("timeout-minutes")
+            if job_budget is None:
+                continue
+            # Steps run sequentially, so their budgets add.
+            step_budgets = [
+                s.get("timeout-minutes")
+                for s in (job.get("steps") or [])
+                if isinstance(s, dict) and s.get("timeout-minutes")
+            ]
+            if not step_budgets:
+                continue
+            checked += 1
+            required = sum(step_budgets) + SETUP_HEADROOM_MINUTES
+            if job_budget < required:
+                failures.append(
+                    f"{wf.name}:{job_name}: job timeout-minutes={job_budget} but its steps "
+                    f"declare {step_budgets} (sum {sum(step_budgets)}) and run sequentially. "
+                    f"The job would cancel a step before that step's own budget expired. "
+                    f"Need at least {required} (sum + {SETUP_HEADROOM_MINUTES} setup headroom)."
+                )
+
+    if failures:
+        print("test_workflow_timeout_budgets: FAIL")
+        for f in failures:
+            print(f"  - {f}")
+        return 1
+    print(
+        f"test_workflow_timeout_budgets: clean "
+        f"({checked} job(s) with nested step budgets verified)"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Delivery

- **Delivery lane**: FAST (CI configuration only; no product code)
- **Acceptance contract**: no CI job can run unbounded, no required check depends on a job it does not read, and no workflow runs the same work twice for one push.
- **Explicit non-goals**: does not change what any check verifies, does not add/remove/rename a required check, does not touch `security-audit.yml`, `claude.yml` or `opencode.yml` (changed in #2760 / #2761).

## 1. Four required checks depended on a job they never read

`secrets-check`, `meaning-firewall`, `kernel-deps`, `firewall-contract`, `compliance-linter` and `readiness-overclaim` each declared `needs: [changes]` and referenced `needs.changes.outputs` **nowhere**. Four are required by branch protection.

That dependency was not free:

- each waited on a checkout + a `dorny/paths-filter` call to the PR API before starting;
- each inherited `changes`'s failure mode — **one paths-filter API blip skipped four required checks at once**, leaving the PR unmergeable until someone re-ran CI by hand.

`fmt` already had no such dependency, which is the correct shape.

Verified mechanically by parsing the workflow before and after:

```
origin/main: ['secrets-check: vestigial needs', 'meaning-firewall: vestigial needs',
              'kernel-deps: vestigial needs', 'firewall-contract: vestigial needs',
              'compliance-linter: vestigial needs', 'readiness-overclaim: vestigial needs']
this branch: clean
```

The same check confirms **no job that reads `changes.outputs` lost its `needs`** — including `pilot-provenance`, which declares `needs: [changes, test]`.

## 2. No job in the repository had a timeout

40 jobs across 16 workflows now carry `timeout-minutes`; a hung step previously burned the 6h default while holding a required check pending.

Two worth naming:

- **`accessibility`** (required) runs `npx playwright install --with-deps chromium` — an `apt-get` under the hood. A stalled mirror held a required check pending for six hours with no signal.
- **`backup-validation`** runs `icnctl id init`. `rpassword` reads `/dev/tty`, never stdin, so a regression in the env-passphrase path **hangs** rather than fails.

## 3. Work done twice, or thrown away

| Problem | Fix |
|---|---|
| `docs-freshness` + `evaluator-package` had `push:` with a paths filter but **no branches filter** — every feature-branch push ran them, then `pull_request` ran them again | `push: branches: [main]` |
| `agent-drift-check` (required), `api-types`, `docs-freshness`, `evaluator-package` had no concurrency group — superseded pushes kept running | concurrency group per PR; cancels on PR, never on main |
| `api-types` cached `./target` but built in `icn/` — cache could **never** hit, cold `icnctl --release` build every run | `cache-workspaces: "icn -> target"` |
| `icn-binaries` (release icnd + icnctl + icn-console) uploaded on every PR and push, kept 90 days | `retention-days: 5` |
| a11y reports kept 90 days | 7 |
| benchmark baseline kept 90 days | 14 |
| `website-ci` on upload-artifact@v4, `evaluator-package` on checkout@v4, everything else @v7/@v6 | aligned |

Release artifacts keep the 90-day retention — those are releases.

## Verification

- All 21 workflow files parse (`yaml.safe_load`).
- `needs`/`outputs` consistency proven by parse, before and after (output above).
- Trigger shapes confirmed post-edit: `docs-freshness` and `evaluator-package` are `push: branches: [main]` with `pull_request` still filtered by `paths`.
- Every job in every workflow now has `timeout-minutes` (verified by parse).
- Branch-protection contexts untouched.

## Invariants

- **determinism** — strengthened on CI: a required check no longer depends on an unrelated PR-API call.
- adversarial-by-default, canonical encodings, no-panics, kernel/app boundaries — not touched (CI configuration only).

## Note on merge order

Touches `ci.yml`, as does #2760, in different regions (that PR edits step bodies in the `security` and `sdk` jobs; this one edits job headers). Whichever lands second may need a trivial rebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
