### PR TITLE
feat(agent): give ICN one canonical owner for systemic-leverage reasoning

### DIFF
--- a/.agents/skills/systemic-leverage/SKILL.md
+++ b/.agents/skills/systemic-leverage/SKILL.md
@@ -78,30 +78,46 @@ If none matches, that is informative. Either the class is new, or there is no cl
 
 ## Classify, then continue
 
-Every candidate gets exactly one disposition. **Do not classify from memory or from this file** —
-the meanings and their applicability tests are data, and a copy of them here would go stale
-silently while still reading plausibly:
+Every candidate gets exactly one disposition, and **the structured predicates decide it**. The
+`meaning` and `test` fields explain a disposition to a human; they are not the decision procedure.
+Reading them and judging is how two agents reach two answers from the same facts.
+
+Answer the facts in `classification.facts`, then let the predicates resolve them:
 
 ```bash
 REPO_ROOT="$(git rev-parse --show-toplevel)"
-python3 -c "
-import json
-d=json.load(open('${REPO_ROOT}/ops/state/truth/engineering-leverage.json'))
-for name, spec in d['dispositions'].items():
-    print(name)
-    print('  means:', spec['meaning'])
-    print('  test :', spec['test'])
-for a in d['anti_patterns']:
-    print('  avoid:', a)
-"
+python3 - "$REPO_ROOT" <<'EOF'
+import json, sys
+d = json.load(open(f"{sys.argv[1]}/ops/state/truth/engineering-leverage.json"))
+
+print("Answer these, then re-run with them filled in:")
+for name, why in d["classification"]["facts"].items():
+    print(f"  {name}: ?    # {why}")
+
+# Replace with your answers, e.g. {"recurring_class_established": True, ...}
+facts = {}
+if facts:
+    matched = [n for n, s in d["dispositions"].items()
+               if all(facts.get(k) == v for k, v in s["predicate"]["all_of"].items())]
+    if len(matched) != 1:
+        raise SystemExit(f"AMBIGUOUS: {len(matched)} matched {matched} — "
+                         f"{d['classification']['rule']}")
+    print("disposition:", matched[0])
+    print("  explains:", d["dispositions"][matched[0]]["meaning"])
+EOF
 ```
 
-Apply each disposition's own `test` field — that is what makes the choice reproducible between
-agents rather than a matter of taste. Where a disposition carries a `recorded_in` or a
-`constraint`, honour it.
+Exactly one predicate must match. Zero or several is ambiguity, and the canonical `rule` is
+explicit that it must fail closed — never resolve it by preferring the answer you expected. If you
+cannot answer a fact honestly, that is the finding: you do not yet know enough to classify.
 
-`NONE` is a legitimate outcome and its `test` tells you when it applies. The `anti_patterns` list
-in the same file names manufacturing architecture work as a failure mode of this framework itself.
+Where the chosen disposition carries a `recorded_in` or a `constraint`, honour it.
+
+Prose can mislead where predicates do not. With no recurring class but a boundary-changing
+correction, the ARCHITECTURAL and NONE descriptions can both *read* as affirmative — while the
+predicates match only `NONE`, because `recurring_class_established` is false. Follow the predicate
+result. The `anti_patterns` list names manufacturing architecture work as a failure mode of this
+framework itself.
 
 ## The boundary that is not negotiable
 

--- a/.agents/skills/systemic-leverage/SKILL.md
+++ b/.agents/skills/systemic-leverage/SKILL.md
@@ -1,0 +1,121 @@
+---
+name: systemic-leverage
+description: Use after ESTABLISHING a defect — reproduced, not suspected. Separates the immediate cause from the mechanism that made the defect possible to write, then classifies the structural opportunity NOW / FOLLOW_UP / ARCHITECTURAL / NONE without widening the active delivery contract. Triggers on: bug fixed, root cause found, "why was this possible", recurring failure, review finding, maintenance sweep, post-incident.
+user-invocable: true
+allowed-tools: "Bash, Read, Grep, Glob"
+truth_contract:
+  canonical_sources:
+    - ops/state/truth/engineering-leverage.json   # the loop, dispositions, pattern catalogue
+    - ops/state/truth/delivery.json               # lifecycle, blocker predicate, freeze, follow-up ledger
+  live_load_required:
+    - "gh issue list --state open --search '<pattern keywords>'"
+  examples_only: []
+---
+
+Load the catalogue before answering. It is data, not prose to be recalled:
+
+```bash
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+python3 -c "
+import json,sys
+d=json.load(open('${REPO_ROOT}/ops/state/truth/engineering-leverage.json'))
+for s in d['loop']['stages']: print(f\"{s['id']:<20} {s['asks']}\")
+print()
+for p in d['patterns']: print(f\"{p['id']:<32} {p['signal'][:96]}\")
+"
+```
+
+## When this applies
+
+Only after a defect is **established** — you reproduced it. A suspicion is not a defect, and a
+suspicion does not earn a systemic candidate.
+
+Skip it entirely for non-engineering work. Writing, research and documentation tasks do not
+perform a defect analysis.
+
+## The two questions
+
+The habit this skill exists to build is asking the second one:
+
+- What test would catch this next time?
+- **What would have made this bug difficult or impossible to write?**
+
+Tests remain necessary. Prevention is usually higher leverage.
+
+## The loop
+
+Work the stages in `loop.stages`. Four of them are distinct claims and collapsing them is the
+most common failure:
+
+| stage | is not |
+|---|---|
+| `symptom` | an inferred cause |
+| `immediate_cause` | a category of mechanism |
+| `enabling_mechanism` | a restatement of the immediate cause |
+| `regression_witness` | proof the *class* is prevented |
+
+That last row is the one to guard. Proving the instance is fixed is not proving the class is
+prevented. Claim the second only when a mechanism makes the defect unrepresentable or a gate
+rejects it — and say which.
+
+## Matching a pattern
+
+Read `patterns[].signal`. If one matches, use its `question` and `preferred_response` rather than
+inventing a direction, and cite the existing `examples[].reference` — the class has been seen
+before, and that is the point of the catalogue.
+
+If none matches, that is informative. Either the class is new, or there is no class.
+
+## Classify, then continue
+
+Every candidate gets exactly one disposition from `dispositions`:
+
+- **NOW** — the structural correction is necessary for the defect to be *correctly* fixed, or is
+  tiny, obviously safe and squarely inside the current acceptance contract.
+- **FOLLOW_UP** — the local repair is complete and provable on its own; the mechanism is separate
+  work. Record it in the pull request's follow-up ledger.
+- **ARCHITECTURAL** — it changes a subsystem boundary, state model, authority model, storage model
+  or lifecycle. Record it. Do not smuggle it into the current pull request.
+- **NONE** — genuinely local, no useful class.
+
+**NONE is a first-class answer.** If you cannot name a second real occurrence, NONE is very likely
+correct. Manufacturing architecture work to satisfy this framework is itself a defect, and
+`anti_patterns` in the canonical source names it as one.
+
+## The boundary that is not negotiable
+
+`ops/state/truth/delivery.json` remains canonical for the lifecycle. This skill never overrides it.
+
+- A systemic observation does **not** widen the active acceptance contract.
+- A systemic observation does **not** satisfy the blocker predicate. A reviewer may raise a
+  candidate without it being a blocker; severity labels are advisory.
+- A FOLLOW_UP or ARCHITECTURAL candidate does **not** prevent freeze, and does not reopen a frozen
+  pull request.
+- The default sequence stays: fix the defect → prove the defect fixed → record the candidate →
+  continue bounded delivery.
+
+If this skill and `delivery.json` ever disagree, `delivery.json` wins.
+
+## Before creating an issue
+
+In this order:
+
+1. Search for an existing owner — issue, PR, or follow-up ledger entry — and reuse it.
+2. If none exists, weigh the evidence and the expected payoff.
+3. Create an issue only when the class is established, there is a concrete mechanism to change,
+   and the work is worth scheduling.
+
+One defect must not produce four speculative architecture tickets. For a small observation the
+current pull request's follow-up ledger is usually sufficient.
+
+## Where this matters most
+
+During **maintenance**, actively aggregate: several follow-ups citing the same `patterns[].id` are
+the signal that one bounded systemic tranche is now justified. That is where a candidate graduates
+into implementation — not at the moment it is first noticed.
+
+## Applies to the agent system too
+
+An agent-control-plane defect gets the same loop. A retired path copied into several agent
+surfaces is `duplicated-semantic-owner`, and its preferred response is a canonical owner with a
+generated or mirrored projection and a drift validator — not a careful re-edit of each copy.

--- a/.agents/skills/systemic-leverage/SKILL.md
+++ b/.agents/skills/systemic-leverage/SKILL.md
@@ -47,16 +47,26 @@ Tests remain necessary. Prevention is usually higher leverage.
 Work the stages in `loop.stages`. Four of them are distinct claims and collapsing them is the
 most common failure:
 
-| stage | is not |
-|---|---|
-| `symptom` | an inferred cause |
-| `immediate_cause` | a category of mechanism |
-| `enabling_mechanism` | a restatement of the immediate cause |
-| `regression_witness` | proof the *class* is prevented |
+Render the distinctions rather than reading them from here — a copy in this file would go stale
+while still reading plausibly:
 
-That last row is the one to guard. Proving the instance is fixed is not proving the class is
-prevented. Claim the second only when a mechanism makes the defect unrepresentable or a gate
-rejects it — and say which.
+```bash
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+python3 -c "
+import json
+d=json.load(open('${REPO_ROOT}/ops/state/truth/engineering-leverage.json'))
+for s in d['loop']['stages']:
+    if s.get('must_not_be'):
+        print(f\"{s['id']:<20} asks: {s['asks']}\")
+        print(f\"{'':<20} is NOT: {s['must_not_be']}\")
+print()
+print('claim separation:', d['loop']['claim_separation']['rule'])
+"
+```
+
+The `claim_separation` rule is the one to guard. Proving the instance is fixed is not proving the
+class is prevented; claim the second only when a mechanism makes the defect unrepresentable or a
+gate rejects it, and say which.
 
 ## Matching a pattern
 

