### PR TITLE
fix(agent): repair four broken references in the Claude-facing surfaces

### DIFF
--- a/.agents/skills/verify/SKILL.md
+++ b/.agents/skills/verify/SKILL.md
@@ -7,7 +7,7 @@ allowed-tools: "Bash, Read, Grep, Glob"
 truth_contract:
   canonical_sources:
     - ops/state/truth/policy.json       # validation_ladder
-    - ops/state/config/repo-map.json    # workspace root (rust commands run from icn/icn/)
+    - ops/state/config/repo-map.json    # workspace root (rust commands run from icn/)
   live_load_required:
     - "git diff --name-only origin/main...HEAD"
   examples_only: []

--- a/.claude/agents/icn-economics-advisor.md
+++ b/.claude/agents/icn-economics-advisor.md
@@ -101,7 +101,7 @@ ledger.append_entry(spend).await?;
 ## Verification
 
 ```bash
-cd icn/icn
+cd "$(git rev-parse --show-toplevel)/icn"
 cargo fmt --all --check
 cargo clippy -p icn-ledger --all-targets -- -D warnings
 cargo test -p icn-ledger --lib

--- a/.claude/agents/icn-governance-advisor.md
+++ b/.claude/agents/icn-governance-advisor.md
@@ -107,7 +107,7 @@ A parameter at a lower scope overrides the parent, but only if the parent scope 
 ## Verification
 
 ```bash
-cd icn/icn
+cd "$(git rev-parse --show-toplevel)/icn"
 cargo fmt --all --check
 cargo clippy -p icn-ccl -p icn-governance -p icn-community -p icn-coop -p icn-entity --all-targets -- -D warnings
 cargo test -p icn-ccl --lib

--- a/.claude/agents/icn-ops.md
+++ b/.claude/agents/icn-ops.md
@@ -107,8 +107,11 @@ kubectl exec -n icn-alpha deployment/icn-node -- icnctl net peers
 **Check disk (recurring issue — Rust build artifacts fill icn-dev):**
 ```bash
 df -h / /var/lib/rancher
-du -sh ~/projects/icn/target  # usually the culprit
-cargo clean  # if > 20GB
+# Build output is spread across every agent worktree, not one tree, so a single
+# `cargo clean` does not bound it. icn-disk-guard classifies each worktree and
+# reclaims only Cargo output from merged, inactive, clean ones.
+icn-disk-guard            # audit only; never deletes
+icn-disk-guard --auto     # reclaim what it classifies as safe
 ```
 
 **Restart a stuck pod:**
@@ -118,7 +121,7 @@ kubectl rollout restart deployment/<name> -n <namespace>
 
 **Check ops/mcp state:**
 ```bash
-cd ~/projects/icn/ops/mcp && git status
+cd "$(git rev-parse --show-toplevel)/ops/mcp" && git status
 ```
 
 ## Release Readiness Checklist
@@ -139,7 +142,7 @@ Before tagging a release:
 
 ## Known Recurring Issues
 
-1. **icn-dev disk fill** — Rust build artifacts grow unboundedly. Run `cargo clean` in `~/projects/icn/` when disk > 70%. Add to pre-session checklist.
+1. **icn-dev disk fill** — every agent worktree builds into its own `icn/target`, so build output grows with the number of worktrees, not with one tree. Run `icn-disk-guard` to audit and `icn-disk-guard --auto` to reclaim; it only removes Cargo output from worktrees it classifies merged-and-inactive and never touches source. A merged worktree still held by a live process reports as `MERGED-BUT-PROCESS-PINNED` — that is agent-lifecycle debt, not something the guard resolves.
 2. **P2P 0.0.0.0 advertisement** — Nodes advertise loopback. Fixed by IPv6 Happy Eyeballs (Mar 21). Verify fix is live before any federation demo.
 3. **ops/mcp dirty state** — 4 modified + 10 untracked files pending commit since Mar 13. Run `git status && git add -A && git commit` on icn-dev.
 4. **ExecutionReceiptGate key** — Signing key not configured in K3s secrets. Required for Flow 1B.
