### PR TITLE
ci(deps): cover every npm lockfile and group updates so the queue can drain

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,5 +1,22 @@
 # Dependabot Configuration
 # https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+#
+# ─── Two things this file has to get right ───────────────────────────────────
+#
+# 1. COVERAGE. Dependabot *security* updates run against every manifest it can
+#    find, whatever this file says. Dependabot *version* updates run only
+#    against the directories listed below. A lockfile that appears here only via
+#    a security alert is therefore a lockfile that never receives routine
+#    maintenance — it drifts until an advisory forces a jump. Every npm
+#    lockfile in the repository must have an entry here.
+#
+# 2. GROUPING. `main` is a strict-protected branch with no merge queue, so every
+#    merge marks every other open PR out-of-date. A queue of N ungrouped
+#    dependency PRs therefore costs N branch updates and N full CI runs, and in
+#    practice never drains — it just accumulates. Grouping is what keeps the
+#    queue drainable: production minor/patch updates arrive as ONE pull request
+#    per workspace. Majors are deliberately left ungrouped, because a major
+#    needs to be reviewed and verified on its own.
 
 version: 2
 updates:
@@ -20,7 +37,6 @@ updates:
     commit-message:
       prefix: "deps"
       include: "scope"
-    # Group minor and patch updates
     groups:
       tokio:
         patterns:
@@ -34,6 +50,16 @@ updates:
           - "*dalek"
           - "chacha*"
           - "pqcrypto*"
+      # Catch-all for everything not matched above. Without this, each
+      # remaining crate opened its own PR: axum, proptest, getrandom,
+      # futures-util, hyper, hyper-util and opentelemetry_sdk were seven
+      # separate pull requests, none of which ever merged.
+      cargo-minor-and-patch:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
       dev-dependencies:
         dependency-type: "development"
         update-types:
@@ -60,6 +86,11 @@ updates:
       - dependency-name: "typescript"
         update-types: ["version-update:semver-major"]
     groups:
+      production-dependencies:
+        dependency-type: "production"
+        update-types:
+          - "minor"
+          - "patch"
       dev-dependencies:
         dependency-type: "development"
         update-types:
@@ -84,6 +115,11 @@ updates:
         patterns:
           - "react-native*"
           - "@react-native*"
+      production-dependencies:
+        dependency-type: "production"
+        update-types:
+          - "minor"
+          - "patch"
       dev-dependencies:
         dependency-type: "development"
 
@@ -100,8 +136,117 @@ updates:
     commit-message:
       prefix: "deps(pilot-ui)"
     groups:
+      production-dependencies:
+        dependency-type: "production"
+        update-types:
+          - "minor"
+          - "patch"
       dev-dependencies:
         dependency-type: "development"
+        update-types:
+          - "minor"
+          - "patch"
+
+  # Public website. Previously absent: it received security PRs only, so the
+  # Astro toolchain drifted far enough that the outstanding advisory now needs a
+  # major upgrade rather than a patch.
+  - package-ecosystem: "npm"
+    directory: "/website"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+      - "website"
+    commit-message:
+      prefix: "deps(website)"
+    groups:
+      astro:
+        patterns:
+          - "astro"
+          - "@astrojs/*"
+      production-dependencies:
+        dependency-type: "production"
+        update-types:
+          - "minor"
+          - "patch"
+      dev-dependencies:
+        dependency-type: "development"
+        update-types:
+          - "minor"
+          - "patch"
+
+  # Agent-facing MCP server. Previously absent from version updates.
+  - package-ecosystem: "npm"
+    directory: "/ops/mcp"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+      - "ops"
+    commit-message:
+      prefix: "deps(mcp)"
+    groups:
+      production-dependencies:
+        dependency-type: "production"
+        update-types:
+          - "minor"
+          - "patch"
+      dev-dependencies:
+        dependency-type: "development"
+        update-types:
+          - "minor"
+          - "patch"
+
+  # Example apps. Both are Expo projects and both were absent from version
+  # updates. Grouped tightly and rate-limited: they are demonstrations, so they
+  # should receive routine maintenance without generating review load.
+  - package-ecosystem: "npm"
+    directory: "/examples/mobile-app"
+    schedule:
+      interval: "monthly"
+    open-pull-requests-limit: 3
+    labels:
+      - "dependencies"
+      - "examples"
+    commit-message:
+      prefix: "deps(mobile-example)"
+    groups:
+      expo:
+        patterns:
+          - "expo*"
+          - "@expo/*"
+      all-minor-and-patch:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
+
+  - package-ecosystem: "npm"
+    directory: "/sdk/react-native/examples/CoopWallet"
+    schedule:
+      interval: "monthly"
+    open-pull-requests-limit: 3
+    labels:
+      - "dependencies"
+      - "examples"
+    commit-message:
+      prefix: "deps(coopwallet)"
+    groups:
+      expo:
+        patterns:
+          - "expo*"
+          - "@expo/*"
+      all-minor-and-patch:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
 
   # GitHub Actions
   - package-ecosystem: "github-actions"