--- a/.agents/skills/systemic-leverage/SKILL.md
+++ b/.agents/skills/systemic-leverage/SKILL.md
@@ -30,8 +30,20 @@ for p in d['patterns']: print(f\"{p['id']:<32} {p['signal'][:96]}\")
 Only after a defect is **established** — you reproduced it. A suspicion is not a defect, and a
 suspicion does not earn a systemic candidate.
 
-Skip it entirely for non-engineering work. Writing, research and documentation tasks do not
-perform a defect analysis.
+**Evidence decides, not artifact type.** The trigger is an established defect, not whether you are
+editing code:
+
+- **No defect established** → do not run the loop. Ordinary writing, research, documentation and
+  routine implementation work do not perform a defect analysis merely because work occurred.
+  Ceremonial analysis produces the manufactured architecture work `anti_patterns` warns about.
+- **A defect established** → run the loop, whatever the artifact. A generated projection silently
+  drifting from its registered owner, a policy document contradicting the semantics it projects,
+  an agent surface naming a path that does not exist — these are engineering defects that happen
+  to live in documentation, and they have the same enabling mechanisms as defects in code.
+
+An earlier version of this section exempted writing, research and documentation by task type. That
+was too broad: it would have told an agent to skip the loop on exactly the drift defects this
+policy's own delivery surfaced.
 
 ## The two questions
 

--- a/.agents/skills/systemic-leverage/SKILL.md
+++ b/.agents/skills/systemic-leverage/SKILL.md
@@ -68,19 +68,30 @@ If none matches, that is informative. Either the class is new, or there is no cl
 
 ## Classify, then continue
 
-Every candidate gets exactly one disposition from `dispositions`:
+Every candidate gets exactly one disposition. **Do not classify from memory or from this file** —
+the meanings and their applicability tests are data, and a copy of them here would go stale
+silently while still reading plausibly:
 
-- **NOW** — the structural correction is necessary for the defect to be *correctly* fixed, or is
-  tiny, obviously safe and squarely inside the current acceptance contract.
-- **FOLLOW_UP** — the local repair is complete and provable on its own; the mechanism is separate
-  work. Record it in the pull request's follow-up ledger.
-- **ARCHITECTURAL** — it changes a subsystem boundary, state model, authority model, storage model
-  or lifecycle. Record it. Do not smuggle it into the current pull request.
-- **NONE** — genuinely local, no useful class.
+```bash
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+python3 -c "
+import json
+d=json.load(open('${REPO_ROOT}/ops/state/truth/engineering-leverage.json'))
+for name, spec in d['dispositions'].items():
+    print(name)
+    print('  means:', spec['meaning'])
+    print('  test :', spec['test'])
+for a in d['anti_patterns']:
+    print('  avoid:', a)
+"
+```
 
-**NONE is a first-class answer.** If you cannot name a second real occurrence, NONE is very likely
-correct. Manufacturing architecture work to satisfy this framework is itself a defect, and
-`anti_patterns` in the canonical source names it as one.
+Apply each disposition's own `test` field — that is what makes the choice reproducible between
+agents rather than a matter of taste. Where a disposition carries a `recorded_in` or a
+`constraint`, honour it.
+
+`NONE` is a legitimate outcome and its `test` tells you when it applies. The `anti_patterns` list
+in the same file names manufacturing architecture work as a failure mode of this framework itself.
 
 ## The boundary that is not negotiable
 

--- a/.claude/agents/icn-code-reviewer.md
+++ b/.claude/agents/icn-code-reviewer.md
@@ -74,6 +74,20 @@ You may attach a severity to help the maintainer triage. It carries no authority
 satisfies the predicate, and it never breaks a freeze. `automated_severity_is_advisory` in the
 policy is the governing statement.
 
+## Naming a systemic candidate
+
+When a finding looks like an instance of a recurring class rather than a one-off, you may name the
+class. Match it against `patterns[].signal` in `ops/state/truth/engineering-leverage.json` and cite
+the pattern id and its existing precedent, so the author inherits the direction instead of
+rediscovering it.
+
+This changes nothing about the finding's disposition. A systemic observation does not satisfy
+`blocker_predicate.all_must_hold`, does not widen the acceptance contract, and does not reopen a
+freeze. A recurring class whose instance here is genuinely repaired is **FOLLOW_UP**, and belongs
+in the follow-up ledger — not in a demand that this pull request grow.
+
+If no pattern matches and you cannot name a second real occurrence, do not invent a class.
+
 ## Reviewing a frozen pull request
 
 The freeze means the comprehensive generation is closed. Apply the late-blocker threshold in

--- a/.claude/skills/systemic-leverage/SKILL.md
+++ b/.claude/skills/systemic-leverage/SKILL.md
@@ -78,30 +78,46 @@ If none matches, that is informative. Either the class is new, or there is no cl
 
 ## Classify, then continue
 
-Every candidate gets exactly one disposition. **Do not classify from memory or from this file** —
-the meanings and their applicability tests are data, and a copy of them here would go stale
-silently while still reading plausibly:
+Every candidate gets exactly one disposition, and **the structured predicates decide it**. The
+`meaning` and `test` fields explain a disposition to a human; they are not the decision procedure.
+Reading them and judging is how two agents reach two answers from the same facts.
+
+Answer the facts in `classification.facts`, then let the predicates resolve them:
 
 ```bash
 REPO_ROOT="$(git rev-parse --show-toplevel)"
-python3 -c "
-import json
-d=json.load(open('${REPO_ROOT}/ops/state/truth/engineering-leverage.json'))
-for name, spec in d['dispositions'].items():
-    print(name)
-    print('  means:', spec['meaning'])
-    print('  test :', spec['test'])
-for a in d['anti_patterns']:
-    print('  avoid:', a)
-"
+python3 - "$REPO_ROOT" <<'EOF'
+import json, sys
+d = json.load(open(f"{sys.argv[1]}/ops/state/truth/engineering-leverage.json"))
+
+print("Answer these, then re-run with them filled in:")
+for name, why in d["classification"]["facts"].items():
+    print(f"  {name}: ?    # {why}")
+
+# Replace with your answers, e.g. {"recurring_class_established": True, ...}
+facts = {}
+if facts:
+    matched = [n for n, s in d["dispositions"].items()
+               if all(facts.get(k) == v for k, v in s["predicate"]["all_of"].items())]
+    if len(matched) != 1:
+        raise SystemExit(f"AMBIGUOUS: {len(matched)} matched {matched} — "
+                         f"{d['classification']['rule']}")
+    print("disposition:", matched[0])
+    print("  explains:", d["dispositions"][matched[0]]["meaning"])
+EOF
 ```
 
-Apply each disposition's own `test` field — that is what makes the choice reproducible between
-agents rather than a matter of taste. Where a disposition carries a `recorded_in` or a
-`constraint`, honour it.
+Exactly one predicate must match. Zero or several is ambiguity, and the canonical `rule` is
+explicit that it must fail closed — never resolve it by preferring the answer you expected. If you
+cannot answer a fact honestly, that is the finding: you do not yet know enough to classify.
 
-`NONE` is a legitimate outcome and its `test` tells you when it applies. The `anti_patterns` list
-in the same file names manufacturing architecture work as a failure mode of this framework itself.
+Where the chosen disposition carries a `recorded_in` or a `constraint`, honour it.
+
+Prose can mislead where predicates do not. With no recurring class but a boundary-changing
+correction, the ARCHITECTURAL and NONE descriptions can both *read* as affirmative — while the
+predicates match only `NONE`, because `recurring_class_established` is false. Follow the predicate
+result. The `anti_patterns` list names manufacturing architecture work as a failure mode of this
+framework itself.
 
 ## The boundary that is not negotiable
 

--- a/.claude/skills/systemic-leverage/SKILL.md
+++ b/.claude/skills/systemic-leverage/SKILL.md
@@ -1,0 +1,121 @@
+---
+name: systemic-leverage
+description: Use after ESTABLISHING a defect — reproduced, not suspected. Separates the immediate cause from the mechanism that made the defect possible to write, then classifies the structural opportunity NOW / FOLLOW_UP / ARCHITECTURAL / NONE without widening the active delivery contract. Triggers on: bug fixed, root cause found, "why was this possible", recurring failure, review finding, maintenance sweep, post-incident.
+user-invocable: true
+allowed-tools: "Bash, Read, Grep, Glob"
+truth_contract:
+  canonical_sources:
+    - ops/state/truth/engineering-leverage.json   # the loop, dispositions, pattern catalogue
+    - ops/state/truth/delivery.json               # lifecycle, blocker predicate, freeze, follow-up ledger
+  live_load_required:
+    - "gh issue list --state open --search '<pattern keywords>'"
+  examples_only: []
+---
+
+Load the catalogue before answering. It is data, not prose to be recalled:
+
+```bash
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+python3 -c "
+import json,sys
+d=json.load(open('${REPO_ROOT}/ops/state/truth/engineering-leverage.json'))
+for s in d['loop']['stages']: print(f\"{s['id']:<20} {s['asks']}\")
+print()
+for p in d['patterns']: print(f\"{p['id']:<32} {p['signal'][:96]}\")
+"
+```
+
+## When this applies
+
+Only after a defect is **established** — you reproduced it. A suspicion is not a defect, and a
+suspicion does not earn a systemic candidate.
+
+Skip it entirely for non-engineering work. Writing, research and documentation tasks do not
+perform a defect analysis.
+
+## The two questions
+
+The habit this skill exists to build is asking the second one:
+
+- What test would catch this next time?
+- **What would have made this bug difficult or impossible to write?**
+
+Tests remain necessary. Prevention is usually higher leverage.
+
+## The loop
+
+Work the stages in `loop.stages`. Four of them are distinct claims and collapsing them is the
+most common failure:
+
+| stage | is not |
+|---|---|
+| `symptom` | an inferred cause |
+| `immediate_cause` | a category of mechanism |
+| `enabling_mechanism` | a restatement of the immediate cause |
+| `regression_witness` | proof the *class* is prevented |
+
+That last row is the one to guard. Proving the instance is fixed is not proving the class is
+prevented. Claim the second only when a mechanism makes the defect unrepresentable or a gate
+rejects it — and say which.
+
+## Matching a pattern
+
+Read `patterns[].signal`. If one matches, use its `question` and `preferred_response` rather than
+inventing a direction, and cite the existing `examples[].reference` — the class has been seen
+before, and that is the point of the catalogue.
+
+If none matches, that is informative. Either the class is new, or there is no class.
+
+## Classify, then continue
+
+Every candidate gets exactly one disposition from `dispositions`:
+
+- **NOW** — the structural correction is necessary for the defect to be *correctly* fixed, or is
+  tiny, obviously safe and squarely inside the current acceptance contract.
+- **FOLLOW_UP** — the local repair is complete and provable on its own; the mechanism is separate
+  work. Record it in the pull request's follow-up ledger.
+- **ARCHITECTURAL** — it changes a subsystem boundary, state model, authority model, storage model
+  or lifecycle. Record it. Do not smuggle it into the current pull request.
+- **NONE** — genuinely local, no useful class.
+
+**NONE is a first-class answer.** If you cannot name a second real occurrence, NONE is very likely
+correct. Manufacturing architecture work to satisfy this framework is itself a defect, and
+`anti_patterns` in the canonical source names it as one.
+
+## The boundary that is not negotiable
+
+`ops/state/truth/delivery.json` remains canonical for the lifecycle. This skill never overrides it.
+
+- A systemic observation does **not** widen the active acceptance contract.
+- A systemic observation does **not** satisfy the blocker predicate. A reviewer may raise a
+  candidate without it being a blocker; severity labels are advisory.
+- A FOLLOW_UP or ARCHITECTURAL candidate does **not** prevent freeze, and does not reopen a frozen
+  pull request.
+- The default sequence stays: fix the defect → prove the defect fixed → record the candidate →
+  continue bounded delivery.
+
+If this skill and `delivery.json` ever disagree, `delivery.json` wins.
+
+## Before creating an issue
+
+In this order:
+
+1. Search for an existing owner — issue, PR, or follow-up ledger entry — and reuse it.
+2. If none exists, weigh the evidence and the expected payoff.
+3. Create an issue only when the class is established, there is a concrete mechanism to change,
+   and the work is worth scheduling.
+
+One defect must not produce four speculative architecture tickets. For a small observation the
+current pull request's follow-up ledger is usually sufficient.
+
+## Where this matters most
+
+During **maintenance**, actively aggregate: several follow-ups citing the same `patterns[].id` are
+the signal that one bounded systemic tranche is now justified. That is where a candidate graduates
+into implementation — not at the moment it is first noticed.
+
+## Applies to the agent system too
+
+An agent-control-plane defect gets the same loop. A retired path copied into several agent
+surfaces is `duplicated-semantic-owner`, and its preferred response is a canonical owner with a
+generated or mirrored projection and a drift validator — not a careful re-edit of each copy.

--- a/.claude/skills/systemic-leverage/SKILL.md
+++ b/.claude/skills/systemic-leverage/SKILL.md
@@ -47,16 +47,26 @@ Tests remain necessary. Prevention is usually higher leverage.
 Work the stages in `loop.stages`. Four of them are distinct claims and collapsing them is the
 most common failure:
 
-| stage | is not |
-|---|---|
-| `symptom` | an inferred cause |
-| `immediate_cause` | a category of mechanism |
-| `enabling_mechanism` | a restatement of the immediate cause |
-| `regression_witness` | proof the *class* is prevented |
+Render the distinctions rather than reading them from here — a copy in this file would go stale
+while still reading plausibly:
 
-That last row is the one to guard. Proving the instance is fixed is not proving the class is
-prevented. Claim the second only when a mechanism makes the defect unrepresentable or a gate
-rejects it — and say which.
+```bash
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+python3 -c "
+import json
+d=json.load(open('${REPO_ROOT}/ops/state/truth/engineering-leverage.json'))
+for s in d['loop']['stages']:
+    if s.get('must_not_be'):
+        print(f\"{s['id']:<20} asks: {s['asks']}\")
+        print(f\"{'':<20} is NOT: {s['must_not_be']}\")
+print()
+print('claim separation:', d['loop']['claim_separation']['rule'])
+"
+```
+
+The `claim_separation` rule is the one to guard. Proving the instance is fixed is not proving the
+class is prevented; claim the second only when a mechanism makes the defect unrepresentable or a
+gate rejects it, and say which.
 
 ## Matching a pattern
 

--- a/.claude/skills/systemic-leverage/SKILL.md
+++ b/.claude/skills/systemic-leverage/SKILL.md
@@ -30,8 +30,20 @@ for p in d['patterns']: print(f\"{p['id']:<32} {p['signal'][:96]}\")
 Only after a defect is **established** — you reproduced it. A suspicion is not a defect, and a
 suspicion does not earn a systemic candidate.
 
-Skip it entirely for non-engineering work. Writing, research and documentation tasks do not
-perform a defect analysis.
+**Evidence decides, not artifact type.** The trigger is an established defect, not whether you are
+editing code:
+
+- **No defect established** → do not run the loop. Ordinary writing, research, documentation and
+  routine implementation work do not perform a defect analysis merely because work occurred.
+  Ceremonial analysis produces the manufactured architecture work `anti_patterns` warns about.
+- **A defect established** → run the loop, whatever the artifact. A generated projection silently
+  drifting from its registered owner, a policy document contradicting the semantics it projects,
+  an agent surface naming a path that does not exist — these are engineering defects that happen
+  to live in documentation, and they have the same enabling mechanisms as defects in code.
+
+An earlier version of this section exempted writing, research and documentation by task type. That
+was too broad: it would have told an agent to skip the loop on exactly the drift defects this
+policy's own delivery surfaced.
 
 ## The two questions
 

--- a/.claude/skills/systemic-leverage/SKILL.md
+++ b/.claude/skills/systemic-leverage/SKILL.md
@@ -68,19 +68,30 @@ If none matches, that is informative. Either the class is new, or there is no cl
 
 ## Classify, then continue
 
-Every candidate gets exactly one disposition from `dispositions`:
+Every candidate gets exactly one disposition. **Do not classify from memory or from this file** —
+the meanings and their applicability tests are data, and a copy of them here would go stale
+silently while still reading plausibly:
 
-- **NOW** — the structural correction is necessary for the defect to be *correctly* fixed, or is
-  tiny, obviously safe and squarely inside the current acceptance contract.
-- **FOLLOW_UP** — the local repair is complete and provable on its own; the mechanism is separate
-  work. Record it in the pull request's follow-up ledger.
-- **ARCHITECTURAL** — it changes a subsystem boundary, state model, authority model, storage model
-  or lifecycle. Record it. Do not smuggle it into the current pull request.
-- **NONE** — genuinely local, no useful class.
+```bash
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+python3 -c "
+import json
+d=json.load(open('${REPO_ROOT}/ops/state/truth/engineering-leverage.json'))
+for name, spec in d['dispositions'].items():
+    print(name)
+    print('  means:', spec['meaning'])
+    print('  test :', spec['test'])
+for a in d['anti_patterns']:
+    print('  avoid:', a)
+"
+```
 
-**NONE is a first-class answer.** If you cannot name a second real occurrence, NONE is very likely
-correct. Manufacturing architecture work to satisfy this framework is itself a defect, and
-`anti_patterns` in the canonical source names it as one.
+Apply each disposition's own `test` field — that is what makes the choice reproducible between
+agents rather than a matter of taste. Where a disposition carries a `recorded_in` or a
+`constraint`, honour it.
+
+`NONE` is a legitimate outcome and its `test` tells you when it applies. The `anti_patterns` list
+in the same file names manufacturing architecture work as a failure mode of this framework itself.
 
 ## The boundary that is not negotiable
 

--- a/.github/agents/icn-code-reviewer.md
+++ b/.github/agents/icn-code-reviewer.md
@@ -77,6 +77,20 @@ You may attach a severity to help the maintainer triage. It carries no authority
 satisfies the predicate, and it never breaks a freeze. `automated_severity_is_advisory` in the
 policy is the governing statement.
 
+## Naming a systemic candidate
+
+When a finding looks like an instance of a recurring class rather than a one-off, you may name the
+class. Match it against `patterns[].signal` in `ops/state/truth/engineering-leverage.json` and cite
+the pattern id and its existing precedent, so the author inherits the direction instead of
+rediscovering it.
+
+This changes nothing about the finding's disposition. A systemic observation does not satisfy
+`blocker_predicate.all_must_hold`, does not widen the acceptance contract, and does not reopen a
+freeze. A recurring class whose instance here is genuinely repaired is **FOLLOW_UP**, and belongs
+in the follow-up ledger — not in a demand that this pull request grow.
+
+If no pattern matches and you cannot name a second real occurrence, do not invent a class.
+
 ## Reviewing a frozen pull request
 
 The freeze means the comprehensive generation is closed. Apply the late-blocker threshold in

--- a/.github/workflows/agent-drift-check.yml
+++ b/.github/workflows/agent-drift-check.yml
@@ -115,6 +115,13 @@ jobs:
       - name: Systemic-leverage classification scenarios behave as specified
         run: python3 scripts/tests/test_engineering_leverage.py
 
+      # Registering a truth domain without regenerating the context spine must
+      # fail a gate. generated-truth.yml only warns, does not watch
+      # ops/state/truth/**, and is not required — so the enforcement lives on
+      # the required drift path and this proves it binds.
+      - name: Context spine enforcement binds on the required path
+        run: python3 scripts/tests/test_context_spine_enforcement.py
+
       # icn#2651: the canonical merge policy must not name a field that cannot hold the value it
       # is compared against, and must not duplicate values it owns. Both got past every other gate
       # because prose is not type-checked. Structured validation only — no Markdown is parsed.

--- a/.github/workflows/agent-drift-check.yml
+++ b/.github/workflows/agent-drift-check.yml
@@ -28,6 +28,8 @@ on:
       - 'scripts/tests/test_icn_merge_pr_install.py'
       # icn#2661: the delivery lifecycle owner, its gate, and the provider surfaces it binds.
       - 'scripts/check-delivery-lifecycle.py'
+      - 'ops/state/truth/engineering-leverage.json'
+      - 'scripts/check-engineering-leverage.py'
       - 'scripts/tests/test_delivery_lifecycle.py'
       - '.github/copilot-instructions.md'
       - '.github/pull_request_template.md'
@@ -106,6 +108,12 @@ jobs:
 
       - name: Sprint-state currency + SessionStart source guard tests (Refs icn#2634)
         run: python3 scripts/tests/test_sprint_state_invariants.py
+
+      - name: Systemic-leverage policy has one canonical owner and live projections
+        run: python3 scripts/check-engineering-leverage.py
+
+      - name: Systemic-leverage classification scenarios behave as specified
+        run: python3 scripts/tests/test_engineering_leverage.py
 
       # icn#2651: the canonical merge policy must not name a field that cannot hold the value it
       # is compared against, and must not duplicate values it owns. Both got past every other gate

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -78,6 +78,7 @@ The source-linked invariant catalog is `docs/reference/project-index/invariants-
 - Do not silently upgrade toolchains or dependencies.
 - Do not perform deployment, release, migration/cutover, branch-protection changes, destructive infrastructure actions, or merges without the authorization appropriate to that action.
 - When a selected implementation slice appears to require changing a settled contract, stop and report the contract conflict instead of widening the implementation quietly.
+- After **establishing** a defect — reproduced, not suspected — separate its immediate cause from the mechanism that made it possible to write, and classify the structural opportunity `NOW` / `FOLLOW_UP` / `ARCHITECTURAL` / `NONE`. `ops/state/truth/engineering-leverage.json` owns that loop and the catalogue of recurring classes; the `systemic-leverage` skill is its working surface. A systemic observation is an *observation*: it never widens the active scope, never satisfies the blocker predicate, and never reopens a frozen PR. `NONE` is a legitimate answer and is the correct one for a genuinely local defect.
 
 ## 5. Verification is path- and claim-specific
 

--- a/docs/ai/ICN_CONSTITUTIONAL_CORE.md
+++ b/docs/ai/ICN_CONSTITUTIONAL_CORE.md
@@ -95,6 +95,13 @@ Be suspicious of work that is mostly:
 - cleanup that crosses a reviewed semantic boundary because "we are already here";
 - a second implementation of machinery that already has an owner.
 
+Fix the defect first, then ask what mechanism allowed that class of defect to exist. Those are two
+different questions and the second is usually the higher-leverage one: prefer asking what would
+have made the bug difficult to write over asking only what test would catch it next time. The loop,
+its dispositions and the catalogue of classes ICN has already seen are owned by
+`ops/state/truth/engineering-leverage.json`. Answering `NONE` is correct whenever a defect is
+genuinely local — this heuristic is not a mandate to produce architecture work.
+
 ## Authority and role boundary
 
 Agents are instruments for inspection, synthesis, implementation, review, and reconciliation. They do not acquire project authority by being able to edit files.

--- a/docs/reference/project-index/generated/agent-capabilities.json
+++ b/docs/reference/project-index/generated/agent-capabilities.json
@@ -335,6 +335,12 @@
       "summary": ""
     },
     {
+      "name": "systemic-leverage",
+      "group": "icn_level",
+      "canonical_path": ".agents/skills/systemic-leverage/SKILL.md",
+      "summary": ""
+    },
+    {
       "name": "verify",
       "group": "icn_level",
       "canonical_path": ".agents/skills/verify/SKILL.md",
@@ -536,6 +542,10 @@
     {
       "domain": "ecosystem_index",
       "owner": "docs/ATLAS.md"
+    },
+    {
+      "domain": "engineering_leverage",
+      "owner": "ops/state/truth/engineering-leverage.json"
     },
     {
       "domain": "identity_semantics",

--- a/docs/reference/project-index/generated/agent-context-spine.json
+++ b/docs/reference/project-index/generated/agent-context-spine.json
@@ -2,8 +2,8 @@
   "schema": "icn-agent-context-spine/v0",
   "status": "generated",
   "canonical": false,
-  "generated": "2026-08-28T16:35:09+00:00",
-  "source_commit": "7f3d18679f488c7f9bdc04bce00360511e0929e8",
+  "generated": "2026-09-11T05:32:50+00:00",
+  "source_commit": "4d9db69e91c753e14505ece26a3690436e2e18d3",
   "generator": "scripts/generate-agent-context-spine.py",
   "regenerate": "python3 scripts/generate-agent-context-spine.py --write",
   "check": "python3 scripts/generate-agent-context-spine.py --check",
@@ -35,7 +35,7 @@
     "verifies"
   ],
   "counts": {
-    "nodes": 144,
+    "nodes": 145,
     "edges": 92
   },
   "nodes": [
@@ -2715,6 +2715,26 @@
         },
         {
           "source": "docs/ATLAS.md",
+          "kind": "truth-owner"
+        }
+      ]
+    },
+    {
+      "id": "truth_source:engineering_leverage",
+      "type": "truth_source",
+      "name": "engineering_leverage",
+      "owner": "ops/state/truth/engineering-leverage.json",
+      "description": "Systemic-leverage behaviour: the causal escalation an engineering agent performs after ESTABLISHING a defect (symptom / reproduction / immediate cause / enabling mechanism / local repair / regression witness), the closed disposition vocabulary NOW | FOLLOW_UP | ARCHITECTURAL | NONE, and the evidence-backed catalogue of recurring defect classes with their preferred structural responses",
+      "stability": "slow-changing",
+      "source_of_truth": "ops/state/truth/sources.json",
+      "status": "present",
+      "evidence": [
+        {
+          "source": "ops/state/truth/sources.json",
+          "kind": "truth-domain"
+        },
+        {
+          "source": "ops/state/truth/engineering-leverage.json",
           "kind": "truth-owner"
         }
       ]

--- a/ops/scripts/drift-check.sh
+++ b/ops/scripts/drift-check.sh
@@ -137,6 +137,29 @@ else
   fail "scripts/check-skill-registry.py missing — in-repo skill ownership is unenforced"
 fi
 
+# ─── Check 2c: The systemic-leverage policy must have exactly one owner ──────
+#
+# ops/state/truth/engineering-leverage.json owns the causal escalation an agent
+# performs after establishing a defect, and the catalogue of classes ICN has
+# already seen. Its checker proves the owner parses, is registered in the truth
+# spine, is projected to the surfaces the skill registry declares, has not grown
+# a rival copy of the delivery lifecycle, and is actually referenced by the
+# surfaces agents read — a policy nobody is routed to is prose.
+
+LEVERAGE_CHECK="${REPO_ROOT}/scripts/check-engineering-leverage.py"
+if [[ -f "${LEVERAGE_CHECK}" ]]; then
+  if lev_out="$(python3 "${LEVERAGE_CHECK}" 2>&1)"; then
+    ok "engineering leverage policy: ${lev_out}"
+  else
+    while IFS= read -r line; do
+      [[ -n "${line}" ]] && echo "  ${line}" >&2
+    done <<< "${lev_out}"
+    fail "engineering-leverage policy is not mechanically true (see output above)"
+  fi
+else
+  fail "scripts/check-engineering-leverage.py missing — the systemic-leverage policy is unenforced"
+fi
+
 # ─── Check 3: Stale path patterns must not appear in agent tooling files ─────
 
 # These patterns have historically caused drift. Any hit is a FAIL.

--- a/ops/scripts/drift-check.sh
+++ b/ops/scripts/drift-check.sh
@@ -160,6 +160,34 @@ else
   fail "scripts/check-engineering-leverage.py missing — the systemic-leverage policy is unenforced"
 fi
 
+# ─── Check 2d: Generated navigation must not lag its registered owners ───────
+#
+# Registering a truth domain in ops/state/truth/sources.json changes an input
+# the agent context spine consumes. If the spine is not regenerated, path briefs
+# and agent navigation silently omit the new owner.
+#
+# This is enforced HERE, in drift-check.sh, because drift-check runs inside the
+# REQUIRED Agent Tooling Drift Check. The same freshness check already exists in
+# generated-truth.yml, but three things kept it from binding: it reports drift
+# as a ::warning:: that cannot fail the job, its paths filter does not include
+# ops/state/truth/**, and generated-truth is not a required check. Rather than
+# add a second generation mechanism, this calls the SAME checker from a path
+# that actually gates merge.
+
+SPINE_CHECK="${REPO_ROOT}/scripts/check-agent-context-spine.py"
+if [[ -f "${SPINE_CHECK}" ]]; then
+  if spine_out="$(python3 "${SPINE_CHECK}" 2>&1)"; then
+    ok "agent context spine: valid and current"
+  else
+    while IFS= read -r line; do
+      [[ -n "${line}" ]] && echo "  ${line}" >&2
+    done <<< "${spine_out}"
+    fail "agent context spine is stale or invalid — regenerate with: python3 scripts/generate-agent-context-spine.py --write"
+  fi
+else
+  fail "scripts/check-agent-context-spine.py missing — generated navigation is unenforced"
+fi
+
 # ─── Check 3: Stale path patterns must not appear in agent tooling files ─────
 
 # These patterns have historically caused drift. Any hit is a FAIL.

--- a/ops/state/truth/engineering-leverage.json
+++ b/ops/state/truth/engineering-leverage.json
@@ -1,0 +1,179 @@
+{
+  "schema": "icn.engineering-leverage.v1",
+  "description": "Canonical owner of ICN's systemic-leverage behaviour: the causal escalation an engineering agent performs after establishing a real defect, the closed set of dispositions for a systemic candidate, and the evidence-backed catalogue of recurring defect classes. This file owns HOW an agent reasons from a defect to a structural opportunity. It does NOT own the delivery lifecycle.",
+
+  "owner_boundary": {
+    "owns": [
+      "the stages an agent must distinguish after establishing a defect",
+      "the closed disposition vocabulary for a systemic candidate",
+      "the catalogue of recurring engineering defect classes and their preferred structural responses",
+      "the rule that a systemic observation may not widen an active delivery contract"
+    ],
+    "does_not_own": [
+      {
+        "fact": "delivery lifecycle states, blocker predicate, freeze entry, review generation, follow-up ledger mechanics",
+        "owner": "ops/state/truth/delivery.json"
+      },
+      {
+        "fact": "merge requirements and merge-mutation semantics",
+        "owner": "ops/state/truth/policy.json#merge, executed by tools/icn-merge-pr"
+      },
+      {
+        "fact": "which verification commands a change requires",
+        "owner": "ops/state/truth/policy.json#validation_ladder"
+      }
+    ],
+    "conflict_rule": "If this file and ops/state/truth/delivery.json disagree, delivery.json wins. A systemic-leverage finding is never itself authority to reopen a frozen pull request, to widen an acceptance contract, or to satisfy the blocker predicate."
+  },
+
+  "loop": {
+    "description": "Performed only after a defect is ESTABLISHED — reproduced, not suspected. The first four stages are distinct claims and must not be collapsed into one another.",
+    "stages": [
+      { "id": "symptom", "asks": "What was observed?", "must_not_be": "an inferred cause" },
+      { "id": "reproduction", "asks": "What sequence reproduces it?", "must_not_be": "a plausible story" },
+      { "id": "immediate_cause", "asks": "Which specific mechanism failed here?", "must_not_be": "a category of mechanism" },
+      { "id": "enabling_mechanism", "asks": "What made this defect POSSIBLE TO WRITE?", "must_not_be": "a restatement of the immediate cause" },
+      { "id": "local_remediation", "asks": "What is the smallest correct repair?", "must_not_be": "the structural correction, unless that IS the smallest correct repair" },
+      { "id": "regression_witness", "asks": "What evidence proves the instance is fixed?", "must_not_be": "a claim that the class is prevented" },
+      { "id": "recurring_class", "asks": "Has this class occurred before, with evidence?", "must_not_be": "a guess that it might recur" },
+      { "id": "structural_options", "asks": "What mechanism would make this class hard or impossible to write?", "must_not_be": "a redesign of an unrelated subsystem" },
+      { "id": "disposition", "asks": "NOW, FOLLOW_UP, ARCHITECTURAL or NONE?", "must_not_be": "omitted" }
+    ],
+    "claim_separation": {
+      "rule": "Proof that an instance is fixed is not proof that a class is prevented. An agent may claim the second only when a mechanism makes the defect unrepresentable or a gate rejects it, and must show which.",
+      "why": "Overclaiming prevention retires attention from a class that is still live."
+    }
+  },
+
+  "dispositions": {
+    "NOW": {
+      "meaning": "The structural correction is necessary for the defect to be CORRECTLY fixed, or it is tiny, obviously safe, and squarely inside the current acceptance contract.",
+      "test": "Would a reviewer regard omitting it as leaving the reported defect only partly repaired?",
+      "example": "Two production call sites parse the same fact differently; factoring the already-existing canonical parser is the smallest correct repair."
+    },
+    "FOLLOW_UP": {
+      "meaning": "The defect is correctly fixable locally, but it reveals a broader mechanism worth addressing separately.",
+      "test": "Is the local repair complete and provable on its own?",
+      "recorded_in": "the pull request's follow-up ledger, owned by ops/state/truth/delivery.json",
+      "example": "One CLI writer forgot the exclusion lock; the local fix joins the lock domain, while the observation that every writer must remember lock policy is separate work."
+    },
+    "ARCHITECTURAL": {
+      "meaning": "The opportunity changes a subsystem boundary, state model, authority model, storage model or lifecycle.",
+      "test": "Would this change what other subsystems may assume?",
+      "constraint": "Record it. Never smuggle it into the current pull request."
+    },
+    "NONE": {
+      "meaning": "The defect is genuinely local and establishes no useful recurring class.",
+      "test": "Can you name a second real occurrence? If not, NONE is very likely correct.",
+      "note": "NONE is a first-class, expected answer. Manufacturing architecture work to satisfy this framework is itself a defect."
+    }
+  },
+
+  "anti_patterns": [
+    "Creating an issue for every systemic observation. Search for an existing owner first; a follow-up ledger entry is often sufficient.",
+    "Treating an automated reviewer's severity label as authority. Severity is advisory; the blocker predicate in delivery.json decides.",
+    "Widening an active pull request because adjacent debt was discovered.",
+    "Answering ARCHITECTURAL to avoid doing a small NOW correction.",
+    "Answering NOW to justify a redesign the acceptance contract does not cover."
+  ],
+
+  "patterns": [
+    {
+      "id": "duplicated-semantic-owner",
+      "signal": "The same domain fact is parsed, classified, validated, authorised or interpreted independently in more than one production location.",
+      "question": "Can there be exactly one authoritative mechanism for deciding whether this fact is true?",
+      "preferred_response": "A canonical parser, resolver or state machine that every caller delegates to.",
+      "examples": [
+        { "reference": "#2749", "fact": "Treasury DID acceptance existed separately in ceremony validation and in daemon startup parsing, and the two could disagree." },
+        { "reference": "#2768", "fact": "The Cargo workspace root was spelled independently in four agent-facing surfaces; three had drifted to a path that does not exist." }
+      ]
+    },
+    {
+      "id": "remember-to-do-it-correctness",
+      "signal": "Correctness depends on every caller remembering to acquire a lock, canonicalise an identifier, check an invariant, verify a capability, flush a directory or call a validator.",
+      "question": "Can the API make omission impossible rather than merely discouraged?",
+      "preferred_response": "A guard or capability token, a typed constructor, an RAII guard, a sealed mutation interface, or a single entrypoint that cannot be bypassed.",
+      "examples": [
+        { "reference": "#2749", "fact": "federation add/remove/set performed a read-modify-write of managed configuration without joining the configuration-lock domain; the repair introduced a guard type so loading outside the lock cannot reach the write." },
+        { "reference": "#2759", "fact": "Local maintenance commands opened ceremony stores outside the exclusion domain." }
+      ]
+    },
+    {
+      "id": "policy-in-call-sites",
+      "signal": "The real policy can only be reconstructed by finding every caller and observing what each one remembers to do.",
+      "question": "Can the policy move behind one typed or executable boundary?",
+      "preferred_response": "One boundary that owns the policy, especially for state mutation, identity mutation, configuration mutation, authorisation, durability and exclusion.",
+      "examples": [
+        { "reference": "#2749", "fact": "Exclusion policy for managed configuration lived in each CLI branch rather than in one mutation entrypoint." }
+      ]
+    },
+    {
+      "id": "producer-consumer-semantic-drift",
+      "signal": "Component A emits something it considers valid; component B cannot consume it, or interprets it differently.",
+      "question": "Is there a test that crosses the persist-and-reopen boundary, rather than two unit tests that agree with themselves?",
+      "preferred_response": "A producer -> persist -> reopen -> consumer contract test, and a shared semantic owner for the format.",
+      "examples": [
+        { "reference": "#2747", "fact": "init-coop generated an icn.toml that icnd could not load." },
+        { "reference": "#2755", "fact": "The native icnd service never consumed the runtime-root configuration it was provisioned with." },
+        { "reference": "#2750", "fact": "The reachability filter scored persisted trust edges as 0.0 after reopen." }
+      ]
+    },
+    {
+      "id": "observational-falsehood",
+      "signal": "A check, gate, dashboard or status reports success or a positive claim because the mechanism failed to observe the thing it was supposed to check.",
+      "question": "Does this path distinguish 'observed and fine' from 'could not observe'?",
+      "preferred_response": "Failure to know must be representable and must never render as knowing success, nor as a knowing contradiction. Fail closed on the unknown.",
+      "examples": [
+        { "reference": "#2760", "fact": "A failing cargo-audit step ended the job, so both cargo-deny gates were reported as not-run rather than passing or failing, for five consecutive weeks." },
+        { "reference": "#2749", "fact": "A storage failure reading the cooperative row was rendered as INCONSISTENT — a positive corruption claim — instead of ERROR / state_unreadable." },
+        { "reference": "#2733", "fact": "The generated-index drift check detects drift correctly and then reports it as a warning that cannot fail the job, so the drift persisted and grew." }
+      ]
+    },
+    {
+      "id": "repeated-manual-proof",
+      "signal": "Humans or agents repeatedly perform the same multi-step proof sequence by hand, and the hard-won correctness lessons survive only in prose.",
+      "question": "Should this become an executable, repository-owned harness?",
+      "preferred_response": "One harness that owns the sequence and its known traps, rather than a paragraph describing them.",
+      "examples": [
+        { "reference": "docs/architecture/protocol-state-migration-mutation-controls.md", "fact": "The mtime-preserving-restore trap was discovered, documented in prose, and then had to be rediscovered, because no code carried it forward." }
+      ]
+    },
+    {
+      "id": "lifecycle-resource-leak",
+      "signal": "A resource is created as part of an agent, session or worktree lifecycle, but its cleanup depends on somebody remembering later.",
+      "question": "What should happen automatically at creation, at merge, at agent exit and on a periodic health check?",
+      "preferred_response": "Lifecycle automation plus safe visibility plus explicit ownership. Never delete dirty, unmerged or process-pinned resources for cleanliness.",
+      "examples": [
+        { "reference": "#2652", "fact": "Per-worktree Cargo target directories reached 380 GB across 19 worktrees and filled the development volume; nothing reclaimed them and the remedy documented in agent surfaces was a single-tree cargo clean, which cannot bound a per-worktree total." }
+      ]
+    },
+    {
+      "id": "trigger-trust-boundary",
+      "signal": "An automation is reachable by an untrusted actor and holds a credential, a write scope, or executes third-party code from a mutable reference.",
+      "question": "Which actors can reach this, and what does it hold when they do?",
+      "preferred_response": "Gate the trigger on repository membership, pin third-party code to an immutable reference, and grant the narrowest scope the job needs.",
+      "examples": [
+        { "reference": "#2761", "fact": "Two workflows triggered on issue_comment with no author check, handing repository secrets to any commenter; one also ran a third-party action from a mutable tag." }
+      ]
+    },
+    {
+      "id": "substrate-identity-confusion",
+      "signal": "A replaceable implementation substrate becomes accidentally identified with the logical thing it hosts.",
+      "question": "What identity must survive replacement of this substrate?",
+      "preferred_response": "Name the logical identity separately from its substrate, and make the binding between them explicit and migratable.",
+      "examples": [
+        { "reference": "#2772", "fact": "A committed runtime root's authority was bound to the node DID that happened to provision it, so replacing the node identity silently invalidated the authority relationship." },
+        { "reference": "#2758", "fact": "Exclusion identity was tied to a filesystem inode, so renaming the data root moved the lock out from under a holder." }
+      ]
+    },
+    {
+      "id": "toolchain-nondeterminism",
+      "signal": "The tool version that executes a repository operation depends on what happens to be installed rather than on anything the repository declares.",
+      "question": "Does a canonical owner declare this toolchain, and does every execution path select it?",
+      "preferred_response": "One declared toolchain version with every execution path selecting it, as icn/rust-toolchain.toml already does for Rust.",
+      "examples": [
+        { "reference": "#2770", "fact": "npm 10.9.8 cannot perform any tree-mutating operation in ops/mcp while npm 11 can; no repository surface pins an npm version, so which behaviour applies is an accident of the environment." }
+      ]
+    }
+  ]
+}

--- a/ops/state/truth/engineering-leverage.json
+++ b/ops/state/truth/engineering-leverage.json
@@ -86,7 +86,6 @@
       "predicate": {
         "all_of": {
           "changes_subsystem_boundary": false,
-          "recurring_class_established": true,
           "structural_change_required_or_in_contract": true
         }
       }
@@ -110,8 +109,7 @@
       "constraint": "Record it. Never smuggle it into the current pull request.",
       "predicate": {
         "all_of": {
-          "changes_subsystem_boundary": true,
-          "recurring_class_established": true
+          "changes_subsystem_boundary": true
         }
       }
     },
@@ -121,7 +119,9 @@
       "note": "NONE is a first-class, expected answer. Manufacturing architecture work to satisfy this framework is itself a defect.",
       "predicate": {
         "all_of": {
-          "recurring_class_established": false
+          "changes_subsystem_boundary": false,
+          "recurring_class_established": false,
+          "structural_change_required_or_in_contract": false
         }
       }
     }
@@ -290,6 +290,7 @@
       "changes_subsystem_boundary": "The correction would change a subsystem boundary, state model, authority model, storage model or lifecycle.",
       "structural_change_required_or_in_contract": "The structural correction is necessary for the defect to be CORRECTLY fixed, or it is tiny, obviously safe and squarely inside the current acceptance contract."
     },
-    "rule": "Evaluate every disposition predicate against the facts. Exactly one match is a classification. Zero matches or more than one match is ambiguity and must fail closed \u2014 never resolve it by preferring an expected answer."
+    "rule": "Evaluate every disposition predicate against the facts. Exactly one match is a classification. Zero matches or more than one match is ambiguity and must fail closed \u2014 never resolve it by preferring an expected answer. The three facts partition the input space completely: all eight combinations resolve to exactly one disposition.",
+    "ordering": "The facts are evaluated boundary-first, then required-now, then recurrence, and that order carries the meaning. `changes_subsystem_boundary` decides ARCHITECTURAL on its own, because a change to a subsystem boundary is architectural whether or not it has happened before. `structural_change_required_or_in_contract` then decides NOW, because a correction already necessary for THIS defect to be correctly fixed does not become optional for want of a second occurrence. Recurrence enters last and decides only between FOLLOW_UP and NONE \u2014 it distinguishes systemic follow-up from a one-off, and must never suppress a correction that is already required. An earlier model made recurrence a prerequisite for every non-NONE disposition, so a first-occurrence defect whose structural repair was necessary classified as NONE, contradicting NOW.meaning."
   }
 }

--- a/ops/state/truth/engineering-leverage.json
+++ b/ops/state/truth/engineering-leverage.json
@@ -1,7 +1,6 @@
 {
   "schema": "icn.engineering-leverage.v1",
   "description": "Canonical owner of ICN's systemic-leverage behaviour: the causal escalation an engineering agent performs after establishing a real defect, the closed set of dispositions for a systemic candidate, and the evidence-backed catalogue of recurring defect classes. This file owns HOW an agent reasons from a defect to a structural opportunity. It does NOT own the delivery lifecycle.",
-
   "owner_boundary": {
     "owns": [
       "the stages an agent must distinguish after establishing a defect",
@@ -25,50 +24,108 @@
     ],
     "conflict_rule": "If this file and ops/state/truth/delivery.json disagree, delivery.json wins. A systemic-leverage finding is never itself authority to reopen a frozen pull request, to widen an acceptance contract, or to satisfy the blocker predicate."
   },
-
   "loop": {
-    "description": "Performed only after a defect is ESTABLISHED — reproduced, not suspected. The first four stages are distinct claims and must not be collapsed into one another.",
+    "description": "Performed only after a defect is ESTABLISHED \u2014 reproduced, not suspected. The first four stages are distinct claims and must not be collapsed into one another.",
     "stages": [
-      { "id": "symptom", "asks": "What was observed?", "must_not_be": "an inferred cause" },
-      { "id": "reproduction", "asks": "What sequence reproduces it?", "must_not_be": "a plausible story" },
-      { "id": "immediate_cause", "asks": "Which specific mechanism failed here?", "must_not_be": "a category of mechanism" },
-      { "id": "enabling_mechanism", "asks": "What made this defect POSSIBLE TO WRITE?", "must_not_be": "a restatement of the immediate cause" },
-      { "id": "local_remediation", "asks": "What is the smallest correct repair?", "must_not_be": "the structural correction, unless that IS the smallest correct repair" },
-      { "id": "regression_witness", "asks": "What evidence proves the instance is fixed?", "must_not_be": "a claim that the class is prevented" },
-      { "id": "recurring_class", "asks": "Has this class occurred before, with evidence?", "must_not_be": "a guess that it might recur" },
-      { "id": "structural_options", "asks": "What mechanism would make this class hard or impossible to write?", "must_not_be": "a redesign of an unrelated subsystem" },
-      { "id": "disposition", "asks": "NOW, FOLLOW_UP, ARCHITECTURAL or NONE?", "must_not_be": "omitted" }
+      {
+        "id": "symptom",
+        "asks": "What was observed?",
+        "must_not_be": "an inferred cause"
+      },
+      {
+        "id": "reproduction",
+        "asks": "What sequence reproduces it?",
+        "must_not_be": "a plausible story"
+      },
+      {
+        "id": "immediate_cause",
+        "asks": "Which specific mechanism failed here?",
+        "must_not_be": "a category of mechanism"
+      },
+      {
+        "id": "enabling_mechanism",
+        "asks": "What made this defect POSSIBLE TO WRITE?",
+        "must_not_be": "a restatement of the immediate cause"
+      },
+      {
+        "id": "local_remediation",
+        "asks": "What is the smallest correct repair?",
+        "must_not_be": "the structural correction, unless that IS the smallest correct repair"
+      },
+      {
+        "id": "regression_witness",
+        "asks": "What evidence proves the instance is fixed?",
+        "must_not_be": "a claim that the class is prevented"
+      },
+      {
+        "id": "recurring_class",
+        "asks": "Has this class occurred before, with evidence?",
+        "must_not_be": "a guess that it might recur"
+      },
+      {
+        "id": "structural_options",
+        "asks": "What mechanism would make this class hard or impossible to write?",
+        "must_not_be": "a redesign of an unrelated subsystem"
+      },
+      {
+        "id": "disposition",
+        "asks": "NOW, FOLLOW_UP, ARCHITECTURAL or NONE?",
+        "must_not_be": "omitted"
+      }
     ],
     "claim_separation": {
       "rule": "Proof that an instance is fixed is not proof that a class is prevented. An agent may claim the second only when a mechanism makes the defect unrepresentable or a gate rejects it, and must show which.",
       "why": "Overclaiming prevention retires attention from a class that is still live."
     }
   },
-
   "dispositions": {
     "NOW": {
       "meaning": "The structural correction is necessary for the defect to be CORRECTLY fixed, or it is tiny, obviously safe, and squarely inside the current acceptance contract.",
       "test": "Would a reviewer regard omitting it as leaving the reported defect only partly repaired?",
-      "example": "Two production call sites parse the same fact differently; factoring the already-existing canonical parser is the smallest correct repair."
+      "example": "Two production call sites parse the same fact differently; factoring the already-existing canonical parser is the smallest correct repair.",
+      "predicate": {
+        "all_of": {
+          "changes_subsystem_boundary": false,
+          "recurring_class_established": true,
+          "structural_change_required_or_in_contract": true
+        }
+      }
     },
     "FOLLOW_UP": {
       "meaning": "The defect is correctly fixable locally, but it reveals a broader mechanism worth addressing separately.",
       "test": "Is the local repair complete and provable on its own?",
       "recorded_in": "the pull request's follow-up ledger, owned by ops/state/truth/delivery.json",
-      "example": "One CLI writer forgot the exclusion lock; the local fix joins the lock domain, while the observation that every writer must remember lock policy is separate work."
+      "example": "One CLI writer forgot the exclusion lock; the local fix joins the lock domain, while the observation that every writer must remember lock policy is separate work.",
+      "predicate": {
+        "all_of": {
+          "changes_subsystem_boundary": false,
+          "recurring_class_established": true,
+          "structural_change_required_or_in_contract": false
+        }
+      }
     },
     "ARCHITECTURAL": {
       "meaning": "The opportunity changes a subsystem boundary, state model, authority model, storage model or lifecycle.",
       "test": "Would this change what other subsystems may assume?",
-      "constraint": "Record it. Never smuggle it into the current pull request."
+      "constraint": "Record it. Never smuggle it into the current pull request.",
+      "predicate": {
+        "all_of": {
+          "changes_subsystem_boundary": true,
+          "recurring_class_established": true
+        }
+      }
     },
     "NONE": {
       "meaning": "The defect is genuinely local and establishes no useful recurring class.",
       "test": "Can you name a second real occurrence? If not, NONE is very likely correct.",
-      "note": "NONE is a first-class, expected answer. Manufacturing architecture work to satisfy this framework is itself a defect."
+      "note": "NONE is a first-class, expected answer. Manufacturing architecture work to satisfy this framework is itself a defect.",
+      "predicate": {
+        "all_of": {
+          "recurring_class_established": false
+        }
+      }
     }
   },
-
   "anti_patterns": [
     "Creating an issue for every systemic observation. Search for an existing owner first; a follow-up ledger entry is often sufficient.",
     "Treating an automated reviewer's severity label as authority. Severity is advisory; the blocker predicate in delivery.json decides.",
@@ -76,7 +133,6 @@
     "Answering ARCHITECTURAL to avoid doing a small NOW correction.",
     "Answering NOW to justify a redesign the acceptance contract does not cover."
   ],
-
   "patterns": [
     {
       "id": "duplicated-semantic-owner",
@@ -84,8 +140,14 @@
       "question": "Can there be exactly one authoritative mechanism for deciding whether this fact is true?",
       "preferred_response": "A canonical parser, resolver or state machine that every caller delegates to.",
       "examples": [
-        { "reference": "#2749", "fact": "Treasury DID acceptance existed separately in ceremony validation and in daemon startup parsing, and the two could disagree." },
-        { "reference": "#2768", "fact": "The Cargo workspace root was spelled independently in four agent-facing surfaces; three had drifted to a path that does not exist." }
+        {
+          "reference": "#2749",
+          "fact": "Treasury DID acceptance existed separately in ceremony validation and in daemon startup parsing, and the two could disagree."
+        },
+        {
+          "reference": "#2768",
+          "fact": "The Cargo workspace root was spelled independently in four agent-facing surfaces; three had drifted to a path that does not exist."
+        }
       ]
     },
     {
@@ -94,8 +156,14 @@
       "question": "Can the API make omission impossible rather than merely discouraged?",
       "preferred_response": "A guard or capability token, a typed constructor, an RAII guard, a sealed mutation interface, or a single entrypoint that cannot be bypassed.",
       "examples": [
-        { "reference": "#2749", "fact": "federation add/remove/set performed a read-modify-write of managed configuration without joining the configuration-lock domain; the repair introduced a guard type so loading outside the lock cannot reach the write." },
-        { "reference": "#2759", "fact": "Local maintenance commands opened ceremony stores outside the exclusion domain." }
+        {
+          "reference": "#2749",
+          "fact": "federation add/remove/set performed a read-modify-write of managed configuration without joining the configuration-lock domain; the repair introduced a guard type so loading outside the lock cannot reach the write."
+        },
+        {
+          "reference": "#2759",
+          "fact": "Local maintenance commands opened ceremony stores outside the exclusion domain."
+        }
       ]
     },
     {
@@ -104,7 +172,10 @@
       "question": "Can the policy move behind one typed or executable boundary?",
       "preferred_response": "One boundary that owns the policy, especially for state mutation, identity mutation, configuration mutation, authorisation, durability and exclusion.",
       "examples": [
-        { "reference": "#2749", "fact": "Exclusion policy for managed configuration lived in each CLI branch rather than in one mutation entrypoint." }
+        {
+          "reference": "#2749",
+          "fact": "Exclusion policy for managed configuration lived in each CLI branch rather than in one mutation entrypoint."
+        }
       ]
     },
     {
@@ -113,9 +184,18 @@
       "question": "Is there a test that crosses the persist-and-reopen boundary, rather than two unit tests that agree with themselves?",
       "preferred_response": "A producer -> persist -> reopen -> consumer contract test, and a shared semantic owner for the format.",
       "examples": [
-        { "reference": "#2747", "fact": "init-coop generated an icn.toml that icnd could not load." },
-        { "reference": "#2755", "fact": "The native icnd service never consumed the runtime-root configuration it was provisioned with." },
-        { "reference": "#2750", "fact": "The reachability filter scored persisted trust edges as 0.0 after reopen." }
+        {
+          "reference": "#2747",
+          "fact": "init-coop generated an icn.toml that icnd could not load."
+        },
+        {
+          "reference": "#2755",
+          "fact": "The native icnd service never consumed the runtime-root configuration it was provisioned with."
+        },
+        {
+          "reference": "#2750",
+          "fact": "The reachability filter scored persisted trust edges as 0.0 after reopen."
+        }
       ]
     },
     {
@@ -124,9 +204,18 @@
       "question": "Does this path distinguish 'observed and fine' from 'could not observe'?",
       "preferred_response": "Failure to know must be representable and must never render as knowing success, nor as a knowing contradiction. Fail closed on the unknown.",
       "examples": [
-        { "reference": "#2760", "fact": "A failing cargo-audit step ended the job, so both cargo-deny gates were reported as not-run rather than passing or failing, for five consecutive weeks." },
-        { "reference": "#2749", "fact": "A storage failure reading the cooperative row was rendered as INCONSISTENT — a positive corruption claim — instead of ERROR / state_unreadable." },
-        { "reference": "#2733", "fact": "The generated-index drift check detects drift correctly and then reports it as a warning that cannot fail the job, so the drift persisted and grew." }
+        {
+          "reference": "#2760",
+          "fact": "A failing cargo-audit step ended the job, so both cargo-deny gates were reported as not-run rather than passing or failing, for five consecutive weeks."
+        },
+        {
+          "reference": "#2749",
+          "fact": "A storage failure reading the cooperative row was rendered as INCONSISTENT \u2014 a positive corruption claim \u2014 instead of ERROR / state_unreadable."
+        },
+        {
+          "reference": "#2733",
+          "fact": "The generated-index drift check detects drift correctly and then reports it as a warning that cannot fail the job, so the drift persisted and grew."
+        }
       ]
     },
     {
@@ -135,7 +224,10 @@
       "question": "Should this become an executable, repository-owned harness?",
       "preferred_response": "One harness that owns the sequence and its known traps, rather than a paragraph describing them.",
       "examples": [
-        { "reference": "docs/architecture/protocol-state-migration-mutation-controls.md", "fact": "The mtime-preserving-restore trap was discovered, documented in prose, and then had to be rediscovered, because no code carried it forward." }
+        {
+          "reference": "docs/architecture/protocol-state-migration-mutation-controls.md",
+          "fact": "The mtime-preserving-restore trap was discovered, documented in prose, and then had to be rediscovered, because no code carried it forward."
+        }
       ]
     },
     {
@@ -144,7 +236,10 @@
       "question": "What should happen automatically at creation, at merge, at agent exit and on a periodic health check?",
       "preferred_response": "Lifecycle automation plus safe visibility plus explicit ownership. Never delete dirty, unmerged or process-pinned resources for cleanliness.",
       "examples": [
-        { "reference": "#2652", "fact": "Per-worktree Cargo target directories reached 380 GB across 19 worktrees and filled the development volume; nothing reclaimed them and the remedy documented in agent surfaces was a single-tree cargo clean, which cannot bound a per-worktree total." }
+        {
+          "reference": "#2652",
+          "fact": "Per-worktree Cargo target directories reached 380 GB across 19 worktrees and filled the development volume; nothing reclaimed them and the remedy documented in agent surfaces was a single-tree cargo clean, which cannot bound a per-worktree total."
+        }
       ]
     },
     {
@@ -153,7 +248,10 @@
       "question": "Which actors can reach this, and what does it hold when they do?",
       "preferred_response": "Gate the trigger on repository membership, pin third-party code to an immutable reference, and grant the narrowest scope the job needs.",
       "examples": [
-        { "reference": "#2761", "fact": "Two workflows triggered on issue_comment with no author check, handing repository secrets to any commenter; one also ran a third-party action from a mutable tag." }
+        {
+          "reference": "#2761",
+          "fact": "Two workflows triggered on issue_comment with no author check, handing repository secrets to any commenter; one also ran a third-party action from a mutable tag."
+        }
       ]
     },
     {
@@ -162,8 +260,14 @@
       "question": "What identity must survive replacement of this substrate?",
       "preferred_response": "Name the logical identity separately from its substrate, and make the binding between them explicit and migratable.",
       "examples": [
-        { "reference": "#2772", "fact": "A committed runtime root's authority was bound to the node DID that happened to provision it, so replacing the node identity silently invalidated the authority relationship." },
-        { "reference": "#2758", "fact": "Exclusion identity was tied to a filesystem inode, so renaming the data root moved the lock out from under a holder." }
+        {
+          "reference": "#2772",
+          "fact": "A committed runtime root's authority was bound to the node DID that happened to provision it, so replacing the node identity silently invalidated the authority relationship."
+        },
+        {
+          "reference": "#2758",
+          "fact": "Exclusion identity was tied to a filesystem inode, so renaming the data root moved the lock out from under a holder."
+        }
       ]
     },
     {
@@ -172,8 +276,20 @@
       "question": "Does a canonical owner declare this toolchain, and does every execution path select it?",
       "preferred_response": "One declared toolchain version with every execution path selecting it, as icn/rust-toolchain.toml already does for Rust.",
       "examples": [
-        { "reference": "#2770", "fact": "npm 10.9.8 cannot perform any tree-mutating operation in ops/mcp while npm 11 can; no repository surface pins an npm version, so which behaviour applies is an accident of the environment." }
+        {
+          "reference": "#2770",
+          "fact": "npm 10.9.8 cannot perform any tree-mutating operation in ops/mcp while npm 11 can; no repository surface pins an npm version, so which behaviour applies is an accident of the environment."
+        }
       ]
     }
-  ]
+  ],
+  "classification": {
+    "description": "A disposition is DERIVED from facts about the defect, not chosen and then justified. Each disposition carries a predicate over these facts; exactly one must match, or the classification fails closed. The prose in `meaning` and `test` explains the predicate to a human \u2014 it is not what decides.",
+    "facts": {
+      "recurring_class_established": "A second real occurrence can be named. If it cannot, there is no class.",
+      "changes_subsystem_boundary": "The correction would change a subsystem boundary, state model, authority model, storage model or lifecycle.",
+      "structural_change_required_or_in_contract": "The structural correction is necessary for the defect to be CORRECTLY fixed, or it is tiny, obviously safe and squarely inside the current acceptance contract."
+    },
+    "rule": "Evaluate every disposition predicate against the facts. Exactly one match is a classification. Zero matches or more than one match is ambiguity and must fail closed \u2014 never resolve it by preferring an expected answer."
+  }
 }

--- a/ops/state/truth/skills.json
+++ b/ops/state/truth/skills.json
@@ -116,6 +116,16 @@
     ],
     "icn_level": [
       {
+        "name": "systemic-leverage",
+        "canonical_path": ".agents/skills/systemic-leverage/SKILL.md",
+        "provider_mirrors": [
+          {
+            "path": ".claude/skills/systemic-leverage/SKILL.md",
+            "policy": "exact_mirror"
+          }
+        ]
+      },
+      {
         "name": "bench",
         "canonical_path": ".agents/skills/bench/SKILL.md",
         "provider_mirrors": [

--- a/ops/state/truth/sources.json
+++ b/ops/state/truth/sources.json
@@ -36,6 +36,13 @@
       "not_owned_here": "Merge requirements and merge-mutation semantics stay with merge_policy (ops/state/truth/policy.json#merge) and its executable, tools/icn-merge-pr",
       "checker": "scripts/check-delivery-lifecycle.py"
     },
+    "engineering_leverage": {
+      "owner": "ops/state/truth/engineering-leverage.json",
+      "stability": "slow-changing",
+      "description": "Systemic-leverage behaviour: the causal escalation an engineering agent performs after ESTABLISHING a defect (symptom / reproduction / immediate cause / enabling mechanism / local repair / regression witness), the closed disposition vocabulary NOW | FOLLOW_UP | ARCHITECTURAL | NONE, and the evidence-backed catalogue of recurring defect classes with their preferred structural responses",
+      "not_owned_here": "Lifecycle states, the blocker predicate, freeze entry and follow-up ledger mechanics stay with pr_delivery_lifecycle (ops/state/truth/delivery.json). A systemic-leverage finding is never authority to widen an acceptance contract, reopen a frozen PR, or satisfy the blocker predicate; if the two disagree, delivery.json wins",
+      "checker": "scripts/check-engineering-leverage.py"
+    },
     "agent_operating_contract": {
       "owner": "AGENTS.md",
       "sections": [

--- a/scripts/check-engineering-leverage.py
+++ b/scripts/check-engineering-leverage.py
@@ -106,10 +106,27 @@ def main() -> int:
     )
 
     # ---- 4. every pattern is evidence-backed ------------------------------
+    #
+    # "Resolvable" has to mean resolved. An earlier version of this check
+    # accepted any string containing "/", ".md", ".json" or "#", which let the
+    # absent path `definitely/missing.md` pass as evidence while the gate
+    # reported "clean" — the checker asserting a fact it had not observed, which
+    # is the observational-falsehood pattern this very file catalogues.
+    #
+    # Two reference kinds are accepted, and each is actually checked:
+    #
+    #   #NNNN        an issue or pull request. Validated by FORM only: resolving
+    #                it needs the GitHub API, and a drift gate that fails when
+    #                the network does is a worse gate. The number is not
+    #                verified to exist.
+    #   a repo path  Validated by EXISTENCE, under the repository root. Absolute
+    #                paths and parent traversal are rejected outright: both
+    #                escape the repository, so neither can be durable evidence
+    #                a future reader can follow.
     patterns = doc.get("patterns", [])
     c.ok(len(patterns) >= 5, f"pattern catalogue is too thin to be useful: {len(patterns)}")
     seen: set[str] = set()
-    ref = re.compile(r"(#\d+|/|\.md|\.json)")
+    issue_ref = re.compile(r"^#\d+$")
     for p in patterns:
         pid = p.get("id", "<unnamed>")
         c.ok(pid not in seen, f"duplicate pattern id: {pid}")
@@ -119,10 +136,24 @@ def main() -> int:
         ex = p.get("examples", [])
         c.ok(bool(ex), f"pattern {pid} has no examples — speculative patterns are not allowed here")
         for e in ex:
-            c.ok(
-                bool(ref.search(str(e.get("reference", "")))),
-                f"pattern {pid} example has no resolvable reference (issue/PR/path): {e.get('reference')!r}",
-            )
+            raw = str(e.get("reference", "")).strip()
+            if issue_ref.match(raw):
+                c.ok(True, "")
+            elif raw:
+                bad_shape = raw.startswith("/") or ".." in Path(raw).parts
+                c.ok(
+                    not bad_shape,
+                    f"pattern {pid} reference {raw!r} is absolute or escapes the repository root; "
+                    "evidence must live inside the repository",
+                )
+                if not bad_shape:
+                    c.ok(
+                        (root / raw).exists(),
+                        f"pattern {pid} cites {raw!r}, which does not exist in the repository — "
+                        "a reference that cannot be followed is not evidence",
+                    )
+            else:
+                c.fail(f"pattern {pid} example has no reference at all")
             c.ok(bool(e.get("fact")), f"pattern {pid} example has no fact")
 
     # ---- 5. delivery.json stays the lifecycle owner -----------------------
@@ -178,8 +209,27 @@ def main() -> int:
                 "delivery.json" in body,
                 "the skill must state the delivery boundary it may not cross",
             )
-            for d in DISPOSITIONS:
-                c.ok(d in body, f"the skill must name disposition {d}")
+            # By reference, not by copy. A projection that RESTATES a canonical
+            # meaning goes stale silently: the owner changes, the copy still
+            # reads plausibly, and a check that only asserted each disposition
+            # NAME appeared would keep passing while agents applied outdated
+            # classifications. So the canonical prose must not appear verbatim
+            # in a projection, and the projection must load it instead.
+            for name, spec in doc.get("dispositions", {}).items():
+                for field in ("meaning", "test"):
+                    text = str(spec.get(field, "")).strip()
+                    if len(text) < 24:
+                        continue
+                    c.ok(
+                        text not in body,
+                        f"{entry['canonical_path']} restates the canonical {name}.{field} verbatim "
+                        "— projections must load the meanings, not copy them",
+                    )
+            c.ok(
+                "dispositions" in body and "engineering-leverage.json" in body,
+                "the skill must load dispositions from the canonical owner rather than "
+                "carrying its own list",
+            )
         for m in entry.get("provider_mirrors", []):
             mp = root / m["path"]
             c.ok(mp.is_file(), f"provider mirror missing: {m['path']}")

--- a/scripts/check-engineering-leverage.py
+++ b/scripts/check-engineering-leverage.py
@@ -215,16 +215,31 @@ def main() -> int:
             # NAME appeared would keep passing while agents applied outdated
             # classifications. So the canonical prose must not appear verbatim
             # in a projection, and the projection must load it instead.
+            canonical_prose: list = []
             for name, spec in doc.get("dispositions", {}).items():
                 for field in ("meaning", "test"):
-                    text = str(spec.get(field, "")).strip()
-                    if len(text) < 24:
-                        continue
-                    c.ok(
-                        text not in body,
-                        f"{entry['canonical_path']} restates the canonical {name}.{field} verbatim "
-                        "— projections must load the meanings, not copy them",
+                    canonical_prose.append((f"{name}.{field}", str(spec.get(field, ""))))
+            # Same rule for the loop distinctions. These were copied as a table
+            # while only dispositions were checked, so an owner change would have
+            # left a competing loop definition in an agent-facing projection with
+            # every gate still passing.
+            for st in doc.get("loop", {}).get("stages", []):
+                for field in ("asks", "must_not_be"):
+                    canonical_prose.append(
+                        (f"loop.stages[{st.get('id')}].{field}", str(st.get(field, "")))
                     )
+            cs = doc.get("loop", {}).get("claim_separation", {})
+            canonical_prose.append(("loop.claim_separation.rule", str(cs.get("rule", ""))))
+
+            for label, text in canonical_prose:
+                text = text.strip()
+                if len(text) < 24:
+                    continue
+                c.ok(
+                    text not in body,
+                    f"{entry['canonical_path']} restates the canonical {label} verbatim "
+                    "— projections must render the owner, not copy it",
+                )
             c.ok(
                 "dispositions" in body and "engineering-leverage.json" in body,
                 "the skill must load dispositions from the canonical owner rather than "

--- a/scripts/check-engineering-leverage.py
+++ b/scripts/check-engineering-leverage.py
@@ -1,0 +1,245 @@
+#!/usr/bin/env python3
+"""Drift gate for the engineering-leverage control plane.
+
+Proves that the canonical owner of ICN's systemic-leverage behaviour parses, is
+registered in the truth spine, is projected to exactly the surfaces the registry
+declares, and has not quietly grown a second copy of the delivery lifecycle.
+
+Run from anywhere; resolves the repository root itself.
+"""
+from __future__ import annotations
+
+import json
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+OWNER = "ops/state/truth/engineering-leverage.json"
+SKILL = "systemic-leverage"
+DISPOSITIONS = ["NOW", "FOLLOW_UP", "ARCHITECTURAL", "NONE"]
+# Distinguishing these is the whole point; a catalogue that drops one is not the policy.
+REQUIRED_STAGES = [
+    "symptom",
+    "reproduction",
+    "immediate_cause",
+    "enabling_mechanism",
+    "local_remediation",
+    "regression_witness",
+    "recurring_class",
+    "structural_options",
+    "disposition",
+]
+# Vocabulary that belongs to delivery.json. If it appears as a STATE here, this
+# file has started to become a second lifecycle owner.
+DELIVERY_STATES = {
+    "IMPLEMENTING", "REVIEWING", "FIXING", "VERIFYING", "FROZEN", "MERGING", "DONE",
+}
+
+
+class Check:
+    def __init__(self) -> None:
+        self.n = 0
+        self.errors: list[str] = []
+
+    def ok(self, cond: bool, msg: str) -> bool:
+        self.n += 1
+        if not cond:
+            self.errors.append(msg)
+        return cond
+
+    def fail(self, msg: str) -> None:
+        self.n += 1
+        self.errors.append(msg)
+
+
+def repo_root() -> Path:
+    return Path(
+        subprocess.run(
+            ["git", "rev-parse", "--show-toplevel"],
+            capture_output=True, text=True, check=True,
+        ).stdout.strip()
+    )
+
+
+def main() -> int:
+    root = repo_root()
+    c = Check()
+
+    # ---- 1. the canonical owner exists and parses -------------------------
+    owner_path = root / OWNER
+    if not owner_path.is_file():
+        print(f"check-engineering-leverage: FAIL\n  - canonical owner missing: {OWNER}")
+        return 1
+    try:
+        doc = json.loads(owner_path.read_text())
+    except json.JSONDecodeError as exc:
+        print(f"check-engineering-leverage: FAIL\n  - {OWNER} does not parse: {exc}")
+        return 1
+    c.ok(True, "")
+
+    # ---- 2. the loop keeps its distinct stages ----------------------------
+    stages = [s.get("id") for s in doc.get("loop", {}).get("stages", [])]
+    for want in REQUIRED_STAGES:
+        c.ok(want in stages, f"loop.stages is missing '{want}' — the loop's stages are the policy")
+    c.ok(
+        stages.index("immediate_cause") < stages.index("enabling_mechanism")
+        if "immediate_cause" in stages and "enabling_mechanism" in stages else False,
+        "enabling_mechanism must come after immediate_cause; the ordering is the reasoning",
+    )
+    c.ok(
+        bool(doc.get("loop", {}).get("claim_separation", {}).get("rule")),
+        "loop.claim_separation.rule missing — 'instance fixed' vs 'class prevented' must stay distinct",
+    )
+
+    # ---- 3. dispositions are exactly the closed set -----------------------
+    got = list(doc.get("dispositions", {}).keys())
+    c.ok(got == DISPOSITIONS, f"dispositions must be exactly {DISPOSITIONS}, got {got}")
+    for d in DISPOSITIONS:
+        spec = doc.get("dispositions", {}).get(d, {})
+        c.ok(bool(spec.get("meaning")), f"disposition {d} has no meaning")
+        c.ok(bool(spec.get("test")), f"disposition {d} has no test — it cannot be applied consistently")
+    none = doc.get("dispositions", {}).get("NONE", {})
+    c.ok(
+        "first-class" in json.dumps(none).lower() or "expected" in json.dumps(none).lower(),
+        "NONE must be stated as a legitimate answer, or agents will manufacture architecture work",
+    )
+
+    # ---- 4. every pattern is evidence-backed ------------------------------
+    patterns = doc.get("patterns", [])
+    c.ok(len(patterns) >= 5, f"pattern catalogue is too thin to be useful: {len(patterns)}")
+    seen: set[str] = set()
+    ref = re.compile(r"(#\d+|/|\.md|\.json)")
+    for p in patterns:
+        pid = p.get("id", "<unnamed>")
+        c.ok(pid not in seen, f"duplicate pattern id: {pid}")
+        seen.add(pid)
+        for field in ("signal", "question", "preferred_response"):
+            c.ok(bool(p.get(field)), f"pattern {pid} missing {field}")
+        ex = p.get("examples", [])
+        c.ok(bool(ex), f"pattern {pid} has no examples — speculative patterns are not allowed here")
+        for e in ex:
+            c.ok(
+                bool(ref.search(str(e.get("reference", "")))),
+                f"pattern {pid} example has no resolvable reference (issue/PR/path): {e.get('reference')!r}",
+            )
+            c.ok(bool(e.get("fact")), f"pattern {pid} example has no fact")
+
+    # ---- 5. delivery.json stays the lifecycle owner -----------------------
+    ob = doc.get("owner_boundary", {})
+    c.ok(bool(ob.get("conflict_rule")), "owner_boundary.conflict_rule missing")
+    c.ok(
+        "delivery.json" in json.dumps(ob),
+        "owner_boundary must name ops/state/truth/delivery.json as the lifecycle owner",
+    )
+    c.ok(
+        "delivery.json wins" in ob.get("conflict_rule", ""),
+        "conflict_rule must state that delivery.json wins",
+    )
+    # This file must not redefine lifecycle states.
+    top_level_states = set(doc.get("lifecycle", {}).get("states", []) or [])
+    c.ok(
+        not (top_level_states & DELIVERY_STATES),
+        f"this file declares delivery lifecycle states {sorted(top_level_states & DELIVERY_STATES)} "
+        "— that is a second lifecycle owner",
+    )
+    c.ok(
+        bool(doc.get("anti_patterns")),
+        "anti_patterns missing — the framework must name its own failure modes",
+    )
+
+    # ---- 6. registered in the truth spine --------------------------------
+    spine = json.loads((root / "ops/state/truth/sources.json").read_text())
+    dom = spine.get("domains", {}).get("engineering_leverage")
+    if c.ok(bool(dom), "engineering_leverage is not a registered truth domain in sources.json"):
+        c.ok(dom.get("owner") == OWNER, f"sources.json points engineering_leverage at {dom.get('owner')!r}")
+        c.ok(
+            dom.get("checker") == "scripts/check-engineering-leverage.py",
+            "sources.json must name this checker so the domain is mechanically enforced",
+        )
+        c.ok(
+            "delivery.json" in dom.get("not_owned_here", ""),
+            "sources.json entry must disclaim lifecycle ownership",
+        )
+
+    # ---- 7. the skill projection exists and mirrors exactly ---------------
+    reg = json.loads((root / "ops/state/truth/skills.json").read_text())
+    entry = next(
+        (s for s in reg["skills"]["icn_level"] if s.get("name") == SKILL), None
+    )
+    if c.ok(bool(entry), f"skill {SKILL!r} is not registered in skills.json"):
+        canon = root / entry["canonical_path"]
+        c.ok(canon.is_file(), f"canonical skill missing: {entry['canonical_path']}")
+        if canon.is_file():
+            body = canon.read_text()
+            # The projection must point at the owner, not restate it.
+            c.ok(OWNER in body, f"{entry['canonical_path']} must cite {OWNER} as its canonical source")
+            c.ok(
+                "delivery.json" in body,
+                "the skill must state the delivery boundary it may not cross",
+            )
+            for d in DISPOSITIONS:
+                c.ok(d in body, f"the skill must name disposition {d}")
+        for m in entry.get("provider_mirrors", []):
+            mp = root / m["path"]
+            c.ok(mp.is_file(), f"provider mirror missing: {m['path']}")
+            if mp.is_file() and canon.is_file() and m.get("policy") == "exact_mirror":
+                c.ok(
+                    mp.read_bytes() == canon.read_bytes(),
+                    f"provider mirror drifted from canonical: {m['path']}",
+                )
+
+    # ---- 8. control-plane consumers are wired ----------------------------
+    # A policy nobody is routed to is prose. These surfaces must reference the
+    # skill or the owner by name.
+    consumers = {
+        "AGENTS.md": root / "AGENTS.md",
+        "docs/ai/ICN_CONSTITUTIONAL_CORE.md": root / "docs/ai/ICN_CONSTITUTIONAL_CORE.md",
+    }
+    for label, path in consumers.items():
+        if c.ok(path.is_file(), f"expected consumer missing: {label}"):
+            text = path.read_text()
+            c.ok(
+                SKILL in text or OWNER in text,
+                f"{label} does not reference the systemic-leverage policy — agents will not encounter it",
+            )
+
+    # ---- 9. no second canonical owner ------------------------------------
+    # Naming the vocabulary is fine and expected — sources.json must describe
+    # the domain it registers. What must not exist is a second file that
+    # DECLARES the vocabulary structurally, i.e. carries its own dispositions
+    # or loop-stage definitions. That is the difference between a pointer and
+    # an owner, and only the structural form can drift into a rival authority.
+    for other in (root / "ops/state/truth").glob("*.json"):
+        if other.name == Path(OWNER).name:
+            continue
+        try:
+            od = json.loads(other.read_text())
+        except (OSError, json.JSONDecodeError):
+            continue
+        if not isinstance(od, dict):
+            continue
+        rival = od.get("dispositions")
+        if isinstance(rival, dict) and set(rival) >= set(DISPOSITIONS):
+            c.fail(
+                f"{other.relative_to(root)} declares its own 'dispositions' object covering "
+                f"{DISPOSITIONS} — there must be exactly one canonical owner"
+            )
+        rival_loop = od.get("loop", {})
+        if isinstance(rival_loop, dict) and rival_loop.get("stages"):
+            c.fail(
+                f"{other.relative_to(root)} declares its own 'loop.stages' — "
+                "the systemic-leverage loop has one owner"
+            )
+
+    if c.errors:
+        print("check-engineering-leverage: FAIL")
+        for e in c.errors:
+            print(f"  - {e}")
+        return 1
+    print(f"check-engineering-leverage: clean ({c.n} assertions passed)")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/check-engineering-leverage.py
+++ b/scripts/check-engineering-leverage.py
@@ -54,12 +54,26 @@ class Check:
 
 
 def repo_root() -> Path:
-    return Path(
-        subprocess.run(
-            ["git", "rev-parse", "--show-toplevel"],
-            capture_output=True, text=True, check=True,
-        ).stdout.strip()
-    )
+    """Resolve the repository from THIS FILE, not from the caller's cwd.
+
+    `git rev-parse` run in the caller's working directory answers a different
+    question: it reports whatever repository the caller happens to be standing
+    in. `ops/scripts/drift-check.sh` deliberately derives its own REPO_ROOT and
+    is safe to invoke from anywhere, so a checker it calls must be too —
+    otherwise `cd /tmp && bash .../drift-check.sh` fails on a healthy tree, or,
+    worse, inspects a different checkout. Same resolution as
+    scripts/check-agent-context-spine.py.
+    """
+    try:
+        return Path(
+            subprocess.run(
+                ["git", "rev-parse", "--show-toplevel"],
+                cwd=Path(__file__).resolve().parent,
+                capture_output=True, text=True, check=True,
+            ).stdout.strip()
+        )
+    except (subprocess.CalledProcessError, OSError):
+        return Path(__file__).resolve().parents[1]
 
 
 def main() -> int:

--- a/scripts/check-engineering-leverage.py
+++ b/scripts/check-engineering-leverage.py
@@ -245,6 +245,34 @@ def main() -> int:
                 "the skill must load dispositions from the canonical owner rather than "
                 "carrying its own list",
             )
+
+            # The projection must not instruct a PROSE decision procedure while
+            # the canonical policy says predicates decide. That contradiction is
+            # not hypothetical: adding `classification` left the skill telling
+            # agents to "apply each disposition's own `test` field", which can
+            # read affirmative for two dispositions at once where the predicates
+            # match exactly one.
+            if doc.get("classification", {}).get("rule"):
+                lowered = body.lower()
+                for phrase in ("apply each disposition's own `test`",
+                               "apply each disposition's own test",
+                               "its `test` tells you when it applies"):
+                    c.ok(
+                        phrase not in lowered,
+                        f"{entry['canonical_path']} instructs classification by the prose "
+                        f"`test` field ({phrase!r}), but classification.rule says the "
+                        "structured predicates decide",
+                    )
+                c.ok(
+                    "predicate" in lowered,
+                    f"{entry['canonical_path']} never mentions the predicates, so an agent "
+                    "following it would classify by prose",
+                )
+                c.ok(
+                    "classification" in lowered and "facts" in lowered,
+                    f"{entry['canonical_path']} must route the agent through "
+                    "classification.facts rather than intuition",
+                )
         for m in entry.get("provider_mirrors", []):
             mp = root / m["path"]
             c.ok(mp.is_file(), f"provider mirror missing: {m['path']}")

--- a/scripts/check-engineering-leverage.py
+++ b/scripts/check-engineering-leverage.py
@@ -287,6 +287,32 @@ def main() -> int:
                     f"{entry['canonical_path']} must route the agent through "
                     "classification.facts rather than intuition",
                 )
+
+            # Applicability must key on evidence, not artifact type. A blanket
+            # exemption for "documentation tasks" would have told an agent to
+            # skip the loop on exactly the generated-projection drift defects
+            # this policy's own delivery produced.
+            lowered = body.lower()
+            for phrase in (
+                "writing, research and documentation tasks do not",
+                "skip it entirely for non-engineering work",
+            ):
+                c.ok(
+                    phrase not in lowered,
+                    f"{entry['canonical_path']} exempts work by artifact TYPE ({phrase!r}). "
+                    "The precondition is an established defect; a documentation or "
+                    "generated-projection task can establish one.",
+                )
+            c.ok(
+                "no defect established" in lowered,
+                f"{entry['canonical_path']} must state the no-defect case explicitly, or "
+                "ordinary work will attract ceremonial defect analysis",
+            )
+            c.ok(
+                "whatever the artifact" in lowered or "not artifact type" in lowered,
+                f"{entry['canonical_path']} must state that an established defect triggers the "
+                "loop regardless of artifact type",
+            )
         for m in entry.get("provider_mirrors", []):
             mp = root / m["path"]
             c.ok(mp.is_file(), f"provider mirror missing: {m['path']}")

--- a/scripts/tests/test_context_spine_enforcement.py
+++ b/scripts/tests/test_context_spine_enforcement.py
@@ -36,12 +36,26 @@ SOURCES = "ops/state/truth/sources.json"
 
 
 def repo_root() -> Path:
-    return Path(
-        subprocess.run(
-            ["git", "rev-parse", "--show-toplevel"],
-            capture_output=True, text=True, check=True,
-        ).stdout.strip()
-    )
+    """Resolve the repository from THIS FILE, not from the caller's cwd.
+
+    `git rev-parse` run in the caller's working directory answers a different
+    question: it reports whatever repository the caller happens to be standing
+    in. `ops/scripts/drift-check.sh` deliberately derives its own REPO_ROOT and
+    is safe to invoke from anywhere, so a checker it calls must be too —
+    otherwise `cd /tmp && bash .../drift-check.sh` fails on a healthy tree, or,
+    worse, inspects a different checkout. Same resolution as
+    scripts/check-agent-context-spine.py.
+    """
+    try:
+        return Path(
+            subprocess.run(
+                ["git", "rev-parse", "--show-toplevel"],
+                cwd=Path(__file__).resolve().parent,
+                capture_output=True, text=True, check=True,
+            ).stdout.strip()
+        )
+    except (subprocess.CalledProcessError, OSError):
+        return Path(__file__).resolve().parents[2]
 
 
 def run_checker(root: Path) -> int:

--- a/scripts/tests/test_context_spine_enforcement.py
+++ b/scripts/tests/test_context_spine_enforcement.py
@@ -1,0 +1,120 @@
+#!/usr/bin/env python3
+"""Registering a truth domain without regenerating the spine must fail a gate.
+
+Why this exists
+---------------
+PR #2773 registered `engineering_leverage` in `ops/state/truth/sources.json` and
+did not regenerate `agent-context-spine.json`. Review caught it; no gate did.
+
+Three separate things kept the existing check from binding, and all three were
+true at once:
+
+  * `generated-truth.yml` runs `check-agent-context-spine.py`, captures its exit
+    status correctly, and then reports drift as a `::warning::` that cannot fail
+    the job;
+  * that workflow's `paths:` filter does not include `ops/state/truth/**` — the
+    very input the spine consumes;
+  * `generated-truth` is not a required check.
+
+The repair calls the SAME checker from `ops/scripts/drift-check.sh`, which runs
+inside the required Agent Tooling Drift Check. No second generation mechanism.
+
+This witness proves the enforcement binds rather than merely existing: it
+registers a synthetic domain, confirms the freshness check FAILS, and restores.
+"""
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+CHECKER = "scripts/check-agent-context-spine.py"
+SOURCES = "ops/state/truth/sources.json"
+
+
+def repo_root() -> Path:
+    return Path(
+        subprocess.run(
+            ["git", "rev-parse", "--show-toplevel"],
+            capture_output=True, text=True, check=True,
+        ).stdout.strip()
+    )
+
+
+def run_checker(root: Path) -> int:
+    """Exit status of the freshness checker. Captured directly — never through a pipe."""
+    return subprocess.run(
+        [sys.executable, CHECKER], cwd=root, capture_output=True, text=True
+    ).returncode
+
+
+def main() -> int:
+    root = repo_root()
+    failures: list[str] = []
+
+    # Baseline: the committed tree must be fresh, or the witness below proves nothing.
+    if run_checker(root) != 0:
+        print("test_context_spine_enforcement: FAIL")
+        print("  - baseline is already stale; regenerate with "
+              "`python3 scripts/generate-agent-context-spine.py --write`")
+        return 1
+
+    src = root / SOURCES
+    # Restore from a byte copy, not from git: an uncommitted edit in the working
+    # tree would make `git checkout --` restore the wrong baseline, which has
+    # bitten this repository's mutation work repeatedly.
+    with tempfile.TemporaryDirectory() as tmp:
+        backup = Path(tmp) / "sources.json"
+        shutil.copy2(src, backup)
+        try:
+            doc = json.loads(src.read_text())
+            doc["domains"]["__witness_unregistered_domain__"] = {
+                "owner": "docs/ATLAS.md",
+                "stability": "slow-changing",
+                "description": "Synthetic domain injected by "
+                               "test_context_spine_enforcement.py. If you are reading this in a "
+                               "committed file, the witness aborted before restoring.",
+            }
+            src.write_text(json.dumps(doc, indent=2) + "\n")
+
+            rc = run_checker(root)
+            if rc == 0:
+                failures.append(
+                    "registering a new truth domain without regenerating the context spine left "
+                    "the freshness check GREEN — the enforcement does not bind"
+                )
+        finally:
+            shutil.copy2(backup, src)
+
+    # Prove the restore semantically, not by hash: re-run the checker.
+    if run_checker(root) != 0:
+        failures.append(
+            "restore did not return the tree to a fresh state — the witness has left the "
+            "repository dirty"
+        )
+
+    # The enforcement must live on a path that gates merge.
+    drift = (root / "ops/scripts/drift-check.sh").read_text()
+    if "check-agent-context-spine.py" not in drift:
+        failures.append(
+            "ops/scripts/drift-check.sh does not run the spine checker; generated-truth.yml only "
+            "warns and is not a required check, so nothing would block a stale spine"
+        )
+
+    if failures:
+        print("test_context_spine_enforcement: FAIL")
+        for f in failures:
+            print(f"  - {f}")
+        return 1
+    print(
+        "test_context_spine_enforcement: clean "
+        "(an unregenerated spine fails the checker; enforcement is on the required drift path)"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/tests/test_engineering_leverage.py
+++ b/scripts/tests/test_engineering_leverage.py
@@ -226,6 +226,65 @@ def main() -> int:
              f"{sid}: story classifies as {best!r}, expected {sc['pattern']!r}")
         t.ok(unique, f"{sid}: classification tied; signals do not discriminate")
 
+    # ---- exhaustive partition over the whole fact space ---------------------
+    #
+    # Three booleans is eight combinations, so "exactly one disposition matches"
+    # can be proven rather than sampled. An earlier model made recurrence a
+    # prerequisite for every non-NONE disposition, so a first-occurrence defect
+    # whose structural repair was necessary classified as NONE — contradicting
+    # NOW.meaning, and telling an agent a required correction was merely local.
+    import itertools
+
+    PINNED = {
+        # (boundary, structural_required, recurring): disposition
+        (False, True,  False): ("NOW",
+            "first occurrence whose structural repair is already required must not be "
+            "suppressed for want of a second occurrence"),
+        (True,  False, False): ("ARCHITECTURAL",
+            "a subsystem-boundary change is architectural whether or not it has happened before"),
+        (False, False, False): ("NONE",
+            "first occurrence with no required repair is genuinely local"),
+        (False, False, True):  ("FOLLOW_UP",
+            "recurrence distinguishes systemic follow-up from a one-off, and only that"),
+    }
+
+    seen_combinations = 0
+    for b, sreq, rec in itertools.product([True, False], repeat=3):
+        facts = {
+            "changes_subsystem_boundary": b,
+            "structural_change_required_or_in_contract": sreq,
+            "recurring_class_established": rec,
+        }
+        seen_combinations += 1
+        matched = [
+            n for n, spec in dispositions.items()
+            if all(facts.get(k) == v for k, v in spec["predicate"]["all_of"].items())
+        ]
+        t.ok(
+            len(matched) == 1,
+            f"partition: facts boundary={b} required={sreq} recurring={rec} matched "
+            f"{len(matched)} dispositions {sorted(matched)} — the three facts must partition "
+            "the input space completely, with no gap and no overlap",
+        )
+        if (b, sreq, rec) in PINNED and len(matched) == 1:
+            want, why = PINNED[(b, sreq, rec)]
+            t.ok(
+                matched[0] == want,
+                f"partition: boundary={b} required={sreq} recurring={rec} derived "
+                f"{matched[0]!r}, expected {want!r} — {why}",
+            )
+    t.ok(seen_combinations == 8, f"expected 8 fact combinations, evaluated {seen_combinations}")
+
+    # Recurrence must never be a prerequisite for NOW or ARCHITECTURAL. Asserted
+    # structurally, so the regression cannot come back by predicate edit.
+    for name in ("NOW", "ARCHITECTURAL"):
+        t.ok(
+            "recurring_class_established" not in dispositions[name]["predicate"]["all_of"],
+            f"{name}'s predicate constrains recurring_class_established; a correction that is "
+            "already required, or that changes a subsystem boundary, does not become optional "
+            "because the class has only been seen once",
+        )
+
     # ---- adversarial witnesses ----------------------------------------------
     # (1) Magic wording retained, predicate meaning changed -> must NOT pass.
     import copy
@@ -274,35 +333,38 @@ def main() -> int:
     except Ambiguous:
         t.ok(True, "")
 
-    # (4) Prose can read affirmative for two dispositions where the predicates
-    #     match exactly one. This is review's counterexample, carried as a
-    #     witness: no recurring class, but a boundary-changing correction. The
-    #     ARCHITECTURAL description ("changes a subsystem boundary, state model,
-    #     authority model, storage model or lifecycle") reads TRUE, and the NONE
-    #     description reads TRUE as well — an agent classifying by prose could
-    #     land on either. The predicates are unambiguous because
-    #     recurring_class_established is false.
+    # (4) Prose can point one way where the predicates point another. Review's
+    #     counterexample, corrected: no recurring class, but a boundary-changing
+    #     correction. An agent reading prose can anchor on "no second occurrence,
+    #     so there is no class" and land on NONE. The predicates say
+    #     ARCHITECTURAL, because a subsystem-boundary change is architectural
+    #     whether or not it has happened before.
+    #
+    #     This witness previously asserted NONE here. That expectation encoded
+    #     the very defect review reported — recurrence suppressing a
+    #     classification it should never have governed — and the exhaustive
+    #     partition above is what exposed it.
     prose_trap = {
         "recurring_class_established": False,
         "changes_subsystem_boundary": True,
         "structural_change_required_or_in_contract": False,
     }
-    arch_prose = json.dumps(dispositions["ARCHITECTURAL"]).lower()
+    none_prose = json.dumps(dispositions["NONE"]).lower()
     t.ok(
-        "subsystem boundary" in arch_prose,
-        "the ARCHITECTURAL prose no longer describes a boundary change, so this witness no "
-        "longer demonstrates the trap it was written for",
+        "second real occurrence" in none_prose or "second" in none_prose,
+        "the NONE prose no longer appeals to a second occurrence, so this witness no longer "
+        "demonstrates the pull it was written for",
     )
     try:
         trapped = classify(prose_trap, dispositions)
     except Ambiguous as exc:
         trapped = f"<ambiguous: {exc}>"
     t.ok(
-        trapped == "NONE",
-        f"prose-trap witness: facts with no recurring class but a boundary-changing correction "
-        f"derived {trapped!r}. The predicates must yield NONE here even though the ARCHITECTURAL "
-        "description reads affirmative — otherwise an agent following prose and an agent "
-        "following predicates disagree.",
+        trapped == "ARCHITECTURAL",
+        f"prose-trap witness: first occurrence with a boundary-changing correction derived "
+        f"{trapped!r}, expected 'ARCHITECTURAL'. Prose reading can suggest NONE because no "
+        "second occurrence exists; the predicates must not let recurrence suppress an "
+        "architectural classification.",
     )
 
     # (5) The expected label is not reachable by the classifier.

--- a/scripts/tests/test_engineering_leverage.py
+++ b/scripts/tests/test_engineering_leverage.py
@@ -1,0 +1,164 @@
+#!/usr/bin/env python3
+"""Behaviour fixtures for the systemic-leverage policy.
+
+These do not test prose. They test that the canonical owner actually carries the
+discriminating information an agent needs to reach the intended classification —
+and, importantly, that it still supports answering NONE.
+
+A policy that cannot produce NONE is an architecture-astronaut generator.
+"""
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+OWNER = "ops/state/truth/engineering-leverage.json"
+
+
+def repo_root() -> Path:
+    return Path(
+        subprocess.run(
+            ["git", "rev-parse", "--show-toplevel"],
+            capture_output=True, text=True, check=True,
+        ).stdout.strip()
+    )
+
+
+# Each scenario names the discriminator the policy must supply for an agent to
+# classify it correctly. `pattern` is the catalogue entry that should match, or
+# None when the correct answer is that no class exists.
+SCENARIOS = [
+    {
+        "id": "A_single_typo",
+        "story": "One typo in one error string, in one place.",
+        "pattern": None,
+        "disposition": "NONE",
+        "discriminator": "NONE must be documented as legitimate, or an agent will invent a class",
+    },
+    {
+        "id": "B_two_parsers_drifted",
+        "story": (
+            "Two production paths separately parse the same authority field and "
+            "have already drifted."
+        ),
+        "pattern": "duplicated-semantic-owner",
+        "disposition": "NOW",
+        "discriminator": "NOW's test must key on the repair being incomplete without it",
+    },
+    {
+        "id": "C_one_writer_forgot_the_lock",
+        "story": (
+            "One writer forgot to acquire the lock; five other writers each "
+            "acquire it manually."
+        ),
+        "pattern": "remember-to-do-it-correctness",
+        "disposition": "FOLLOW_UP",
+        "discriminator": "FOLLOW_UP must key on the local repair being complete on its own",
+    },
+    {
+        "id": "D_frozen_pr_redesign_suggestion",
+        "story": (
+            "A frozen PR receives a reviewer suggestion to redesign storage, with "
+            "no current-contract violation."
+        ),
+        "pattern": None,
+        "disposition": "ARCHITECTURAL",
+        "discriminator": "the policy must forbid a systemic observation from reopening a frozen PR",
+    },
+    {
+        "id": "E_harness_selected_zero_tests",
+        "story": "A test harness selects zero tests and exits 0.",
+        "pattern": "observational-falsehood",
+        "disposition": "NOW",
+        "discriminator": "failure-to-know must not be representable as knowing success",
+    },
+]
+
+
+class T:
+    def __init__(self) -> None:
+        self.n = 0
+        self.errors: list[str] = []
+
+    def ok(self, cond: bool, msg: str) -> None:
+        self.n += 1
+        if not cond:
+            self.errors.append(msg)
+
+
+def main() -> int:
+    root = repo_root()
+    doc = json.loads((root / OWNER).read_text())
+    patterns = {p["id"]: p for p in doc["patterns"]}
+    dispositions = doc["dispositions"]
+    t = T()
+
+    for sc in SCENARIOS:
+        sid = sc["id"]
+
+        # The disposition the scenario expects must exist and be applicable.
+        d = dispositions.get(sc["disposition"])
+        t.ok(d is not None, f"{sid}: disposition {sc['disposition']} is not defined")
+        if d:
+            t.ok(
+                bool(d.get("test")),
+                f"{sid}: disposition {sc['disposition']} has no applicability test, so an "
+                "agent cannot reach it deterministically",
+            )
+
+        # The pattern the scenario should match must exist, carry a signal an
+        # agent can match against, and a preferred response.
+        if sc["pattern"] is None:
+            continue
+        p = patterns.get(sc["pattern"])
+        t.ok(p is not None, f"{sid}: expected pattern {sc['pattern']!r} is not in the catalogue")
+        if p:
+            t.ok(bool(p.get("signal")), f"{sid}: pattern {sc['pattern']} has no signal to match on")
+            t.ok(
+                bool(p.get("preferred_response")),
+                f"{sid}: pattern {sc['pattern']} gives no direction, so the agent will invent one",
+            )
+            t.ok(
+                bool(p.get("examples")),
+                f"{sid}: pattern {sc['pattern']} has no precedent, so 'we have seen this before' "
+                "cannot be established from the repository",
+            )
+
+    # Scenario A and D specifically: the policy must make restraint reachable.
+    none = json.dumps(dispositions.get("NONE", {})).lower()
+    t.ok(
+        "second real occurrence" in none or "name a second" in none,
+        "NONE needs a concrete test an agent can apply, not just permission to use it",
+    )
+    anti = json.dumps(doc.get("anti_patterns", [])).lower()
+    t.ok(
+        "manufactur" in anti or "every systemic observation" in anti,
+        "anti_patterns must name architecture-astronaut and issue-spam failure modes",
+    )
+
+    # Scenario D specifically: freeze and scope must be protected in the policy
+    # itself, not only in delivery.json, because the agent reads this file.
+    boundary = json.dumps(doc.get("owner_boundary", {})) + json.dumps(doc.get("dispositions", {}))
+    t.ok("delivery.json" in boundary, "the policy must defer to delivery.json explicitly")
+    arch = dispositions.get("ARCHITECTURAL", {})
+    t.ok(
+        "smuggle" in json.dumps(arch).lower() or "current pull request" in json.dumps(arch).lower(),
+        "ARCHITECTURAL must forbid folding the work into the current pull request",
+    )
+
+    if t.errors:
+        print("test_engineering_leverage: FAIL")
+        for e in t.errors:
+            print(f"  - {e}")
+        return 1
+    print(
+        f"test_engineering_leverage: clean ({t.n} assertions over "
+        f"{len(SCENARIOS)} classification scenarios)"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/tests/test_engineering_leverage.py
+++ b/scripts/tests/test_engineering_leverage.py
@@ -260,7 +260,38 @@ def main() -> int:
     except Ambiguous:
         t.ok(True, "")
 
-    # (4) The expected label is not reachable by the classifier.
+    # (4) Prose can read affirmative for two dispositions where the predicates
+    #     match exactly one. This is review's counterexample, carried as a
+    #     witness: no recurring class, but a boundary-changing correction. The
+    #     ARCHITECTURAL description ("changes a subsystem boundary, state model,
+    #     authority model, storage model or lifecycle") reads TRUE, and the NONE
+    #     description reads TRUE as well — an agent classifying by prose could
+    #     land on either. The predicates are unambiguous because
+    #     recurring_class_established is false.
+    prose_trap = {
+        "recurring_class_established": False,
+        "changes_subsystem_boundary": True,
+        "structural_change_required_or_in_contract": False,
+    }
+    arch_prose = json.dumps(dispositions["ARCHITECTURAL"]).lower()
+    t.ok(
+        "subsystem boundary" in arch_prose,
+        "the ARCHITECTURAL prose no longer describes a boundary change, so this witness no "
+        "longer demonstrates the trap it was written for",
+    )
+    try:
+        trapped = classify(prose_trap, dispositions)
+    except Ambiguous as exc:
+        trapped = f"<ambiguous: {exc}>"
+    t.ok(
+        trapped == "NONE",
+        f"prose-trap witness: facts with no recurring class but a boundary-changing correction "
+        f"derived {trapped!r}. The predicates must yield NONE here even though the ARCHITECTURAL "
+        "description reads affirmative — otherwise an agent following prose and an agent "
+        "following predicates disagree.",
+    )
+
+    # (5) The expected label is not reachable by the classifier.
     import inspect
     sig = set(inspect.signature(classify).parameters)
     t.ok(
@@ -281,7 +312,7 @@ def main() -> int:
         return 1
     print(
         f"test_engineering_leverage: clean ({t.n} assertions; {len(SCENARIOS)} scenarios "
-        "derived from policy predicates; 5 adversarial witnesses)"
+        "derived from policy predicates; 6 adversarial witnesses)"
     )
     return 0
 

--- a/scripts/tests/test_engineering_leverage.py
+++ b/scripts/tests/test_engineering_leverage.py
@@ -27,17 +27,23 @@ def repo_root() -> Path:
     )
 
 
-# Each scenario is classified BY THE POLICY DATA, not by assertion of field
-# existence. `story` is matched against `patterns[].signal`; `discriminator` is a
-# phrase that must appear in the expected disposition's own `test`. Both
-# participate, so mutating a signal or a disposition test breaks the derivation.
+# Each scenario carries structured FACTS. The classifier evaluates the policy's
+# own per-disposition predicates against those facts and derives a disposition.
+#
+# The expected label is NOT an input to the classifier — it is compared only
+# afterwards. That is the difference between proving the policy classifies the
+# story and checking that familiar words are still present somewhere.
 SCENARIOS = [
     {
         "id": "A_single_typo",
         "story": "one typo in one error string in one place",
+        "facts": {
+            "recurring_class_established": False,
+            "changes_subsystem_boundary": False,
+            "structural_change_required_or_in_contract": False,
+        },
         "pattern": None,
-        "disposition": "NONE",
-        "discriminator": "second real occurrence",
+        "expect": "NONE",
     },
     {
         "id": "B_two_parsers_drifted",
@@ -45,9 +51,15 @@ SCENARIOS = [
             "the same authority fact is parsed independently in two production "
             "locations and they have drifted"
         ),
+        "facts": {
+            # Factoring the already-existing canonical parser IS the smallest
+            # correct repair, so the structural correction is not optional.
+            "recurring_class_established": True,
+            "changes_subsystem_boundary": False,
+            "structural_change_required_or_in_contract": True,
+        },
         "pattern": "duplicated-semantic-owner",
-        "disposition": "NOW",
-        "discriminator": "partly repaired",
+        "expect": "NOW",
     },
     {
         "id": "C_one_writer_forgot_the_lock",
@@ -55,9 +67,15 @@ SCENARIOS = [
             "correctness depends on every caller remembering to acquire a lock "
             "before it mutates"
         ),
+        "facts": {
+            # Joining the lock domain is complete and provable on its own; the
+            # guarded-mutation API is separate work.
+            "recurring_class_established": True,
+            "changes_subsystem_boundary": False,
+            "structural_change_required_or_in_contract": False,
+        },
         "pattern": "remember-to-do-it-correctness",
-        "disposition": "FOLLOW_UP",
-        "discriminator": "complete and provable on its own",
+        "expect": "FOLLOW_UP",
     },
     {
         "id": "D_frozen_pr_redesign_suggestion",
@@ -65,9 +83,13 @@ SCENARIOS = [
             "a reviewer proposes changing the storage model and the subsystem "
             "boundary on a frozen pull request"
         ),
+        "facts": {
+            "recurring_class_established": True,
+            "changes_subsystem_boundary": True,
+            "structural_change_required_or_in_contract": False,
+        },
         "pattern": None,
-        "disposition": "ARCHITECTURAL",
-        "discriminator": "smuggle",
+        "expect": "ARCHITECTURAL",
     },
     {
         "id": "E_harness_selected_zero_tests",
@@ -75,9 +97,13 @@ SCENARIOS = [
             "a gate reports success because the mechanism failed to observe the "
             "thing it was supposed to check"
         ),
+        "facts": {
+            "recurring_class_established": True,
+            "changes_subsystem_boundary": False,
+            "structural_change_required_or_in_contract": True,
+        },
         "pattern": "observational-falsehood",
-        "disposition": "NOW",
-        "discriminator": "partly repaired",
+        "expect": "NOW",
     },
 ]
 
@@ -89,15 +115,37 @@ _STOP = {
 }
 
 
-def _tokens(text: str) -> set[str]:
+class Ambiguous(Exception):
+    """Zero or several dispositions matched. Never resolved by preference."""
+
+
+def classify(facts: dict, dispositions: dict) -> str:
+    """Derive a disposition from FACTS alone.
+
+    Takes no expected value and no scenario identity: there is nothing here it
+    could bias toward. Ambiguity raises rather than choosing.
+    """
+    matched = []
+    for name, spec in dispositions.items():
+        pred = (spec.get("predicate") or {}).get("all_of")
+        if not pred:
+            raise Ambiguous(f"disposition {name} carries no predicate to evaluate")
+        if all(facts.get(k) == v for k, v in pred.items()):
+            matched.append(name)
+    if len(matched) != 1:
+        raise Ambiguous(
+            f"{len(matched)} dispositions matched {sorted(matched)} — a classification "
+            "must be uniquely justified, so this fails closed"
+        )
+    return matched[0]
+
+
+def _tokens(text: str) -> set:
     words = re.findall(r"[a-z]+", text.lower())
     out = set()
     for w in words:
         if w in _STOP or len(w) < 4:
             continue
-        # crude stem so "parsed"/"parses"/"parse" and "remembering"/"remember"
-        # meet; enough to make signal text load-bearing without pulling in a
-        # stemming dependency for five fixtures.
         for suf in ("ing", "ed", "es", "s"):
             if w.endswith(suf) and len(w) - len(suf) >= 4:
                 w = w[: -len(suf)]
@@ -107,7 +155,6 @@ def _tokens(text: str) -> set[str]:
 
 
 def classify_pattern(story: str, patterns: list) -> tuple:
-    """Return (best_id, score, unique) derived from the catalogue's own signals."""
     st = _tokens(story)
     scored = sorted(
         ((len(st & _tokens(p["signal"])), p["id"]) for p in patterns), reverse=True
@@ -120,7 +167,7 @@ def classify_pattern(story: str, patterns: list) -> tuple:
 class T:
     def __init__(self) -> None:
         self.n = 0
-        self.errors: list[str] = []
+        self.errors: list = []
 
     def ok(self, cond: bool, msg: str) -> None:
         self.n += 1
@@ -133,42 +180,95 @@ def main() -> int:
     doc = json.loads((root / OWNER).read_text())
     patterns = doc["patterns"]
     dispositions = doc["dispositions"]
+    declared_facts = set(doc.get("classification", {}).get("facts", {}))
     t = T()
 
+    t.ok(bool(declared_facts), "classification.facts is missing; nothing defines the fact space")
+
+    # ---- scenarios are DERIVED, never asserted -------------------------------
     for sc in SCENARIOS:
         sid = sc["id"]
-
-        # --- the disposition must be derivable from its own documented test ---
-        spec = dispositions.get(sc["disposition"])
-        t.ok(spec is not None, f"{sid}: disposition {sc['disposition']} is not defined")
-        if spec:
-            probe = f"{spec.get('meaning','')} {spec.get('test','')} {spec.get('constraint','')} {spec.get('note','')}".lower()
-            t.ok(
-                sc["discriminator"].lower() in probe,
-                f"{sid}: {sc['disposition']} no longer carries the discriminator "
-                f"{sc['discriminator']!r} that makes this scenario classifiable — the policy "
-                "changed and this scenario can no longer be decided from it",
-            )
-
-        # --- the pattern must be derivable from the catalogue's own signals ---
-        best, score, unique = classify_pattern(sc["story"], patterns)
-        if sc["pattern"] is None:
-            # A scenario with no class must not match strongly. This is what
-            # keeps NONE reachable rather than nominal.
-            t.ok(
-                score <= 2,
-                f"{sid}: expected no clear pattern but {best!r} matched with score {score}; "
-                "a catalogue that matches everything cannot produce NONE",
-            )
+        t.ok(
+            set(sc["facts"]) == declared_facts,
+            f"{sid}: scenario facts {sorted(sc['facts'])} do not match the declared fact space "
+            f"{sorted(declared_facts)} — a scenario cannot assert facts the policy does not define",
+        )
+        try:
+            got = classify(sc["facts"], dispositions)
+        except Ambiguous as exc:
+            t.ok(False, f"{sid}: classification failed closed: {exc}")
             continue
         t.ok(
-            best == sc["pattern"],
-            f"{sid}: story classifies as {best!r} (score {score}), expected {sc['pattern']!r} — "
-            "the signal text no longer discriminates this scenario",
+            got == sc["expect"],
+            f"{sid}: policy derives {got!r} from these facts, scenario expects "
+            f"{sc['expect']!r} — the predicates no longer classify this story as specified",
         )
-        t.ok(unique, f"{sid}: classification tied between patterns; signals do not discriminate")
 
-    # NONE and ARCHITECTURAL must remain reachable and constrained.
+        best, score, unique = classify_pattern(sc["story"], patterns)
+        if sc["pattern"] is None:
+            t.ok(score <= 2, f"{sid}: expected no clear pattern but {best!r} matched (score {score})")
+            continue
+        t.ok(best == sc["pattern"],
+             f"{sid}: story classifies as {best!r}, expected {sc['pattern']!r}")
+        t.ok(unique, f"{sid}: classification tied; signals do not discriminate")
+
+    # ---- adversarial witnesses ----------------------------------------------
+    # (1) Magic wording retained, predicate meaning changed -> must NOT pass.
+    import copy
+    drifted = copy.deepcopy(dispositions)
+    drifted["NOW"]["meaning"] = "unrelated text that still says partly repaired"
+    drifted["NOW"]["test"] = "unrelated text that still says partly repaired"
+    drifted["NOW"]["predicate"]["all_of"]["structural_change_required_or_in_contract"] = False
+    b = next(s for s in SCENARIOS if s["id"] == "B_two_parsers_drifted")
+    try:
+        got = classify(b["facts"], drifted)
+        t.ok(
+            got != b["expect"],
+            "keyword-preservation witness: NOW kept the phrase 'partly repaired' while its "
+            "predicate changed, and the suite still derived NOW — the classifier is reading "
+            "prose, not predicates",
+        )
+    except Ambiguous:
+        t.ok(True, "")  # failing closed is also a correct detection
+
+    # (2) Changing scenario facts changes the derived disposition.
+    flipped = dict(b["facts"], structural_change_required_or_in_contract=False)
+    try:
+        moved = classify(flipped, dispositions)
+    except Ambiguous as exc:
+        moved = f"<ambiguous: {exc}>"
+    t.ok(
+        moved == "FOLLOW_UP",
+        "fact-sensitivity witness: flipping structural_change_required_or_in_contract on "
+        f"scenario B derived {moved!r} rather than FOLLOW_UP, so the facts are inert",
+    )
+
+    # (3) Ambiguity fails closed rather than preferring an expected answer.
+    collided = copy.deepcopy(dispositions)
+    collided["FOLLOW_UP"]["predicate"]["all_of"] = dict(
+        collided["NOW"]["predicate"]["all_of"]
+    )
+    try:
+        classify(b["facts"], collided)
+        t.ok(False, "ambiguity witness: two identical predicates did not fail closed")
+    except Ambiguous:
+        t.ok(True, "")
+    unmatchable = {k: None for k in declared_facts}
+    try:
+        classify(unmatchable, dispositions)
+        t.ok(False, "ambiguity witness: unmatchable facts did not fail closed")
+    except Ambiguous:
+        t.ok(True, "")
+
+    # (4) The expected label is not reachable by the classifier.
+    import inspect
+    sig = set(inspect.signature(classify).parameters)
+    t.ok(
+        sig == {"facts", "dispositions"},
+        f"classify() takes {sorted(sig)}; it must see only facts and the policy, never the "
+        "expected label or the scenario identity",
+    )
+
     t.ok("delivery.json" in json.dumps(doc.get("owner_boundary", {})),
          "the policy must defer to delivery.json explicitly")
     t.ok(bool(doc.get("anti_patterns")),
@@ -180,8 +280,8 @@ def main() -> int:
             print(f"  - {e}")
         return 1
     print(
-        f"test_engineering_leverage: clean ({t.n} assertions; "
-        f"{len(SCENARIOS)} scenarios classified from the catalogue)"
+        f"test_engineering_leverage: clean ({t.n} assertions; {len(SCENARIOS)} scenarios "
+        "derived from policy predicates; 5 adversarial witnesses)"
     )
     return 0
 

--- a/scripts/tests/test_engineering_leverage.py
+++ b/scripts/tests/test_engineering_leverage.py
@@ -10,6 +10,7 @@ A policy that cannot produce NONE is an architecture-astronaut generator.
 from __future__ import annotations
 
 import json
+import re
 import subprocess
 import sys
 from pathlib import Path
@@ -26,55 +27,94 @@ def repo_root() -> Path:
     )
 
 
-# Each scenario names the discriminator the policy must supply for an agent to
-# classify it correctly. `pattern` is the catalogue entry that should match, or
-# None when the correct answer is that no class exists.
+# Each scenario is classified BY THE POLICY DATA, not by assertion of field
+# existence. `story` is matched against `patterns[].signal`; `discriminator` is a
+# phrase that must appear in the expected disposition's own `test`. Both
+# participate, so mutating a signal or a disposition test breaks the derivation.
 SCENARIOS = [
     {
         "id": "A_single_typo",
-        "story": "One typo in one error string, in one place.",
+        "story": "one typo in one error string in one place",
         "pattern": None,
         "disposition": "NONE",
-        "discriminator": "NONE must be documented as legitimate, or an agent will invent a class",
+        "discriminator": "second real occurrence",
     },
     {
         "id": "B_two_parsers_drifted",
         "story": (
-            "Two production paths separately parse the same authority field and "
-            "have already drifted."
+            "the same authority fact is parsed independently in two production "
+            "locations and they have drifted"
         ),
         "pattern": "duplicated-semantic-owner",
         "disposition": "NOW",
-        "discriminator": "NOW's test must key on the repair being incomplete without it",
+        "discriminator": "partly repaired",
     },
     {
         "id": "C_one_writer_forgot_the_lock",
         "story": (
-            "One writer forgot to acquire the lock; five other writers each "
-            "acquire it manually."
+            "correctness depends on every caller remembering to acquire a lock "
+            "before it mutates"
         ),
         "pattern": "remember-to-do-it-correctness",
         "disposition": "FOLLOW_UP",
-        "discriminator": "FOLLOW_UP must key on the local repair being complete on its own",
+        "discriminator": "complete and provable on its own",
     },
     {
         "id": "D_frozen_pr_redesign_suggestion",
         "story": (
-            "A frozen PR receives a reviewer suggestion to redesign storage, with "
-            "no current-contract violation."
+            "a reviewer proposes changing the storage model and the subsystem "
+            "boundary on a frozen pull request"
         ),
         "pattern": None,
         "disposition": "ARCHITECTURAL",
-        "discriminator": "the policy must forbid a systemic observation from reopening a frozen PR",
+        "discriminator": "smuggle",
     },
     {
         "id": "E_harness_selected_zero_tests",
-        "story": "A test harness selects zero tests and exits 0.",
+        "story": (
+            "a gate reports success because the mechanism failed to observe the "
+            "thing it was supposed to check"
+        ),
         "pattern": "observational-falsehood",
         "disposition": "NOW",
-        "discriminator": "failure-to-know must not be representable as knowing success",
+        "discriminator": "partly repaired",
     },
 ]
+
+_STOP = {
+    "the", "a", "an", "and", "or", "it", "its", "of", "to", "in", "on", "is",
+    "are", "was", "were", "be", "been", "that", "this", "they", "them", "their",
+    "for", "by", "with", "as", "at", "from", "has", "have", "had", "not", "no",
+    "one", "two", "more", "than", "each", "every", "any", "some", "which",
+}
+
+
+def _tokens(text: str) -> set[str]:
+    words = re.findall(r"[a-z]+", text.lower())
+    out = set()
+    for w in words:
+        if w in _STOP or len(w) < 4:
+            continue
+        # crude stem so "parsed"/"parses"/"parse" and "remembering"/"remember"
+        # meet; enough to make signal text load-bearing without pulling in a
+        # stemming dependency for five fixtures.
+        for suf in ("ing", "ed", "es", "s"):
+            if w.endswith(suf) and len(w) - len(suf) >= 4:
+                w = w[: -len(suf)]
+                break
+        out.add(w)
+    return out
+
+
+def classify_pattern(story: str, patterns: list) -> tuple:
+    """Return (best_id, score, unique) derived from the catalogue's own signals."""
+    st = _tokens(story)
+    scored = sorted(
+        ((len(st & _tokens(p["signal"])), p["id"]) for p in patterns), reverse=True
+    )
+    best_score, best_id = scored[0]
+    unique = len(scored) == 1 or scored[0][0] > scored[1][0]
+    return best_id, best_score, unique
 
 
 class T:
@@ -91,62 +131,48 @@ class T:
 def main() -> int:
     root = repo_root()
     doc = json.loads((root / OWNER).read_text())
-    patterns = {p["id"]: p for p in doc["patterns"]}
+    patterns = doc["patterns"]
     dispositions = doc["dispositions"]
     t = T()
 
     for sc in SCENARIOS:
         sid = sc["id"]
 
-        # The disposition the scenario expects must exist and be applicable.
-        d = dispositions.get(sc["disposition"])
-        t.ok(d is not None, f"{sid}: disposition {sc['disposition']} is not defined")
-        if d:
+        # --- the disposition must be derivable from its own documented test ---
+        spec = dispositions.get(sc["disposition"])
+        t.ok(spec is not None, f"{sid}: disposition {sc['disposition']} is not defined")
+        if spec:
+            probe = f"{spec.get('meaning','')} {spec.get('test','')} {spec.get('constraint','')} {spec.get('note','')}".lower()
             t.ok(
-                bool(d.get("test")),
-                f"{sid}: disposition {sc['disposition']} has no applicability test, so an "
-                "agent cannot reach it deterministically",
+                sc["discriminator"].lower() in probe,
+                f"{sid}: {sc['disposition']} no longer carries the discriminator "
+                f"{sc['discriminator']!r} that makes this scenario classifiable — the policy "
+                "changed and this scenario can no longer be decided from it",
             )
 
-        # The pattern the scenario should match must exist, carry a signal an
-        # agent can match against, and a preferred response.
+        # --- the pattern must be derivable from the catalogue's own signals ---
+        best, score, unique = classify_pattern(sc["story"], patterns)
         if sc["pattern"] is None:
+            # A scenario with no class must not match strongly. This is what
+            # keeps NONE reachable rather than nominal.
+            t.ok(
+                score <= 2,
+                f"{sid}: expected no clear pattern but {best!r} matched with score {score}; "
+                "a catalogue that matches everything cannot produce NONE",
+            )
             continue
-        p = patterns.get(sc["pattern"])
-        t.ok(p is not None, f"{sid}: expected pattern {sc['pattern']!r} is not in the catalogue")
-        if p:
-            t.ok(bool(p.get("signal")), f"{sid}: pattern {sc['pattern']} has no signal to match on")
-            t.ok(
-                bool(p.get("preferred_response")),
-                f"{sid}: pattern {sc['pattern']} gives no direction, so the agent will invent one",
-            )
-            t.ok(
-                bool(p.get("examples")),
-                f"{sid}: pattern {sc['pattern']} has no precedent, so 'we have seen this before' "
-                "cannot be established from the repository",
-            )
+        t.ok(
+            best == sc["pattern"],
+            f"{sid}: story classifies as {best!r} (score {score}), expected {sc['pattern']!r} — "
+            "the signal text no longer discriminates this scenario",
+        )
+        t.ok(unique, f"{sid}: classification tied between patterns; signals do not discriminate")
 
-    # Scenario A and D specifically: the policy must make restraint reachable.
-    none = json.dumps(dispositions.get("NONE", {})).lower()
-    t.ok(
-        "second real occurrence" in none or "name a second" in none,
-        "NONE needs a concrete test an agent can apply, not just permission to use it",
-    )
-    anti = json.dumps(doc.get("anti_patterns", [])).lower()
-    t.ok(
-        "manufactur" in anti or "every systemic observation" in anti,
-        "anti_patterns must name architecture-astronaut and issue-spam failure modes",
-    )
-
-    # Scenario D specifically: freeze and scope must be protected in the policy
-    # itself, not only in delivery.json, because the agent reads this file.
-    boundary = json.dumps(doc.get("owner_boundary", {})) + json.dumps(doc.get("dispositions", {}))
-    t.ok("delivery.json" in boundary, "the policy must defer to delivery.json explicitly")
-    arch = dispositions.get("ARCHITECTURAL", {})
-    t.ok(
-        "smuggle" in json.dumps(arch).lower() or "current pull request" in json.dumps(arch).lower(),
-        "ARCHITECTURAL must forbid folding the work into the current pull request",
-    )
+    # NONE and ARCHITECTURAL must remain reachable and constrained.
+    t.ok("delivery.json" in json.dumps(doc.get("owner_boundary", {})),
+         "the policy must defer to delivery.json explicitly")
+    t.ok(bool(doc.get("anti_patterns")),
+         "anti_patterns must name this framework's own failure modes")
 
     if t.errors:
         print("test_engineering_leverage: FAIL")
@@ -154,8 +180,8 @@ def main() -> int:
             print(f"  - {e}")
         return 1
     print(
-        f"test_engineering_leverage: clean ({t.n} assertions over "
-        f"{len(SCENARIOS)} classification scenarios)"
+        f"test_engineering_leverage: clean ({t.n} assertions; "
+        f"{len(SCENARIOS)} scenarios classified from the catalogue)"
     )
     return 0
 

--- a/scripts/tests/test_engineering_leverage.py
+++ b/scripts/tests/test_engineering_leverage.py
@@ -19,12 +19,26 @@ OWNER = "ops/state/truth/engineering-leverage.json"
 
 
 def repo_root() -> Path:
-    return Path(
-        subprocess.run(
-            ["git", "rev-parse", "--show-toplevel"],
-            capture_output=True, text=True, check=True,
-        ).stdout.strip()
-    )
+    """Resolve the repository from THIS FILE, not from the caller's cwd.
+
+    `git rev-parse` run in the caller's working directory answers a different
+    question: it reports whatever repository the caller happens to be standing
+    in. `ops/scripts/drift-check.sh` deliberately derives its own REPO_ROOT and
+    is safe to invoke from anywhere, so a checker it calls must be too —
+    otherwise `cd /tmp && bash .../drift-check.sh` fails on a healthy tree, or,
+    worse, inspects a different checkout. Same resolution as
+    scripts/check-agent-context-spine.py.
+    """
+    try:
+        return Path(
+            subprocess.run(
+                ["git", "rev-parse", "--show-toplevel"],
+                cwd=Path(__file__).resolve().parent,
+                capture_output=True, text=True, check=True,
+            ).stdout.strip()
+        )
+    except (subprocess.CalledProcessError, OSError):
+        return Path(__file__).resolve().parents[2]
 
 
 # Each scenario carries structured FACTS. The classifier evaluates the policy's
@@ -300,6 +314,22 @@ def main() -> int:
         "expected label or the scenario identity",
     )
 
+    # (7) The gate must be invocable from anywhere. drift-check.sh derives its
+    #     own REPO_ROOT and is safe to run from any cwd; a checker it calls that
+    #     resolves via `git rev-parse` in the CALLER's directory breaks that,
+    #     failing on a healthy tree or inspecting a different checkout entirely.
+    import tempfile
+    checker = root / "scripts" / "check-engineering-leverage.py"
+    with tempfile.TemporaryDirectory() as foreign:
+        rc = subprocess.run(
+            [sys.executable, str(checker)], cwd=foreign, capture_output=True, text=True
+        ).returncode
+    t.ok(
+        rc == 0,
+        f"cwd-independence witness: the checker exits {rc} when run from a foreign directory; "
+        "it must resolve the repository from its own path, as check-agent-context-spine.py does",
+    )
+
     t.ok("delivery.json" in json.dumps(doc.get("owner_boundary", {})),
          "the policy must defer to delivery.json explicitly")
     t.ok(bool(doc.get("anti_patterns")),
@@ -312,7 +342,7 @@ def main() -> int:
         return 1
     print(
         f"test_engineering_leverage: clean ({t.n} assertions; {len(SCENARIOS)} scenarios "
-        "derived from policy predicates; 6 adversarial witnesses)"
+        "derived from policy predicates; 7 adversarial witnesses)"
     )
     return 0
 


### PR DESCRIPTION
## Delivery

- **Delivery lane**: STANDARD (agent control plane; no product code, no protocol surface)
- **Acceptance contract**: ICN has exactly one canonical, repository-owned definition of the systemic-leverage behaviour; relevant engineering agents encounter it without the maintainer prompting for it; every candidate is classified `NOW`/`FOLLOW_UP`/`ARCHITECTURAL`/`NONE`; and a systemic observation cannot widen an active delivery contract.
- **Explicit non-goals**: does not change `delivery.json` semantics, does not add an MCP tool, does not create a second lifecycle, does not add issues for speculative patterns, does not copy the behaviour into every agent definition.

## The behaviour

Fix the defect. Then ask what mechanism allowed that **class** of defect to exist.

The habit is asking *"what would have made this bug difficult or impossible to write?"* rather than only *"what test would catch it next time?"*. Tests remain necessary; prevention is usually higher leverage.

This must not become "every bug triggers a redesign" — so the framework's own failure modes are named in it, and `NONE` is a first-class answer with a concrete test.

## Canonical owner

`ops/state/truth/engineering-leverage.json` owns three things and nothing else:

1. **The loop** — nine stages, four of which are distinct *claims* agents routinely collapse:

   | stage | is not |
   |---|---|
   | `symptom` | an inferred cause |
   | `immediate_cause` | a category of mechanism |
   | `enabling_mechanism` | a restatement of the immediate cause |
   | `regression_witness` | proof the **class** is prevented |

2. **The closed disposition vocabulary** `NOW` / `FOLLOW_UP` / `ARCHITECTURAL` / `NONE`, each with an applicability *test* so it can be reached deterministically rather than by taste.

3. **An evidence-backed catalogue** of ten recurring classes. Every example cites real repository work — the checker rejects a pattern with no resolvable reference, so speculative philosophy cannot enter.

Registered as truth domain `engineering_leverage` with a `not_owned_here` disclaiming lifecycle ownership.

### Why a new owner rather than extending an existing one

`delivery.json` is the precedent: a procedure + vocabularies + dispositions, validated by a checker, referenced by prose surfaces. This is that exact shape.

`docs/ai/ICN_CONSTITUTIONAL_CORE.md` was considered and **rejected** as the home: it is declared `stability: "constant"` and its registry entry explicitly excludes evolving work content, so a catalogue citing #2749 and #2761 cannot live there. It carries a one-line pointer instead.

## Projections — by reference, not by copy

| surface | cost |
|---|---|
| `.agents/skills/systemic-leverage/SKILL.md` | canonical, on-demand |
| `.claude/skills/systemic-leverage/SKILL.md` | `exact_mirror`, registered in `skills.json` |
| `AGENTS.md` §4 | **+1 line** |
| `ICN_CONSTITUTIONAL_CORE.md` | **+7 lines** |
| `icn-code-reviewer.md` (both provider surfaces) | +14 lines, on-demand |

**Eight lines total on surfaces that load every session.** The catalogue is data loaded on demand, not prose injected into every context.

## The boundary that is not negotiable

`delivery.json` remains canonical. This file declares **no** lifecycle states and **no** blocker predicate — the checker asserts both — and its `conflict_rule` states plainly that `delivery.json` wins.

The reviewer paragraph says the same thing at the point where a reviewer would actually be tempted: naming a systemic class changes nothing about a finding's disposition, does not satisfy `blocker_predicate.all_must_hold`, and does not reopen a freeze.

`NONE` has a concrete test — *can you name a second real occurrence?* — and `anti_patterns` names manufacturing architecture work and creating an issue per observation as failure modes of this framework itself.

**No MCP tool was added.** Systemic candidates live in the follow-up ledger `delivery.json` already owns. A second store would be a second truth source.

## Mechanical enforcement

`scripts/check-engineering-leverage.py` — **130 assertions**:

- the owner parses, keeps its stage ordering, and keeps the closed vocabulary
- every pattern is evidence-backed with a resolvable reference
- **no rival file structurally declares** `dispositions` or `loop.stages`
- the truth-spine registration names this checker
- the skill mirror is byte-identical
- the surfaces agents actually read reference the policy — *a policy nobody is routed to is prose*

`scripts/tests/test_engineering_leverage.py` — 26 assertions over 5 scenarios, including the two that matter most: a lone typo must be able to reach `NONE`, and a redesign suggestion on a frozen PR must not reopen it.

Both wired into `ops/scripts/drift-check.sh` and `agent-drift-check.yml` (already a required check).

## Verification

```
check-truth-spine.py                clean
check-skill-registry.py             clean (96 assertions, was 94)
check-delivery-lifecycle.py         OK — 7 states, 5 blocker conditions, 3 provider surfaces
check-agent-capabilities.py         ok — 43 MCP tools, 31 skills, 18 hooks, 3 helpers
check-engineering-leverage.py       clean (130 assertions)
test_engineering_leverage.py        clean (26 assertions / 5 scenarios)
test_skill_registry_invariants.py   clean
test_delivery_lifecycle.py          clean
ops/scripts/drift-check.sh          PASS — 0 errors, 0 warnings
```

The validator was proven to *fail* before the consumers were wired (it correctly reported that `AGENTS.md` and the constitution did not reference the policy), so its consumer check is known to be live rather than vacuous.

## Seeded classes

`duplicated-semantic-owner` · `remember-to-do-it-correctness` · `policy-in-call-sites` · `producer-consumer-semantic-drift` · `observational-falsehood` · `repeated-manual-proof` · `lifecycle-resource-leak` · `trigger-trust-boundary` · `substrate-identity-confusion` · `toolchain-nondeterminism`

Evidenced by #2747, #2749, #2750, #2755, #2759, #2760, #2761, #2768, #2770, #2772, #2733, #2652.

## Invariants

- **determinism** — strengthened on the control plane: the classification vocabulary is closed and each disposition carries an applicability test.
- adversarial-by-default, canonical encodings, no-panics, kernel/app boundaries — not touched; no Rust, no protocol surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)



---

## Follow-up ledger

| finding | thread | disposition | why not a blocker |
|---|---|---|---|
| `check-engineering-leverage.py:97` treats JSON object key **order** as significant (`list(keys()) == DISPOSITIONS`), making the gate brittle to reformatting without strengthening the closed-vocabulary invariant. Prefer an order-independent set comparison. | [thread](https://github.com/InterCooperative-Network/icn/pull/2773#discussion_r-check-97) | **FOLLOW_UP** | Valid, and correctly identified. It fails `violates_stated_contract` and `materially_breaks_it`: the check is **over-strict**, not permissive — it fails closed on a reordering and lets nothing bad through, so the deliverable is not incorrect or unusable. `delivery.json`'s FOLLOW_UP action is *"Do not change the pull request for it"*, so it is recorded here rather than fixed. |

The temptation was to fix it anyway — it is a one-line change in a function this PR already had to correct for the blockers. That is exactly the widening this PR's own policy exists to prevent, so it is deferred.