@@ -148,14 +151,15 @@ Before tagging a release:
 
 ## ops/mcp Quick Reference
 
-The `@icn/ops-mcp` v0.1.0 server runs on icn-dev at `~/projects/icn/ops/mcp/`.
+The `@icn/ops-mcp` server lives at `ops/mcp/` inside the checkout. Resolve it as
+`"$(git rev-parse --show-toplevel)/ops/mcp"` — never a memorized machine path.
 
 **Tool sets:** sessions, tasks, repos, health, decisions, comms, events, watchers
 
 **Start/stop:**
 ```bash
 # On icn-dev
-cd ~/projects/icn/ops/mcp && node dist/index.js
+cd "$(git rev-parse --show-toplevel)/ops/mcp" && node dist/index.js
 ```
 
 **Schema:** v2 — events, mailbox, watchers_process tables (SQLite)

--- a/.claude/agents/icn-trust-federation-advisor.md
+++ b/.claude/agents/icn-trust-federation-advisor.md
@@ -106,7 +106,7 @@ Always try `try_read()` before `block_in_place()`. The `trust_oracle_block_in_pl
 ## Verification
 
 ```bash
-cd icn/icn
+cd "$(git rev-parse --show-toplevel)/icn"
 cargo fmt --all --check
 cargo clippy -p icn-trust -p icn-federation --all-targets -- -D warnings
 cargo test -p icn-trust --lib

--- a/.claude/commands/icn-demo-check.md
+++ b/.claude/commands/icn-demo-check.md
@@ -91,7 +91,7 @@ icnctl federation ping --from alpha --to beta 2>/dev/null || echo "Federation no
 **Step 9: ops/mcp State**
 
 ```
-ssh icn-dev "cd ~/projects/icn/ops/mcp && git status --short"
+ssh icn-dev "cd \"\$(git rev-parse --show-toplevel)/ops/mcp\" && git status --short"
 ```
 
 Flag if uncommitted changes (blocks session tracking and decision audit trail).

--- a/.claude/skills/verify/SKILL.md
+++ b/.claude/skills/verify/SKILL.md
@@ -7,7 +7,7 @@ allowed-tools: "Bash, Read, Grep, Glob"
 truth_contract:
   canonical_sources:
     - ops/state/truth/policy.json       # validation_ladder
-    - ops/state/config/repo-map.json    # workspace root (rust commands run from icn/icn/)
+    - ops/state/config/repo-map.json    # workspace root (rust commands run from icn/)
   live_load_required:
     - "git diff --name-only origin/main...HEAD"
   examples_only: []

--- a/ops/state/truth/agents.json
+++ b/ops/state/truth/agents.json
@@ -104,8 +104,8 @@
   ],
   "orchestrator": {
     "name": "orchestrator",
-    "path": "../../../.claude/agents/orchestrator.md",
-    "note": "Lives at project-level .claude/agents/. Cross-repo coordinator.",
+    "location": "external",
+    "note": "Not in this repository: a user/project-level Claude agent outside the checkout, so there is no in-repo path to validate. Recorded for routing only. The previous value was a relative path escaping the repo root, which can never resolve from a worktree.",
     "routing_triggers": ["cross-repo task", "birds-eye view", "unfamiliar area", "multiple repos"]
   }
 }


### PR DESCRIPTION
## Delivery

- **Delivery lane**: FAST (agent-facing docs/registry only; no product code, no CI workflow)
- **Acceptance contract**: no Claude-facing surface instructs an agent to use a path that does not exist.
- **Explicit non-goals**: no product or protocol behaviour changes; no agent's routing or scope is redefined; no agent added or removed; the hook executable-bit defect (#2691) is left to #2692.