@@ -113,3 +258,10 @@ updates:
       - "ci"
     commit-message:
       prefix: "ci"
+    groups:
+      # actions/checkout, actions/setup-node, actions/setup-python,
+      # codecov/codecov-action and docker/build-push-action were five separate
+      # open PRs. Action bumps are near-always reviewed together; group them.
+      github-actions:
+        patterns:
+          - "*"


### PR DESCRIPTION
## Delivery

- **Delivery lane**: FAST (Dependabot configuration only; no code, no CI workflow change)
- **Acceptance contract**: every npm lockfile in the repository receives version updates, and routine updates arrive as one grouped PR per workspace rather than one per package.
- **Explicit non-goals**: does not upgrade anything, does not close any existing Dependabot PR, does not group major bumps, does not change branch protection.

## The observable symptom

**~30 open dependency PRs, the oldest from July, none of which merge.** This PR fixes the two configuration defects that produce that queue.

## 1. Four of seven npm lockfiles were never configured

Version updates covered `/sdk/typescript`, `/sdk/react-native`, `/web/pilot-ui`. Not covered, all with a `package-lock.json` present:

| Directory | What it is |
|---|---|
| `/website` | the public site |
| `/ops/mcp` | the agent-facing MCP server |
| `/examples/mobile-app` | Expo example |
| `/sdk/react-native/examples/CoopWallet` | Expo example |

The distinction that matters: **Dependabot *security* updates run against every manifest it can find, regardless of this file. *Version* updates run only against the directories listed here.** So these four still raised alerts — what they never received was routine maintenance. They drifted until an advisory forced a jump.

That is not theoretical. `/website` now carries a **critical** `astro` advisory (GHSA-26w7-cxv4-gfx2) whose only remediation is a **semver-major** upgrade to `astro@7.3.2`, dragging `sharp` with it. Had the website been receiving minor/patch updates all along, that would very likely have been a routine bump rather than a framework migration.

## 2. Only development dependencies were grouped

Every *production* dependency opened its own PR, per workspace:

- `browserslist`, `js-yaml`, `brace-expansion`, `fast-uri` — separate PRs, across several lockfiles simultaneously
- cargo: `axum`, `proptest`, `getrandom`, `futures-util`, `hyper`, `hyper-util`, `opentelemetry_sdk` — seven independent PRs
- github-actions: `checkout`, `setup-node`, `setup-python`, `codecov-action`, `build-push-action` — five

**This interacts badly with branch protection.** `main` is strict-protected (`required_status_checks.strict = true`) with **no merge queue**, so every merge marks every other open PR out of date. A queue of N ungrouped PRs costs N branch updates and N full CI runs — the queue cannot drain faster than one PR per CI cycle, so in practice it never drains at all. Grouping is what makes the arithmetic work.

## Change

| | before | after |
|---|---|---|
| update entries | 5 | 9 |
| npm lockfiles covered | 3 of 7 | **7 of 7** |
| npm groups | dev-dependencies only | + `production-dependencies` (minor/patch) per workspace |
| cargo groups | tokio, rustls, crypto, dev | + `cargo-minor-and-patch` catch-all |
| github-actions groups | none | one group for all action bumps |

Majors are **deliberately left ungrouped** — a major needs review and verification on its own, and burying one inside a group of patches is how a breaking change slips through.

Example apps use a monthly schedule, `open-pull-requests-limit: 3` and a single catch-all group: they are demonstrations and should get maintenance without generating review load.

## Verification

- `yaml.safe_load` parses; 9 entries enumerated with their groups.
- All four newly-added directories confirmed to contain `package-lock.json`.
- No existing entry's schedule, labels, reviewers, commit prefix, or the `typescript` major-version `ignore` was altered.

## Follow-up this enables

Once merged, the five open github-actions PRs (#2495, #2494, #2493, #2269, #2268) can be closed and will be regenerated as a **single grouped PR** — five CI cycles becomes one. The same applies to the npm production-dependency PRs.

## Invariants

Not applicable — dependency-bot configuration only; no code, no CI workflow, no protocol surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