> **Correction to an earlier draft of this description.** It previously claimed "no agent's behaviour is redefined". That was wrong, and item 3 below is the counter-example: this PR **does** change agent- and operator-facing *maintenance* behaviour, replacing a single-tree `cargo clean` with `icn-disk-guard`. That change is intentional — the old instruction did not work — and it is the point of item 3, so it should be stated rather than excluded by a blanket non-goal.
>
> The accurate scope: **no product code, no protocol surface, no CI workflow, no Rust.** What changes is what an agent is instructed to *do* when it follows these documents, in the four places where the current instruction is factually wrong.

Four broken references, all verified against disk. Each is a path an agent is told to use that **does not exist**.

## 1. `cd icn/icn` — the workspace root is wrong in four files

`icn-economics-advisor.md:104`, `icn-trust-federation-advisor.md:109` and `icn-governance-advisor.md:110` each open their verification block with:

```bash
cd icn/icn
cargo fmt --all --check
cargo clippy -p … --all-targets -- -D warnings
```

`icn/icn` does not exist — `icn/Cargo.toml` does. **Every verification command those three specialists document fails on its first line.** The registered owner (`ops/state/truth/policy.json → workspace.rust_commands_run_from`) says `icn/`, so the text also contradicted the registry.

Replaced with `cd "$(git rev-parse --show-toplevel)/icn"` — exactly what `CLAUDE.md`'s repository-resolution section prescribes, and correct from any subdirectory.

The same `icn/icn/` spelling appeared in a comment in the `verify` skill. Fixed in the **canonical** copy (`.agents/skills/verify/SKILL.md`) and re-mirrored to `.claude/skills/verify/SKILL.md`; `cmp` confirms byte-identical, as `skills.json`'s `exact_mirror` policy requires.

## 2. `~/projects/icn` — a retired checkout, six references

`CLAUDE.md` declares that tree legacy ("do not use") and says *"Never rely on a memorized machine path"*. `icn-ops.md` (5 sites) and `commands/icn-demo-check.md` (1) still pointed at it. Now resolved through `git rev-parse --show-toplevel`.

## 3. The disk-fill remedy was wrong, not merely wrongly-pathed

`icn-ops.md` told the operator to run `cargo clean` in one tree when disk > 70%.

Build output is spread across **every agent worktree** — each builds into its own `icn/target` — so cleaning a single tree does not bound it. Measured on this VM on 2026-09-10: **100% full, 380 GB of build output across 19 worktrees, one worktree holding 111 GB on its own.** `cargo clean` in any one of them would not have moved the needle.

The remedy is `icn-disk-guard`, which classifies each worktree and reclaims only Cargo output from ones it finds merged, inactive and clean. Also recorded: a merged worktree still held by a live process reports `MERGED-BUT-PROCESS-PINNED`, which is agent-lifecycle debt for an operator, not something a disk guard resolves by killing processes.

## 4. `agents.json` declared an orchestrator path that cannot resolve

```json
"path": "../../../.claude/agents/orchestrator.md"
```

That escapes the repository root, so it can **never** resolve from a worktree — and no `orchestrator.md` exists anywhere in the tree. The entry describes a real routing target that genuinely lives outside the checkout, so it is kept and marked `"location": "external"` (the shape `sources.json` already uses for non-file owners like `git` and `github-api`) rather than carrying a path guaranteed to be wrong.

The other 16 agent entries all resolve and are untouched.

## Verification

| check | result |
|---|---|
| `scripts/check-skill-registry.py` | clean (94 assertions) |
| `scripts/check-truth-spine.py` | clean |
| `ops/scripts/drift-check.sh` | **PASS** — 0 errors, 0 warnings |
| `cmp .agents/skills/verify/SKILL.md .claude/skills/verify/SKILL.md` | identical |
| `grep -rn 'icn/icn' .claude/ .agents/ .codex/` | no matches |
| `grep -rn '~/projects/icn' .claude/` | no matches |

`Agent Tooling Drift Check` is a required check and passes locally.

## Invariants

Not applicable to protocol behaviour — agent-facing documentation and registry only. No Rust, no CI workflow, no wire format.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

