### PR TITLE
feat(ops-mcp): let a repository-derived answer name the revision it came from

### DIFF
--- a/ops/mcp/src/diagnostics/source-revision.ts
+++ b/ops/mcp/src/diagnostics/source-revision.ts
@@ -46,13 +46,22 @@ export type SourceResolution = "explicit_root" | "ICN_ROOT" | "server_location";
  * This is a trust boundary, not a configuration list. Inspecting a working tree makes git apply
  * repository-controlled behaviour to its contents — `.gitattributes` plus a `filter.<driver>.clean`
  * command is executed by `git status` (verified with git 2.43), and it is not the only such
- * mechanism, nor a bounded set. Reading refs and objects does not: `rev-parse` and `rev-list`
- * touch no working-tree content and run no filters.
+ * mechanism, nor a bounded set.
  *
- * So a caller-selected checkout gets ref and object reads only. Its cleanliness is reported as
- * indeterminate rather than probed, because the probe is the exposure. Enumerating individual git
- * knobs was tried and abandoned as the wrong abstraction; removing the dependence on caller
- * working trees altogether is R1-B's job, and this is the bounded bridge until then.
+ * An earlier version of this bridge drew the line at "ref and object reads are inert". That
+ * premise is NOT safe to assert: on a partial clone, traversing objects can trigger a lazy fetch
+ * from a promisor remote, and a remote URL may be `ext::<command>`, which runs a command. Both are
+ * documented git behaviours. Rather than defend a premise that cannot be proven, the line is drawn
+ * where it can be:
+ *
+ *   a caller-selected checkout gets REF RESOLUTION ONLY — no working-tree inspection and no
+ *   object traversal.
+ *
+ * Identity (`HEAD`, its ref name, the upstream's name) survives; cleanliness and divergence are
+ * reported as indeterminate, because the probes that would establish them are the exposure.
+ * Enumerating individual git knobs was tried and abandoned as the wrong abstraction; removing the
+ * dependence on caller working trees altogether is R1-B's job, and this is the bounded bridge
+ * until then.
  */
 export type SourceProvenance = "controlled" | "caller_selected";
 
@@ -185,9 +194,15 @@ async function gitProbe(
     timeoutMs: GIT_TIMEOUT_MS,
     maxStdoutBytes: GIT_MAX_OUTPUT_BYTES,
     maxStderrBytes: 16 * 1024,
-    // GIT_OPTIONAL_LOCKS=0 keeps `git status` from refreshing/writing the index of a tree this
-    // probe is only observing — a diagnostic must not mutate another lane's working state.
-    env: { ...GIT_SANITISED_ENV, GIT_OPTIONAL_LOCKS: "0" },
+    // GIT_OPTIONAL_LOCKS=0 keeps a probe from writing to a tree it only observes.
+    // GIT_NO_LAZY_FETCH=1 keeps a missing object from reaching out to a promisor remote, which
+    // could be an `ext::` URL and therefore a command. Defence in depth: caller-selected sources
+    // no longer traverse objects at all.
+    env: {
+      ...GIT_SANITISED_ENV,
+      GIT_OPTIONAL_LOCKS: "0",
+      GIT_NO_LAZY_FETCH: "1",
+    },
   });
   if (!r.ok) return { ok: false, timedOut: r.timedOut };
   if (wasTruncated(r.stdout)) return { ok: false, timedOut: false, truncated: true };
@@ -364,7 +379,13 @@ export async function describeSourceRevision(
   let behind: number | null = null;
   let ahead: number | null = null;
   let observedAt: Date | null = null;
-  if (upstream) {
+  if (upstream && !inspectWorkingTree) {
+    // Object traversal is withheld for the same reason the working tree is: see SourceProvenance.
+    warnings.push(
+      `divergence from ${upstream} was not measured: doing so traverses objects, which a ` +
+        "caller-selected repository can turn into a fetch from a remote it controls"
+    );
+  } else if (upstream) {
     // Symmetric difference. `HEAD..upstream` counts one direction only, so a clean branch with
     // an unpushed commit would read as "0 behind" and pass for level while holding work that
     // exists nowhere else.

--- a/ops/mcp/src/diagnostics/source-revision.ts
+++ b/ops/mcp/src/diagnostics/source-revision.ts
@@ -1,0 +1,186 @@
+/**
+ * Provenance for repository-derived answers.
+ *
+ * The MCP server resolves "the repository" from whatever tree hosts the compiled
+ * binary (see resolveMonorepoRoot in ../paths.ts), or from ICN_ROOT when it is
+ * set. That tree is not necessarily current, and it is not necessarily clean:
+ * on the development host, three separate checkouts answer to the name "main" at
+ * three different revisions, and orientation answers have so far carried no way
+ * to tell which one produced them.
+ *
+ * This module does not choose a better source — that is a separate change. It
+ * makes the source the server already uses describe itself, so that a stale or
+ * dirty answer says so instead of looking identical to a current one.
+ *
+ * Failure is reported, never assumed away: when a probe cannot run, the
+ * corresponding field is null and `trustworthy` is false. A source whose
+ * cleanliness could not be determined must never be presented as clean.
+ */
+
+import { resolveMonorepoRoot } from "../paths.js";
+import { runCommand } from "../utils/commands.js";
+
+/** How the repository root the answer came from was chosen. */
+export type SourceResolution = "ICN_ROOT" | "server_location";
+
+export type SourceRevision = {
+  /** Absolute path of the checkout this answer was produced from. */
+  source_checkout: string;
+  /** How that path was chosen. */
+  resolved_from: SourceResolution;
+  /** Full commit SHA of that checkout's HEAD; null when it is not a git tree. */
+  source_revision: string | null;
+  /** Branch name, or "HEAD" when detached; null when unknown. */
+  source_ref: string | null;
+  /** Upstream tracking ref (e.g. "origin/main"); null when there is none. */
+  upstream: string | null;
+  /** True/false when determined; null when the probe could not run. */
+  dirty: boolean | null;
+  /** Number of paths reported by `git status --porcelain`; null when unknown. */
+  dirty_paths: number | null;
+  /** Commits the checkout is behind its upstream; null when unknown/no upstream. */
+  behind_upstream: number | null;
+  /**
+   * True only when the revision is known, the tree is known-clean, and it is
+   * known to be level with its upstream. Any unknown makes this false.
+   */
+  trustworthy: boolean;
+  /** Human-readable reasons `trustworthy` is false. Empty when it is true. */
+  warnings: string[];
+};
+
+// Matches the git poller's budget (polling/git.ts). A cold `git status` on a checkout of a
+// few thousand files whose index has not been touched for days has to re-stat the tree, and
+// was observed exceeding a 5s budget on this repository — which fails closed to "unknown"
+// and would report a perfectly clean reference checkout as untrusted.
+const GIT_TIMEOUT_MS = 15_000;
+
+type GitProbe =
+  | { ok: true; out: string }
+  | { ok: false; timedOut: boolean };
+
+async function gitProbe(
+  cwd: string,
+  args: readonly string[]
+): Promise<GitProbe> {
+  const r = await runCommand("git", args, {
+    cwd,
+    timeoutMs: GIT_TIMEOUT_MS,
+    maxStdoutBytes: 256 * 1024,
+    maxStderrBytes: 16 * 1024,
+  });
+  return r.ok ? { ok: true, out: r.stdout.trim() } : { ok: false, timedOut: r.timedOut };
+}
+
+async function git(cwd: string, args: readonly string[]): Promise<string | null> {
+  const r = await gitProbe(cwd, args);
+  return r.ok ? r.out : null;
+}
+
+/**
+ * Describe the checkout a repository-derived answer was produced from.
+ *
+ * `root` defaults to the same root the diagnostics themselves read, so the
+ * stamp always describes the tree that actually produced the payload rather
+ * than a separately resolved one.
+ */
+export async function describeSourceRevision(
+  root?: string
+): Promise<SourceRevision> {
+  const resolvedFrom: SourceResolution = process.env["ICN_ROOT"]
+    ? "ICN_ROOT"
+    : "server_location";
+  const checkout = root ?? resolveMonorepoRoot();
+  const warnings: string[] = [];
+
+  const revision = await git(checkout, ["rev-parse", "HEAD"]);
+  if (!revision) {
+    // Not a git tree, or git is unavailable. Everything below is unknowable.
+    warnings.push(
+      `source checkout is not a readable git tree (${checkout}); this answer cannot be tied to a revision`
+    );
+    return {
+      source_checkout: checkout,
+      resolved_from: resolvedFrom,
+      source_revision: null,
+      source_ref: null,
+      upstream: null,
+      dirty: null,
+      dirty_paths: null,
+      behind_upstream: null,
+      trustworthy: false,
+      warnings,
+    };
+  }
+
+  const ref = await git(checkout, ["rev-parse", "--abbrev-ref", "HEAD"]);
+  const upstream = await git(checkout, [
+    "rev-parse",
+    "--abbrev-ref",
+    "--symbolic-full-name",
+    "@{u}",
+  ]);
+
+  // `git status --porcelain` prints one line per changed path and nothing when
+  // clean. A failed probe is "unknown", never "clean" — reporting an
+  // undetermined tree as clean is the exact failure this stamp exists to remove.
+  const status = await gitProbe(checkout, ["status", "--porcelain"]);
+  let dirty: boolean | null = null;
+  let dirtyPaths: number | null = null;
+  if (!status.ok) {
+    // Why it failed is reported, so an operator can tell a corrupt index from a slow one.
+    const cause = status.timedOut
+      ? ` (git status exceeded ${GIT_TIMEOUT_MS}ms)`
+      : "";
+    warnings.push(
+      `could not determine whether the source checkout is clean${cause}; treating it as untrusted`
+    );
+  } else {
+    dirtyPaths = status.out.length === 0 ? 0 : status.out.split("\n").length;
+    dirty = dirtyPaths > 0;
+    if (dirty) {
+      warnings.push(
+        `source checkout has ${dirtyPaths} uncommitted path(s); this answer may describe unreviewed local edits`
+      );
+    }
+  }
+
+  let behind: number | null = null;
+  if (upstream) {
+    const raw = await git(checkout, [
+      "rev-list",
+      "--count",
+      `HEAD..${upstream}`,
+    ]);
+    const n = raw === null ? NaN : Number.parseInt(raw, 10);
+    behind = Number.isFinite(n) ? n : null;
+    if (behind === null) {
+      warnings.push(
+        `could not measure distance from ${upstream}; treating staleness as unknown`
+      );
+    } else if (behind > 0) {
+      warnings.push(
+        `source checkout is ${behind} commit(s) behind ${upstream}; this answer describes an older revision`
+      );
+    }
+  } else {
+    warnings.push(
+      "source checkout has no upstream tracking ref; its staleness cannot be measured"
+    );
+  }
+
+  const trustworthy = dirty === false && behind === 0;
+
+  return {
+    source_checkout: checkout,
+    resolved_from: resolvedFrom,
+    source_revision: revision,
+    source_ref: ref,
+    upstream,
+    dirty,
+    dirty_paths: dirtyPaths,
+    behind_upstream: behind,
+    trustworthy,
+    warnings,
+  };
+}

--- a/ops/mcp/src/diagnostics/source-revision.ts
+++ b/ops/mcp/src/diagnostics/source-revision.ts
@@ -57,18 +57,40 @@ export type SourceRevision = {
   /**
    * Commits behind the LOCAL tracking ref. No fetch is performed, so this is a LOWER BOUND on
    * staleness and never an overestimate — a checkout that has not fetched since the remote moved
-   * reports 0 while being arbitrarily far behind. Read it together with `upstream_observed_at`.
+   * reports 0 while being arbitrarily far behind. Read it together with `remote_currency`.
    */
   behind_upstream: number | null;
-  /** ISO time the tracking refs were last updated from the remote; null when never/unknown. */
+  /**
+   * Commits the checkout holds that its tracking ref does not. `HEAD..upstream` counts only one
+   * direction, so a clean branch carrying an unpushed commit is "0 behind" while containing
+   * work that exists nowhere else — not level, and not something an orientation answer should
+   * present as canonical.
+   */
+  ahead_of_upstream: number | null;
+  /**
+   * ISO mtime of FETCH_HEAD: evidence that SOME fetch happened. It is repository-wide and
+   * refspec-dependent — `git fetch origin somebranch` refreshes it without touching this
+   * upstream — so it is an upper bound on this ref's freshness and never proof about it.
+   */
   upstream_observed_at: string | null;
   /**
-   * True only when the revision is known, the tree is known-clean, it is level with its tracking
-   * ref, AND that tracking ref was refreshed recently enough to mean anything. Any unknown makes
-   * this false.
+   * Always "unverified" here. Git records no per-ref "when was this last checked against the
+   * remote" (remote-tracking refs carry no reflog in this configuration), so no local evidence
+   * can establish currency. Only an actual fetch can, which is R1-B's job.
+   */
+  remote_currency: "unverified";
+  /**
+   * True when the revision is known, the tree is known-clean, and it is exactly level with its
+   * tracking ref in BOTH directions. Any unknown makes it false. This is a statement about
+   * local faithfulness only — it deliberately does not claim the remote has not moved, because
+   * nothing available here could prove that.
    */
   trustworthy: boolean;
-  /** Human-readable reasons `trustworthy` is false. Empty when it is true. */
+  /**
+   * Conditions a reader must account for, including staleness risk. A non-empty list does not
+   * by itself mean `trustworthy` is false: a checkout can be perfectly faithful to a tracking
+   * ref that is itself old.
+   */
   warnings: string[];
 };
 
@@ -79,13 +101,13 @@ export type SourceRevision = {
 const GIT_TIMEOUT_MS = 15_000;
 
 /**
- * How recently the tracking refs must have been refreshed for `behind_upstream == 0` to support
- * a claim of currency. `@{u}` is a LOCAL ref: a host that never fetches shows 0 behind forever,
- * which is exactly the stale-but-confident state this module exists to expose. An hour is short
- * enough that a host syncing on any normal cadence stays certified, and long enough that the
- * flag is not permanently false on a healthy machine.
+ * Age beyond which fetch evidence is reported as too old to reason about. `@{u}` is a LOCAL
+ * ref: a host that never fetches shows 0 behind forever, which is the stale-but-confident state
+ * this module exists to expose. This drives a WARNING, not the `trustworthy` flag — see
+ * `remote_currency`: the available evidence (repository-wide FETCH_HEAD) cannot be tied to a
+ * particular tracking ref, so it can raise suspicion but must not be used to certify.
  */
-const UPSTREAM_FRESHNESS_WINDOW_MS = 60 * 60 * 1000;
+const UPSTREAM_STALE_AFTER_MS = 60 * 60 * 1000;
 
 // Repository-configured executables are disabled per invocation rather than relying on the
 // caller's git config being benign.
@@ -164,7 +186,9 @@ export async function describeSourceRevision(
       dirty: null,
       dirty_paths: null,
       behind_upstream: null,
+      ahead_of_upstream: null,
       upstream_observed_at: null,
+      remote_currency: "unverified",
       trustworthy: false,
       warnings,
     };
@@ -200,31 +224,50 @@ export async function describeSourceRevision(
   }
 
   let behind: number | null = null;
+  let ahead: number | null = null;
   let observedAt: Date | null = null;
   if (upstream) {
-    const raw = await git(checkout, ["rev-list", "--count", `HEAD..${upstream}`]);
-    const n = raw === null ? NaN : Number.parseInt(raw, 10);
-    behind = Number.isFinite(n) ? n : null;
-    if (behind === null) {
+    // Symmetric difference. `HEAD..upstream` counts one direction only, so a clean branch with
+    // an unpushed commit would read as "0 behind" and pass for level while holding work that
+    // exists nowhere else.
+    const raw = await git(checkout, [
+      "rev-list",
+      "--left-right",
+      "--count",
+      `HEAD...${upstream}`,
+    ]);
+    const parts = raw === null ? [] : raw.split(/\s+/).filter(Boolean);
+    const a = parts.length === 2 ? Number.parseInt(parts[0] as string, 10) : NaN;
+    const b = parts.length === 2 ? Number.parseInt(parts[1] as string, 10) : NaN;
+    ahead = Number.isFinite(a) ? a : null;
+    behind = Number.isFinite(b) ? b : null;
+    if (ahead === null || behind === null) {
       warnings.push(
-        `could not measure distance from ${upstream}; treating staleness as unknown`
+        `could not measure divergence from ${upstream}; treating staleness as unknown`
       );
-    } else if (behind > 0) {
-      warnings.push(
-        `source checkout is ${behind} commit(s) behind ${upstream}; this answer describes an older revision`
-      );
+    } else {
+      if (behind > 0) {
+        warnings.push(
+          `source checkout is ${behind} commit(s) behind ${upstream}; this answer describes an older revision`
+        );
+      }
+      if (ahead > 0) {
+        warnings.push(
+          `source checkout holds ${ahead} commit(s) not in ${upstream}; this answer includes work that exists nowhere else`
+        );
+      }
     }
 
     observedAt = await upstreamObservedAt(checkout);
     const age = observedAt === null ? null : Date.now() - observedAt.getTime();
     if (age === null) {
       warnings.push(
-        `no record of ${upstream} ever being fetched, so distance from the remote is a lower bound only and currency cannot be established`
+        `no record of any fetch in this checkout, so distance from ${upstream} is a lower bound and the remote may have moved`
       );
-    } else if (age > UPSTREAM_FRESHNESS_WINDOW_MS) {
+    } else if (age > UPSTREAM_STALE_AFTER_MS) {
       const hours = Math.floor(age / 3_600_000);
       warnings.push(
-        `${upstream} was last fetched ${hours}h ago, so "${behind ?? "?"} behind" is a lower bound; the remote may have moved since`
+        `last fetch in this checkout was ${hours}h ago, so distance from ${upstream} is a lower bound; the remote may have moved since`
       );
     }
   } else {
@@ -233,10 +276,8 @@ export async function describeSourceRevision(
     );
   }
 
-  const upstreamFresh =
-    observedAt !== null &&
-    Date.now() - observedAt.getTime() <= UPSTREAM_FRESHNESS_WINDOW_MS;
-  const trustworthy = dirty === false && behind === 0 && upstreamFresh;
+  // Local faithfulness only. Remote currency is deliberately excluded: see `remote_currency`.
+  const trustworthy = dirty === false && behind === 0 && ahead === 0;
 
   return {
     source_checkout: checkout,
@@ -247,7 +288,9 @@ export async function describeSourceRevision(
     dirty,
     dirty_paths: dirtyPaths,
     behind_upstream: behind,
+    ahead_of_upstream: ahead,
     upstream_observed_at: observedAt === null ? null : observedAt.toISOString(),
+    remote_currency: "unverified",
     trustworthy,
     warnings,
   };

--- a/ops/mcp/src/diagnostics/source-revision.ts
+++ b/ops/mcp/src/diagnostics/source-revision.ts
@@ -159,7 +159,7 @@ const GIT_SAFE_FLAGS = ["-c", "core.fsmonitor=", "-c", "core.hooksPath=/dev/null
  */
 const STATUS_ARGS = ["status", "--porcelain", "--untracked-files=normal"] as const;
 
-type GitProbe =
+export type GitProbe =
   | { ok: true; out: string }
   | { ok: false; timedOut: boolean; truncated?: boolean };
 
@@ -230,21 +230,43 @@ export async function headRevision(checkout: string): Promise<string | null> {
  *
  * `null` means the state could not be determined, which never compares equal to anything.
  */
-export async function worktreeFingerprint(
+/**
+ * A snapshot of the guarded state, plus the raw probe that produced it.
+ *
+ * The probe is carried out so the caller can reuse it. `git status` is the expensive part of
+ * this module, and the before/after guard already requires two of them; describing the source
+ * from a third scan of the same tree bought nothing but latency.
+ */
+export type WorktreeSnapshot = {
+  fingerprint: string | null;
+  status: GitProbe | null;
+};
+
+export async function snapshotWorktree(
   checkout: string,
   provenance: SourceProvenance = "controlled"
-): Promise<string | null> {
+): Promise<WorktreeSnapshot> {
   const head = await headRevision(checkout);
-  if (head === null) return null;
+  if (head === null) return { fingerprint: null, status: null };
   if (provenance === "caller_selected") {
     // The working tree of a caller-selected checkout is never read, so the guard degrades to the
     // commit alone. Nothing is certified from such a source anyway — `trustworthy` is already
     // false — so this weakens no claim that was being made.
-    return `${head}:worktree-not-inspected`;
+    return { fingerprint: `${head}:worktree-not-inspected`, status: null };
   }
   const status = await gitProbe(checkout, STATUS_ARGS);
-  if (!status.ok) return null;
-  return `${head}:${createHash("sha256").update(status.out).digest("hex")}`;
+  if (!status.ok) return { fingerprint: null, status };
+  return {
+    fingerprint: `${head}:${createHash("sha256").update(status.out).digest("hex")}`,
+    status,
+  };
+}
+
+export async function worktreeFingerprint(
+  checkout: string,
+  provenance: SourceProvenance = "controlled"
+): Promise<string | null> {
+  return (await snapshotWorktree(checkout, provenance)).fingerprint;
 }
 
 /** When the tracking refs were last updated from the remote, via FETCH_HEAD's mtime. */
@@ -266,7 +288,13 @@ async function upstreamObservedAt(checkout: string): Promise<Date | null> {
  */
 export async function describeSourceRevision(
   root?: string,
-  provenance: SourceProvenance = "controlled"
+  provenance: SourceProvenance = "controlled",
+  /**
+   * An already-taken snapshot of the same checkout, reused instead of re-probing. The caller is
+   * responsible for it describing this checkout; passing a stale or foreign one would misreport
+   * cleanliness, so the only caller that supplies it is the one that just took it.
+   */
+  snapshot?: WorktreeSnapshot
 ): Promise<SourceRevision> {
   // An explicitly supplied root is how it was chosen, regardless of what the environment says.
   // icn_ops_agent_runtime deliberately overrides ICN_ROOT with the caller's lane; reporting
@@ -331,7 +359,7 @@ export async function describeSourceRevision(
         "cleanliness is indeterminate and this source cannot be certified"
     );
   } else {
-  const status = await gitProbe(checkout, STATUS_ARGS);
+  const status = snapshot?.status ?? (await gitProbe(checkout, STATUS_ARGS));
   if (!status.ok) {
     const cause = status.timedOut ? ` (git status exceeded ${GIT_TIMEOUT_MS}ms)` : "";
     warnings.push(

--- a/ops/mcp/src/diagnostics/source-revision.ts
+++ b/ops/mcp/src/diagnostics/source-revision.ts
@@ -238,8 +238,18 @@ export async function headRevision(checkout: string): Promise<string | null> {
  * from a third scan of the same tree bought nothing but latency.
  */
 export type WorktreeSnapshot = {
+  /** Commit + working-tree + index-flag state, hashed. Null when it could not be determined. */
   fingerprint: string | null;
+  /** The commit this snapshot was taken at. */
+  head: string | null;
+  /** The raw `status` probe, carried so a description can reuse it rather than re-scanning. */
   status: GitProbe | null;
+  /**
+   * The raw `ls-files -v` probe. Part of the fingerprint because `status` omits files flagged
+   * `assume-unchanged` or `skip-worktree`: without it, a tracked file modified under a flag and
+   * then restored AND unflagged across the read leaves both fingerprints identical.
+   */
+  indexFlags: GitProbe | null;
 };
 
 export async function snapshotWorktree(
@@ -247,19 +257,31 @@ export async function snapshotWorktree(
   provenance: SourceProvenance = "controlled"
 ): Promise<WorktreeSnapshot> {
   const head = await headRevision(checkout);
-  if (head === null) return { fingerprint: null, status: null };
+  if (head === null) {
+    return { fingerprint: null, head: null, status: null, indexFlags: null };
+  }
   if (provenance === "caller_selected") {
     // The working tree of a caller-selected checkout is never read, so the guard degrades to the
     // commit alone. Nothing is certified from such a source anyway — `trustworthy` is already
     // false — so this weakens no claim that was being made.
-    return { fingerprint: `${head}:worktree-not-inspected`, status: null };
+    return {
+      fingerprint: `${head}:worktree-not-inspected`,
+      head,
+      status: null,
+      indexFlags: null,
+    };
   }
   const status = await gitProbe(checkout, STATUS_ARGS);
-  if (!status.ok) return { fingerprint: null, status };
-  return {
-    fingerprint: `${head}:${createHash("sha256").update(status.out).digest("hex")}`,
-    status,
-  };
+  const indexFlags = await gitProbe(checkout, ["ls-files", "-v"]);
+  if (!status.ok || !indexFlags.ok) {
+    return { fingerprint: null, head, status, indexFlags };
+  }
+  const digest = createHash("sha256")
+    .update(status.out)
+    .update("\u0000")
+    .update(indexFlags.out)
+    .digest("hex");
+  return { fingerprint: `${head}:${digest}`, head, status, indexFlags };
 }
 
 export async function worktreeFingerprint(
@@ -307,7 +329,11 @@ export async function describeSourceRevision(
   const checkout = root ?? resolveMonorepoRoot();
   const warnings: string[] = [];
 
-  const revision = await headRevision(checkout);
+  // When a snapshot is supplied, its commit is authoritative. Re-reading HEAD here would place
+  // the revision OUTSIDE the interval the before/after fingerprints guard: a checkout
+  // fast-forwarded after the snapshot would leave both fingerprints equal while this described
+  // the newer tree.
+  const revision = snapshot ? snapshot.head : await headRevision(checkout);
   if (!revision) {
     warnings.push(
       `source checkout is not a readable git tree (${checkout}); this answer cannot be tied to a revision`
@@ -380,7 +406,7 @@ export async function describeSourceRevision(
   // per-path status letter, where a lowercase letter means assume-unchanged and "S" means
   // skip-worktree. This is the fifth mechanism by which the probed repository could hide its
   // own state from the probe; like the others, the answer is to look anyway.
-  const lsFiles = await gitProbe(checkout, ["ls-files", "-v"]);
+  const lsFiles = snapshot?.indexFlags ?? (await gitProbe(checkout, ["ls-files", "-v"]));
   if (!lsFiles.ok) {
     const why = lsFiles.truncated
       ? " (the index listing was too large to read in full)"
@@ -421,7 +447,7 @@ export async function describeSourceRevision(
       "rev-list",
       "--left-right",
       "--count",
-      `HEAD...${upstream}`,
+      `${revision}...${upstream}`,
     ]);
     const parts = raw === null ? [] : raw.split(/\s+/).filter(Boolean);
     const a = parts.length === 2 ? Number.parseInt(parts[0] as string, 10) : NaN;

--- a/ops/mcp/src/diagnostics/source-revision.ts
+++ b/ops/mcp/src/diagnostics/source-revision.ts
@@ -1,32 +1,48 @@
 /**
  * Provenance for repository-derived answers.
  *
- * The MCP server resolves "the repository" from whatever tree hosts the compiled
- * binary (see resolveMonorepoRoot in ../paths.ts), or from ICN_ROOT when it is
- * set. That tree is not necessarily current, and it is not necessarily clean:
- * on the development host, three separate checkouts answer to the name "main" at
- * three different revisions, and orientation answers have so far carried no way
- * to tell which one produced them.
+ * The MCP server resolves "the repository" from whatever tree hosts the compiled binary (see
+ * resolveMonorepoRoot in ../paths.ts), or from ICN_ROOT when it is set. That tree is not
+ * necessarily current, and it is not necessarily clean: on the development host, three separate
+ * checkouts answer to the name "main" at three different revisions, and orientation answers have
+ * so far carried no way to tell which one produced them.
  *
- * This module does not choose a better source — that is a separate change. It
- * makes the source the server already uses describe itself, so that a stale or
- * dirty answer says so instead of looking identical to a current one.
+ * This module does not choose a better source — that is a separate change. It makes the source
+ * the server already uses describe itself, so that a stale or dirty answer says so instead of
+ * looking identical to a current one.
  *
- * Failure is reported, never assumed away: when a probe cannot run, the
- * corresponding field is null and `trustworthy` is false. A source whose
- * cleanliness could not be determined must never be presented as clean.
+ * Three properties the implementation must hold, each of which is a way this could have
+ * silently described the wrong thing:
+ *
+ *  1. FAILURE IS REPORTED, NEVER ASSUMED AWAY. When a probe cannot run, its field is null and
+ *     `trustworthy` is false. A source whose cleanliness could not be determined must never be
+ *     presented as clean.
+ *
+ *  2. THE ENVIRONMENT MUST NOT REDIRECT THE PROBE. `GIT_DIR` overrides `-C`, and git exports it
+ *     into child processes in a linked worktree — the only kind ICN uses. Inherited, it would
+ *     let this report `source_checkout: A` while describing the revision of repository B, which
+ *     is precisely the misattribution the stamp exists to remove. The sanitised environment is
+ *     shared with ../runtime/worktree-identity.ts rather than duplicated.
+ *
+ *  3. A READ-ONLY PROBE MUST NOT EXECUTE REPOSITORY-CONFIGURED CODE. `git status` honours
+ *     `core.fsmonitor`, which may name an executable. Callers can supply the path being probed,
+ *     so an unguarded probe would run that binary with the server's authority. Executable
+ *     integrations are disabled per-invocation, and optional locks are dropped so the probe does
+ *     not write to a tree it is only supposed to observe.
  */
 
+import { statSync } from "node:fs";
 import { resolveMonorepoRoot } from "../paths.js";
+import { GIT_SANITISED_ENV } from "../runtime/worktree-identity.js";
 import { runCommand } from "../utils/commands.js";
 
 /** How the repository root the answer came from was chosen. */
-export type SourceResolution = "ICN_ROOT" | "server_location";
+export type SourceResolution = "explicit_root" | "ICN_ROOT" | "server_location";
 
 export type SourceRevision = {
   /** Absolute path of the checkout this answer was produced from. */
   source_checkout: string;
-  /** How that path was chosen. */
+  /** How that path was chosen. An explicitly supplied root outranks the environment. */
   resolved_from: SourceResolution;
   /** Full commit SHA of that checkout's HEAD; null when it is not a git tree. */
   source_revision: string | null;
@@ -38,36 +54,57 @@ export type SourceRevision = {
   dirty: boolean | null;
   /** Number of paths reported by `git status --porcelain`; null when unknown. */
   dirty_paths: number | null;
-  /** Commits the checkout is behind its upstream; null when unknown/no upstream. */
-  behind_upstream: number | null;
   /**
-   * True only when the revision is known, the tree is known-clean, and it is
-   * known to be level with its upstream. Any unknown makes this false.
+   * Commits behind the LOCAL tracking ref. No fetch is performed, so this is a LOWER BOUND on
+   * staleness and never an overestimate — a checkout that has not fetched since the remote moved
+   * reports 0 while being arbitrarily far behind. Read it together with `upstream_observed_at`.
+   */
+  behind_upstream: number | null;
+  /** ISO time the tracking refs were last updated from the remote; null when never/unknown. */
+  upstream_observed_at: string | null;
+  /**
+   * True only when the revision is known, the tree is known-clean, it is level with its tracking
+   * ref, AND that tracking ref was refreshed recently enough to mean anything. Any unknown makes
+   * this false.
    */
   trustworthy: boolean;
   /** Human-readable reasons `trustworthy` is false. Empty when it is true. */
   warnings: string[];
 };
 
-// Matches the git poller's budget (polling/git.ts). A cold `git status` on a checkout of a
-// few thousand files whose index has not been touched for days has to re-stat the tree, and
-// was observed exceeding a 5s budget on this repository — which fails closed to "unknown"
-// and would report a perfectly clean reference checkout as untrusted.
+// Matches the git poller's budget (polling/git.ts). A cold `git status` on a checkout of a few
+// thousand files whose index has not been touched for days has to re-stat the tree, and was
+// observed exceeding a 5s budget on this repository — which fails closed to "unknown" and would
+// report a perfectly clean reference checkout as untrusted.
 const GIT_TIMEOUT_MS = 15_000;
 
-type GitProbe =
-  | { ok: true; out: string }
-  | { ok: false; timedOut: boolean };
+/**
+ * How recently the tracking refs must have been refreshed for `behind_upstream == 0` to support
+ * a claim of currency. `@{u}` is a LOCAL ref: a host that never fetches shows 0 behind forever,
+ * which is exactly the stale-but-confident state this module exists to expose. An hour is short
+ * enough that a host syncing on any normal cadence stays certified, and long enough that the
+ * flag is not permanently false on a healthy machine.
+ */
+const UPSTREAM_FRESHNESS_WINDOW_MS = 60 * 60 * 1000;
+
+// Repository-configured executables are disabled per invocation rather than relying on the
+// caller's git config being benign.
+const GIT_SAFE_FLAGS = ["-c", "core.fsmonitor=", "-c", "core.hooksPath=/dev/null"] as const;
+
+type GitProbe = { ok: true; out: string } | { ok: false; timedOut: boolean };
 
 async function gitProbe(
   cwd: string,
   args: readonly string[]
 ): Promise<GitProbe> {
-  const r = await runCommand("git", args, {
+  const r = await runCommand("git", [...GIT_SAFE_FLAGS, ...args], {
     cwd,
     timeoutMs: GIT_TIMEOUT_MS,
     maxStdoutBytes: 256 * 1024,
     maxStderrBytes: 16 * 1024,
+    // GIT_OPTIONAL_LOCKS=0 keeps `git status` from refreshing/writing the index of a tree this
+    // probe is only observing — a diagnostic must not mutate another lane's working state.
+    env: { ...GIT_SANITISED_ENV, GIT_OPTIONAL_LOCKS: "0" },
   });
   return r.ok ? { ok: true, out: r.stdout.trim() } : { ok: false, timedOut: r.timedOut };
 }
@@ -77,25 +114,44 @@ async function git(cwd: string, args: readonly string[]): Promise<string | null>
   return r.ok ? r.out : null;
 }
 
+/** Resolve the current HEAD of a checkout, or null when it is not a readable git tree. */
+export async function headRevision(checkout: string): Promise<string | null> {
+  return git(checkout, ["rev-parse", "HEAD"]);
+}
+
+/** When the tracking refs were last updated from the remote, via FETCH_HEAD's mtime. */
+async function upstreamObservedAt(checkout: string): Promise<Date | null> {
+  const p = await git(checkout, ["rev-parse", "--git-path", "FETCH_HEAD"]);
+  if (!p) return null;
+  try {
+    return statSync(p.startsWith("/") ? p : `${checkout}/${p}`).mtime;
+  } catch {
+    return null;
+  }
+}
+
 /**
  * Describe the checkout a repository-derived answer was produced from.
  *
- * `root` defaults to the same root the diagnostics themselves read, so the
- * stamp always describes the tree that actually produced the payload rather
- * than a separately resolved one.
+ * `root` defaults to the same root the diagnostics themselves read, so the stamp always
+ * describes the tree that actually produced the payload rather than a separately resolved one.
  */
 export async function describeSourceRevision(
   root?: string
 ): Promise<SourceRevision> {
-  const resolvedFrom: SourceResolution = process.env["ICN_ROOT"]
-    ? "ICN_ROOT"
-    : "server_location";
+  // An explicitly supplied root is how it was chosen, regardless of what the environment says.
+  // icn_ops_agent_runtime deliberately overrides ICN_ROOT with the caller's lane; reporting
+  // "ICN_ROOT" there would contradict the path in source_checkout.
+  const resolvedFrom: SourceResolution = root
+    ? "explicit_root"
+    : process.env["ICN_ROOT"]
+      ? "ICN_ROOT"
+      : "server_location";
   const checkout = root ?? resolveMonorepoRoot();
   const warnings: string[] = [];
 
-  const revision = await git(checkout, ["rev-parse", "HEAD"]);
+  const revision = await headRevision(checkout);
   if (!revision) {
-    // Not a git tree, or git is unavailable. Everything below is unknowable.
     warnings.push(
       `source checkout is not a readable git tree (${checkout}); this answer cannot be tied to a revision`
     );
@@ -108,6 +164,7 @@ export async function describeSourceRevision(
       dirty: null,
       dirty_paths: null,
       behind_upstream: null,
+      upstream_observed_at: null,
       trustworthy: false,
       warnings,
     };
@@ -121,17 +178,14 @@ export async function describeSourceRevision(
     "@{u}",
   ]);
 
-  // `git status --porcelain` prints one line per changed path and nothing when
-  // clean. A failed probe is "unknown", never "clean" — reporting an
-  // undetermined tree as clean is the exact failure this stamp exists to remove.
+  // `git status --porcelain` prints one line per changed path and nothing when clean. A failed
+  // probe is "unknown", never "clean" — reporting an undetermined tree as clean is the exact
+  // failure this stamp exists to remove.
   const status = await gitProbe(checkout, ["status", "--porcelain"]);
   let dirty: boolean | null = null;
   let dirtyPaths: number | null = null;
   if (!status.ok) {
-    // Why it failed is reported, so an operator can tell a corrupt index from a slow one.
-    const cause = status.timedOut
-      ? ` (git status exceeded ${GIT_TIMEOUT_MS}ms)`
-      : "";
+    const cause = status.timedOut ? ` (git status exceeded ${GIT_TIMEOUT_MS}ms)` : "";
     warnings.push(
       `could not determine whether the source checkout is clean${cause}; treating it as untrusted`
     );
@@ -146,12 +200,9 @@ export async function describeSourceRevision(
   }
 
   let behind: number | null = null;
+  let observedAt: Date | null = null;
   if (upstream) {
-    const raw = await git(checkout, [
-      "rev-list",
-      "--count",
-      `HEAD..${upstream}`,
-    ]);
+    const raw = await git(checkout, ["rev-list", "--count", `HEAD..${upstream}`]);
     const n = raw === null ? NaN : Number.parseInt(raw, 10);
     behind = Number.isFinite(n) ? n : null;
     if (behind === null) {
@@ -163,13 +214,29 @@ export async function describeSourceRevision(
         `source checkout is ${behind} commit(s) behind ${upstream}; this answer describes an older revision`
       );
     }
+
+    observedAt = await upstreamObservedAt(checkout);
+    const age = observedAt === null ? null : Date.now() - observedAt.getTime();
+    if (age === null) {
+      warnings.push(
+        `no record of ${upstream} ever being fetched, so distance from the remote is a lower bound only and currency cannot be established`
+      );
+    } else if (age > UPSTREAM_FRESHNESS_WINDOW_MS) {
+      const hours = Math.floor(age / 3_600_000);
+      warnings.push(
+        `${upstream} was last fetched ${hours}h ago, so "${behind ?? "?"} behind" is a lower bound; the remote may have moved since`
+      );
+    }
   } else {
     warnings.push(
       "source checkout has no upstream tracking ref; its staleness cannot be measured"
     );
   }
 
-  const trustworthy = dirty === false && behind === 0;
+  const upstreamFresh =
+    observedAt !== null &&
+    Date.now() - observedAt.getTime() <= UPSTREAM_FRESHNESS_WINDOW_MS;
+  const trustworthy = dirty === false && behind === 0 && upstreamFresh;
 
   return {
     source_checkout: checkout,
@@ -180,6 +247,7 @@ export async function describeSourceRevision(
     dirty,
     dirty_paths: dirtyPaths,
     behind_upstream: behind,
+    upstream_observed_at: observedAt === null ? null : observedAt.toISOString(),
     trustworthy,
     warnings,
   };

--- a/ops/mcp/src/diagnostics/source-revision.ts
+++ b/ops/mcp/src/diagnostics/source-revision.ts
@@ -128,7 +128,25 @@ const GIT_SAFE_FLAGS = ["-c", "core.fsmonitor=", "-c", "core.hooksPath=/dev/null
  */
 const STATUS_ARGS = ["status", "--porcelain", "--untracked-files=normal"] as const;
 
-type GitProbe = { ok: true; out: string } | { ok: false; timedOut: boolean };
+type GitProbe =
+  | { ok: true; out: string }
+  | { ok: false; timedOut: boolean; truncated?: boolean };
+
+/**
+ * Output budget for a single probe. `ls-files -v` scales with the size of the repository, so a
+ * small budget is a correctness problem and not merely a display one.
+ */
+const GIT_MAX_OUTPUT_BYTES = 8 * 1024 * 1024;
+
+/**
+ * runCommand truncates oversized output and still reports success, appending a marker. For a
+ * probe that COUNTS things, a silently shortened list reads as "fewer findings" rather than
+ * "incomplete answer" — a flagged file past the cutoff would simply not be seen. Truncation is
+ * therefore a probe failure here, which fails closed like any other unknown.
+ */
+export function wasTruncated(out: string): boolean {
+  return /\n… \[truncated \d+ chars\]$/.test(out);
+}
 
 async function gitProbe(
   cwd: string,
@@ -143,13 +161,15 @@ async function gitProbe(
   const r = await runCommand("git", ["--work-tree", cwd, ...GIT_SAFE_FLAGS, ...args], {
     cwd,
     timeoutMs: GIT_TIMEOUT_MS,
-    maxStdoutBytes: 256 * 1024,
+    maxStdoutBytes: GIT_MAX_OUTPUT_BYTES,
     maxStderrBytes: 16 * 1024,
     // GIT_OPTIONAL_LOCKS=0 keeps `git status` from refreshing/writing the index of a tree this
     // probe is only observing — a diagnostic must not mutate another lane's working state.
     env: { ...GIT_SANITISED_ENV, GIT_OPTIONAL_LOCKS: "0" },
   });
-  return r.ok ? { ok: true, out: r.stdout.trim() } : { ok: false, timedOut: r.timedOut };
+  if (!r.ok) return { ok: false, timedOut: r.timedOut };
+  if (wasTruncated(r.stdout)) return { ok: false, timedOut: false, truncated: true };
+  return { ok: true, out: r.stdout.trim() };
 }
 
 async function git(cwd: string, args: readonly string[]): Promise<string | null> {
@@ -274,8 +294,11 @@ export async function describeSourceRevision(
   const lsFiles = await gitProbe(checkout, ["ls-files", "-v"]);
   let indexHidden: number | null = null;
   if (!lsFiles.ok) {
+    const why = lsFiles.truncated
+      ? " (the index listing was too large to read in full)"
+      : "";
     warnings.push(
-      "could not check for index flags that hide tracked files from status; treating cleanliness as incomplete"
+      `could not check for index flags that hide tracked files from status${why}; treating cleanliness as incomplete`
     );
   } else {
     indexHidden = lsFiles.out

--- a/ops/mcp/src/diagnostics/source-revision.ts
+++ b/ops/mcp/src/diagnostics/source-revision.ts
@@ -31,6 +31,7 @@
  *     not write to a tree it is only supposed to observe.
  */
 
+import { createHash } from "node:crypto";
 import { statSync } from "node:fs";
 import { resolveMonorepoRoot } from "../paths.js";
 import { GIT_SANITISED_ENV } from "../runtime/worktree-identity.js";
@@ -113,6 +114,14 @@ const UPSTREAM_STALE_AFTER_MS = 60 * 60 * 1000;
 // caller's git config being benign.
 const GIT_SAFE_FLAGS = ["-c", "core.fsmonitor=", "-c", "core.hooksPath=/dev/null"] as const;
 
+/**
+ * `status.showUntrackedFiles=no` in the probed repository would hide untracked files, letting a
+ * tree holding uncommitted content report clean. The mode is passed explicitly so repository
+ * config cannot suppress the check — the same reasoning as disabling core.fsmonitor: a probe
+ * must not let the thing it is inspecting decide how thoroughly it is inspected.
+ */
+const STATUS_ARGS = ["status", "--porcelain", "--untracked-files=normal"] as const;
+
 type GitProbe = { ok: true; out: string } | { ok: false; timedOut: boolean };
 
 async function gitProbe(
@@ -139,6 +148,27 @@ async function git(cwd: string, args: readonly string[]): Promise<string | null>
 /** Resolve the current HEAD of a checkout, or null when it is not a readable git tree. */
 export async function headRevision(checkout: string): Promise<string | null> {
   return git(checkout, ["rev-parse", "HEAD"]);
+}
+
+/**
+ * A snapshot of everything a repository-derived payload could have been read from: the commit
+ * AND the working tree on top of it.
+ *
+ * Guarding a read with HEAD alone is not enough. A dirty tree can shape a payload and then be
+ * cleaned — `git restore`, `git reset --hard HEAD` — without HEAD ever moving, so the two
+ * revision probes agree while the payload describes content that no longer exists. Comparing
+ * this across the read closes that whole class rather than the commit-shaped instance of it.
+ *
+ * `null` means the state could not be determined, which never compares equal to anything.
+ */
+export async function worktreeFingerprint(
+  checkout: string
+): Promise<string | null> {
+  const head = await headRevision(checkout);
+  if (head === null) return null;
+  const status = await gitProbe(checkout, STATUS_ARGS);
+  if (!status.ok) return null;
+  return `${head}:${createHash("sha256").update(status.out).digest("hex")}`;
 }
 
 /** When the tracking refs were last updated from the remote, via FETCH_HEAD's mtime. */
@@ -205,7 +235,7 @@ export async function describeSourceRevision(
   // `git status --porcelain` prints one line per changed path and nothing when clean. A failed
   // probe is "unknown", never "clean" — reporting an undetermined tree as clean is the exact
   // failure this stamp exists to remove.
-  const status = await gitProbe(checkout, ["status", "--porcelain"]);
+  const status = await gitProbe(checkout, STATUS_ARGS);
   let dirty: boolean | null = null;
   let dirtyPaths: number | null = null;
   if (!status.ok) {

--- a/ops/mcp/src/diagnostics/source-revision.ts
+++ b/ops/mcp/src/diagnostics/source-revision.ts
@@ -56,6 +56,12 @@ export type SourceRevision = {
   /** Number of paths reported by `git status --porcelain`; null when unknown. */
   dirty_paths: number | null;
   /**
+   * Tracked paths carrying `assume-unchanged` or `skip-worktree`. Git omits these from `status`
+   * entirely, so a modified file marked either way leaves a checkout looking spotless. A
+   * non-zero count means `dirty` is not a complete answer, however clean it looks.
+   */
+  index_hidden_paths: number | null;
+  /**
    * Commits behind the LOCAL tracking ref. No fetch is performed, so this is a LOWER BOUND on
    * staleness and never an overestimate — a checkout that has not fetched since the remote moved
    * reports 0 while being arbitrarily far behind. Read it together with `remote_currency`.
@@ -221,6 +227,7 @@ export async function describeSourceRevision(
       upstream: null,
       dirty: null,
       dirty_paths: null,
+      index_hidden_paths: null,
       behind_upstream: null,
       ahead_of_upstream: null,
       upstream_observed_at: null,
@@ -255,6 +262,32 @@ export async function describeSourceRevision(
     if (dirty) {
       warnings.push(
         `source checkout has ${dirtyPaths} uncommitted path(s); this answer may describe unreviewed local edits`
+      );
+    }
+  }
+
+  // `status` is not the whole story: `git update-index --assume-unchanged` and `--skip-worktree`
+  // make git omit a tracked file from status even when it is modified. `ls-files -v` reports a
+  // per-path status letter, where a lowercase letter means assume-unchanged and "S" means
+  // skip-worktree. This is the fifth mechanism by which the probed repository could hide its
+  // own state from the probe; like the others, the answer is to look anyway.
+  const lsFiles = await gitProbe(checkout, ["ls-files", "-v"]);
+  let indexHidden: number | null = null;
+  if (!lsFiles.ok) {
+    warnings.push(
+      "could not check for index flags that hide tracked files from status; treating cleanliness as incomplete"
+    );
+  } else {
+    indexHidden = lsFiles.out
+      .split("\n")
+      .filter((l) => l.length > 0)
+      .filter((l) => {
+        const c = l[0] as string;
+        return c === "S" || (c >= "a" && c <= "z");
+      }).length;
+    if (indexHidden > 0) {
+      warnings.push(
+        `${indexHidden} tracked path(s) carry assume-unchanged or skip-worktree, so git omits them from status; this checkout may hold modifications that cannot be seen`
       );
     }
   }
@@ -313,7 +346,8 @@ export async function describeSourceRevision(
   }
 
   // Local faithfulness only. Remote currency is deliberately excluded: see `remote_currency`.
-  const trustworthy = dirty === false && behind === 0 && ahead === 0;
+  const trustworthy =
+    dirty === false && indexHidden === 0 && behind === 0 && ahead === 0;
 
   return {
     source_checkout: checkout,
@@ -323,6 +357,7 @@ export async function describeSourceRevision(
     upstream,
     dirty,
     dirty_paths: dirtyPaths,
+    index_hidden_paths: indexHidden,
     behind_upstream: behind,
     ahead_of_upstream: ahead,
     upstream_observed_at: observedAt === null ? null : observedAt.toISOString(),

--- a/ops/mcp/src/diagnostics/source-revision.ts
+++ b/ops/mcp/src/diagnostics/source-revision.ts
@@ -40,11 +40,33 @@ import { runCommand } from "../utils/commands.js";
 /** How the repository root the answer came from was chosen. */
 export type SourceResolution = "explicit_root" | "ICN_ROOT" | "server_location";
 
+/**
+ * Whether the checkout being described was chosen by the operator or by the caller.
+ *
+ * This is a trust boundary, not a configuration list. Inspecting a working tree makes git apply
+ * repository-controlled behaviour to its contents — `.gitattributes` plus a `filter.<driver>.clean`
+ * command is executed by `git status` (verified with git 2.43), and it is not the only such
+ * mechanism, nor a bounded set. Reading refs and objects does not: `rev-parse` and `rev-list`
+ * touch no working-tree content and run no filters.
+ *
+ * So a caller-selected checkout gets ref and object reads only. Its cleanliness is reported as
+ * indeterminate rather than probed, because the probe is the exposure. Enumerating individual git
+ * knobs was tried and abandoned as the wrong abstraction; removing the dependence on caller
+ * working trees altogether is R1-B's job, and this is the bounded bridge until then.
+ */
+export type SourceProvenance = "controlled" | "caller_selected";
+
 export type SourceRevision = {
   /** Absolute path of the checkout this answer was produced from. */
   source_checkout: string;
   /** How that path was chosen. An explicitly supplied root outranks the environment. */
   resolved_from: SourceResolution;
+  /**
+   * Whether the operator or the caller chose this checkout. A `caller_selected` source is never
+   * inspected through its working tree, so its cleanliness fields are null by design rather than
+   * by failure — see SourceProvenance.
+   */
+  source_provenance: SourceProvenance;
   /** Full commit SHA of that checkout's HEAD; null when it is not a git tree. */
   source_revision: string | null;
   /** Branch name, or "HEAD" when detached; null when unknown. */
@@ -194,10 +216,17 @@ export async function headRevision(checkout: string): Promise<string | null> {
  * `null` means the state could not be determined, which never compares equal to anything.
  */
 export async function worktreeFingerprint(
-  checkout: string
+  checkout: string,
+  provenance: SourceProvenance = "controlled"
 ): Promise<string | null> {
   const head = await headRevision(checkout);
   if (head === null) return null;
+  if (provenance === "caller_selected") {
+    // The working tree of a caller-selected checkout is never read, so the guard degrades to the
+    // commit alone. Nothing is certified from such a source anyway — `trustworthy` is already
+    // false — so this weakens no claim that was being made.
+    return `${head}:worktree-not-inspected`;
+  }
   const status = await gitProbe(checkout, STATUS_ARGS);
   if (!status.ok) return null;
   return `${head}:${createHash("sha256").update(status.out).digest("hex")}`;
@@ -221,7 +250,8 @@ async function upstreamObservedAt(checkout: string): Promise<Date | null> {
  * describes the tree that actually produced the payload rather than a separately resolved one.
  */
 export async function describeSourceRevision(
-  root?: string
+  root?: string,
+  provenance: SourceProvenance = "controlled"
 ): Promise<SourceRevision> {
   // An explicitly supplied root is how it was chosen, regardless of what the environment says.
   // icn_ops_agent_runtime deliberately overrides ICN_ROOT with the caller's lane; reporting
@@ -242,6 +272,7 @@ export async function describeSourceRevision(
     return {
       source_checkout: checkout,
       resolved_from: resolvedFrom,
+      source_provenance: provenance,
       source_revision: null,
       source_ref: null,
       upstream: null,
@@ -268,9 +299,24 @@ export async function describeSourceRevision(
   // `git status --porcelain` prints one line per changed path and nothing when clean. A failed
   // probe is "unknown", never "clean" — reporting an undetermined tree as clean is the exact
   // failure this stamp exists to remove.
-  const status = await gitProbe(checkout, STATUS_ARGS);
+  // THE BRIDGE. A caller-selected checkout is never inspected through its working tree: doing so
+  // is what lets the repository run code (see SourceProvenance). Cleanliness is therefore
+  // reported as indeterminate — null, not false — and nothing is certified from it. The revision
+  // identity established above came from ref reads and remains valid.
+  const inspectWorkingTree = provenance === "controlled";
+
   let dirty: boolean | null = null;
   let dirtyPaths: number | null = null;
+  let indexHidden: number | null = null;
+
+  if (!inspectWorkingTree) {
+    warnings.push(
+      "cleanliness was not probed: this checkout was selected by the caller, and inspecting a " +
+        "working tree can execute repository-defined behaviour. Revision identity is reported; " +
+        "cleanliness is indeterminate and this source cannot be certified"
+    );
+  } else {
+  const status = await gitProbe(checkout, STATUS_ARGS);
   if (!status.ok) {
     const cause = status.timedOut ? ` (git status exceeded ${GIT_TIMEOUT_MS}ms)` : "";
     warnings.push(
@@ -292,7 +338,6 @@ export async function describeSourceRevision(
   // skip-worktree. This is the fifth mechanism by which the probed repository could hide its
   // own state from the probe; like the others, the answer is to look anyway.
   const lsFiles = await gitProbe(checkout, ["ls-files", "-v"]);
-  let indexHidden: number | null = null;
   if (!lsFiles.ok) {
     const why = lsFiles.truncated
       ? " (the index listing was too large to read in full)"
@@ -313,6 +358,7 @@ export async function describeSourceRevision(
         `${indexHidden} tracked path(s) carry assume-unchanged or skip-worktree, so git omits them from status; this checkout may hold modifications that cannot be seen`
       );
     }
+  }
   }
 
   let behind: number | null = null;
@@ -369,12 +415,20 @@ export async function describeSourceRevision(
   }
 
   // Local faithfulness only. Remote currency is deliberately excluded: see `remote_currency`.
+  // `inspectWorkingTree` is not redundant with the null checks: it states the intent directly, so
+  // a future change that gives these fields a non-null default cannot quietly re-certify an
+  // uninspected source.
   const trustworthy =
-    dirty === false && indexHidden === 0 && behind === 0 && ahead === 0;
+    inspectWorkingTree &&
+    dirty === false &&
+    indexHidden === 0 &&
+    behind === 0 &&
+    ahead === 0;
 
   return {
     source_checkout: checkout,
     resolved_from: resolvedFrom,
+    source_provenance: provenance,
     source_revision: revision,
     source_ref: ref,
     upstream,

--- a/ops/mcp/src/diagnostics/source-revision.ts
+++ b/ops/mcp/src/diagnostics/source-revision.ts
@@ -128,7 +128,13 @@ async function gitProbe(
   cwd: string,
   args: readonly string[]
 ): Promise<GitProbe> {
-  const r = await runCommand("git", [...GIT_SAFE_FLAGS, ...args], {
+  // `--work-tree` pins the probe to the directory being described. `core.worktree` in the
+  // probed repository would otherwise redirect it: a modified checkout whose config points at a
+  // clean copy reports an empty status, so locally modified payload data would be stamped
+  // clean. Verified with git 2.43. This completes the family the sanitised environment,
+  // `core.fsmonitor` and `--untracked-files` belong to — a repository must not get to decide
+  // how, or where, it is inspected.
+  const r = await runCommand("git", ["--work-tree", cwd, ...GIT_SAFE_FLAGS, ...args], {
     cwd,
     timeoutMs: GIT_TIMEOUT_MS,
     maxStdoutBytes: 256 * 1024,

--- a/ops/mcp/src/runtime/worktree-identity.ts
+++ b/ops/mcp/src/runtime/worktree-identity.ts
@@ -34,7 +34,7 @@ import { execFileSync } from "child_process";
  * ICN_ROOT, one layer down: an unchecked environment variable must never be able to
  * misattribute a session to the wrong lane.
  */
-const GIT_SANITISED_ENV: NodeJS.ProcessEnv = (() => {
+export const GIT_SANITISED_ENV: NodeJS.ProcessEnv = (() => {
   const e = { ...process.env };
   for (const k of [
     "GIT_DIR",

--- a/ops/mcp/src/tests/source-revision.test.ts
+++ b/ops/mcp/src/tests/source-revision.test.ts
@@ -1,6 +1,13 @@
 import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
 import { execFileSync } from "node:child_process";
-import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import {
+  chmodSync,
+  existsSync,
+  mkdtempSync,
+  rmSync,
+  utimesSync,
+  writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
@@ -47,6 +54,9 @@ function originWithClone(): { origin: string; clone: string } {
   git(seed, "push", "-u", "origin", "main");
   const clone = tempDir("clone");
   git(clone, "clone", origin, ".");
+  // A clone does not necessarily leave FETCH_HEAD behind, and currency is only claimable with
+  // evidence that the tracking refs were actually refreshed. This mirrors a synced host.
+  git(clone, "fetch", "origin");
   return { origin, clone };
 }
 
@@ -167,18 +177,115 @@ describe("describeSourceRevision — how the root was chosen is reported", () =>
     else process.env["ICN_ROOT"] = saved;
   });
 
-  it("reports ICN_ROOT when the environment pins the root", async () => {
+  it("reports explicit_root when a root is passed, even if ICN_ROOT is set", async () => {
+    const { clone } = originWithClone();
+    process.env["ICN_ROOT"] = "/some/other/checkout";
+    const s = await describeSourceRevision(clone);
+    // icn_ops_agent_runtime deliberately overrides ICN_ROOT with the caller's lane; saying
+    // "ICN_ROOT" here would contradict the path actually reported in source_checkout.
+    expect(s.resolved_from).toBe("explicit_root");
+    expect(s.source_checkout).toBe(clone);
+  });
+
+  it("reports ICN_ROOT when the environment pins the root and none is passed", async () => {
     const { clone } = originWithClone();
     process.env["ICN_ROOT"] = clone;
-    const s = await describeSourceRevision(clone);
+    const s = await describeSourceRevision();
     expect(s.resolved_from).toBe("ICN_ROOT");
+    expect(s.source_checkout).toBe(clone);
   });
 
   it("reports server_location when nothing pins the root", async () => {
-    const { clone } = originWithClone();
     delete process.env["ICN_ROOT"];
-    const s = await describeSourceRevision(clone);
+    const s = await describeSourceRevision();
     expect(s.resolved_from).toBe("server_location");
+  });
+});
+
+// `@{u}` is a LOCAL ref. A host that never fetches sits at "0 behind" forever while the remote
+// moves away from it — stale and confident, which is the exact state this module exists to
+// expose. Currency therefore requires evidence that the tracking refs were actually refreshed.
+describe("describeSourceRevision — a stale tracking ref cannot certify currency", () => {
+  it("refuses to certify when the upstream has not been fetched recently", async () => {
+    const { clone } = originWithClone();
+    const fetchHead = path.join(clone, ".git", "FETCH_HEAD");
+    const longAgo = new Date(Date.now() - 72 * 3600 * 1000);
+    utimesSync(fetchHead, longAgo, longAgo);
+
+    const s = await describeSourceRevision(clone);
+    // Locally everything looks perfect: clean, and level with the tracking ref.
+    expect(s.dirty).toBe(false);
+    expect(s.behind_upstream).toBe(0);
+    // But "0 behind" is only a lower bound against a three-day-old view of the remote.
+    expect(s.trustworthy).toBe(false);
+    expect(s.warnings.join(" ")).toMatch(/lower bound/);
+    expect(s.upstream_observed_at).not.toBeNull();
+  });
+
+  it("records when the tracking refs were last observed", async () => {
+    const { clone } = originWithClone();
+    const s = await describeSourceRevision(clone);
+    expect(s.upstream_observed_at).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+    expect(s.trustworthy).toBe(true);
+  });
+});
+
+// GIT_DIR overrides -C, and git exports it into child processes in a linked worktree — the only
+// kind ICN uses. If it leaked through, this would name one checkout while describing another:
+// the precise misattribution the stamp exists to remove.
+describe("describeSourceRevision — the environment cannot redirect the probe", () => {
+  const savedDir = process.env["GIT_DIR"];
+  const savedWork = process.env["GIT_WORK_TREE"];
+  afterEach(() => {
+    if (savedDir === undefined) delete process.env["GIT_DIR"];
+    else process.env["GIT_DIR"] = savedDir;
+    if (savedWork === undefined) delete process.env["GIT_WORK_TREE"];
+    else process.env["GIT_WORK_TREE"] = savedWork;
+  });
+
+  it("describes the checkout it was given, not the one GIT_DIR points at", async () => {
+    const target = originWithClone().clone;
+    const decoy = originWithClone().clone;
+    // Make the decoy unmistakably different.
+    writeFileSync(path.join(decoy, "decoy.md"), "decoy\n");
+    git(decoy, "add", "decoy.md");
+    git(decoy, "commit", "-m", "decoy commit");
+
+    const targetHead = git(target, "rev-parse", "HEAD");
+    const decoyHead = git(decoy, "rev-parse", "HEAD");
+    expect(targetHead).not.toBe(decoyHead);
+
+    process.env["GIT_DIR"] = path.join(decoy, ".git");
+    process.env["GIT_WORK_TREE"] = decoy;
+
+    const s = await describeSourceRevision(target);
+    expect(s.source_checkout).toBe(target);
+    expect(s.source_revision).toBe(targetHead);
+    expect(s.source_revision).not.toBe(decoyHead);
+  });
+});
+
+// `git status` honours core.fsmonitor, which may name an executable. Callers supply the path
+// probed by icn_ops_agent_runtime, so an unguarded read-only diagnostic would run a binary of
+// the repository's choosing with the server's authority. This asserts the behaviour, not the
+// flag: a sentinel file appears if and only if the configured program actually ran.
+describe("describeSourceRevision — a read-only probe executes no repository-configured code", () => {
+  it("does not run a core.fsmonitor program configured in the probed repository", async () => {
+    const { clone } = originWithClone();
+    const sentinel = path.join(clone, "FSMONITOR_RAN");
+    const hook = path.join(clone, "fsmonitor-hook.sh");
+    writeFileSync(hook, `#!/bin/sh\necho ran > "${sentinel}"\nexit 1\n`);
+    chmodSync(hook, 0o755);
+    git(clone, "config", "core.fsmonitor", hook);
+
+    // Control: with the guard removed, git really does execute it — otherwise this test would
+    // pass for the wrong reason on a git that ignores the setting.
+    execFileSync("git", ["status", "--porcelain"], { cwd: clone, stdio: "ignore" });
+    expect(existsSync(sentinel), "control: git must execute core.fsmonitor unguarded").toBe(true);
+    rmSync(sentinel, { force: true });
+
+    await describeSourceRevision(clone);
+    expect(existsSync(sentinel), "probe must not execute core.fsmonitor").toBe(false);
   });
 });
 

--- a/ops/mcp/src/tests/source-revision.test.ts
+++ b/ops/mcp/src/tests/source-revision.test.ts
@@ -13,7 +13,10 @@ import path from "node:path";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
-import { describeSourceRevision } from "../diagnostics/source-revision.js";
+import {
+  describeSourceRevision,
+  worktreeFingerprint,
+} from "../diagnostics/source-revision.js";
 import { registerAgentOpsTools } from "../tools/agent-ops.js";
 
 // These tests build real git repositories in a temp directory rather than mocking git.
@@ -286,6 +289,51 @@ describe("describeSourceRevision — the environment cannot redirect the probe",
   });
 });
 
+// Repository config must not be able to decide how thoroughly the repository is inspected.
+describe("describeSourceRevision — repository config cannot suppress the cleanliness check", () => {
+  it("sees untracked files even when status.showUntrackedFiles=no", async () => {
+    const { clone } = originWithClone();
+    git(clone, "config", "status.showUntrackedFiles", "no");
+    writeFileSync(path.join(clone, "untracked-manifest.json"), "{}\n");
+
+    // Control: with the repository's own setting honoured, git reports nothing.
+    const suppressed = execFileSync("git", ["status", "--porcelain"], {
+      cwd: clone,
+      encoding: "utf-8",
+    }).trim();
+    expect(suppressed, "control: the config must actually suppress").toBe("");
+
+    const s = await describeSourceRevision(clone);
+    expect(s.dirty).toBe(true);
+    expect(s.dirty_paths).toBe(1);
+    expect(s.trustworthy).toBe(false);
+  });
+});
+
+// Guarding a read with HEAD alone misses a tree that was dirty during the read and cleaned
+// afterwards: the commit never moves, so two HEAD probes agree while the payload describes
+// content that no longer exists.
+describe("worktreeFingerprint — working-tree state is part of the guarded state", () => {
+  it("changes when the tree is dirtied and again when it is cleaned, with HEAD fixed", async () => {
+    const { clone } = originWithClone();
+    const head = git(clone, "rev-parse", "HEAD");
+
+    const clean = await worktreeFingerprint(clone);
+    writeFileSync(path.join(clone, "README.md"), "edited during the read\n");
+    const dirty = await worktreeFingerprint(clone);
+    execFileSync("git", ["restore", "README.md"], { cwd: clone, stdio: "ignore" });
+    const restored = await worktreeFingerprint(clone);
+
+    expect(git(clone, "rev-parse", "HEAD")).toBe(head); // HEAD never moved
+    expect(dirty).not.toBe(clean);
+    expect(restored).toBe(clean);
+  });
+
+  it("is null for a tree whose state cannot be determined", async () => {
+    expect(await worktreeFingerprint(tempDir("nonrepo"))).toBeNull();
+  });
+});
+
 // `git status` honours core.fsmonitor, which may name an executable. Callers supply the path
 // probed by icn_ops_agent_runtime, so an unguarded read-only diagnostic would run a binary of
 // the repository's choosing with the server's authority. This asserts the behaviour, not the
@@ -349,6 +397,10 @@ describe("icn_ops tools — the stamping policy", () => {
       expect(source?.["source_revision"]).toBe(git(repo, "rev-parse", "HEAD"));
       expect(source?.["source_checkout"]).toBe(repo);
       expect(source?.["trustworthy"]).toBe(true);
+      // Through the tool path the root is NOT explicitly supplied, so the stamp must report how
+      // it was really chosen. Defaulting the wrapper's root would make this claim explicit_root
+      // on every response and leave the other two values unreachable in practice.
+      expect(source?.["resolved_from"]).toBe("ICN_ROOT");
       // The payload itself must survive the stamp.
       expect(body["entries"]).toBeDefined();
     }

--- a/ops/mcp/src/tests/source-revision.test.ts
+++ b/ops/mcp/src/tests/source-revision.test.ts
@@ -308,6 +308,25 @@ describe("describeSourceRevision — repository config cannot suppress the clean
     expect(s.dirty_paths).toBe(1);
     expect(s.trustworthy).toBe(false);
   });
+
+  it("sees local modifications even when core.worktree points elsewhere", async () => {
+    const { clone } = originWithClone();
+    const decoy = tempDir("decoy-worktree");
+    writeFileSync(path.join(decoy, "README.md"), "seed\n");
+    writeFileSync(path.join(clone, "README.md"), "locally modified\n");
+    git(clone, "config", "core.worktree", decoy);
+
+    // Control: honouring the repository's own setting inspects the decoy and sees nothing.
+    const redirected = execFileSync("git", ["status", "--porcelain"], {
+      cwd: clone,
+      encoding: "utf-8",
+    }).trim();
+    expect(redirected, "control: core.worktree must actually redirect").toBe("");
+
+    const s = await describeSourceRevision(clone);
+    expect(s.dirty).toBe(true);
+    expect(s.trustworthy).toBe(false);
+  });
 });
 
 // Guarding a read with HEAD alone misses a tree that was dirty during the read and cleaned

--- a/ops/mcp/src/tests/source-revision.test.ts
+++ b/ops/mcp/src/tests/source-revision.test.ts
@@ -15,8 +15,10 @@ import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
 import {
   describeSourceRevision,
+  wasTruncated,
   worktreeFingerprint,
 } from "../diagnostics/source-revision.js";
+import { runCommand } from "../utils/commands.js";
 import { registerAgentOpsTools } from "../tools/agent-ops.js";
 
 // These tests build real git repositories in a temp directory rather than mocking git.
@@ -286,6 +288,31 @@ describe("describeSourceRevision — the environment cannot redirect the probe",
     expect(s.source_checkout).toBe(target);
     expect(s.source_revision).toBe(targetHead);
     expect(s.source_revision).not.toBe(decoyHead);
+  });
+});
+
+// runCommand truncates oversized output and still reports success. A probe that COUNTS things
+// would read a shortened list as "fewer findings" rather than "incomplete answer", so a flagged
+// file past the cutoff would simply not be seen. The marker is produced by runCommand here
+// rather than hand-written, so the test fails if the two modules ever drift apart on its shape.
+describe("wasTruncated — a shortened probe result is not a smaller result", () => {
+  it("recognises the marker runCommand actually emits", async () => {
+    const r = await runCommand("node", ["-e", "console.log('x'.repeat(5000))"], {
+      timeoutMs: 10_000,
+      maxStdoutBytes: 100,
+    });
+    expect(r.ok, "the command itself must succeed — truncation is not a failure there").toBe(true);
+    expect(r.stdout.length).toBeLessThan(5000);
+    expect(wasTruncated(r.stdout)).toBe(true);
+  });
+
+  it("does not flag output that fit within the budget", async () => {
+    const r = await runCommand("node", ["-e", "console.log('short')"], {
+      timeoutMs: 10_000,
+      maxStdoutBytes: 4096,
+    });
+    expect(r.ok).toBe(true);
+    expect(wasTruncated(r.stdout)).toBe(false);
   });
 });
 

--- a/ops/mcp/src/tests/source-revision.test.ts
+++ b/ops/mcp/src/tests/source-revision.test.ts
@@ -316,6 +316,106 @@ describe("wasTruncated — a shortened probe result is not a smaller result", ()
   });
 });
 
+// THE SAFETY BRIDGE (R1-A). Inspecting a working tree makes git apply repository-controlled
+// behaviour to its contents: `.gitattributes` plus `filter.<driver>.clean` is executed by
+// `git status`. That is not a bounded set of knobs, so the bridge does not try to disable them
+// one by one — it declines to inspect the working tree of a checkout the caller chose.
+// Removing the dependence on caller working trees entirely is R1-B.
+describe("the safety bridge — a caller-selected checkout is not inspected", () => {
+  /** A repo whose clean filter writes a sentinel file when git runs it. */
+  function repoWithSideEffectingCleanFilter(): { repo: string; sentinel: string } {
+    const repo = tempDir("evil-filter");
+    git(repo, "init", ".");
+    writeFileSync(path.join(repo, "payload.txt"), "original\n");
+    git(repo, "add", "payload.txt");
+    git(repo, "commit", "-m", "init");
+    writeFileSync(path.join(repo, ".gitattributes"), "* filter=evil\n");
+    git(repo, "add", ".gitattributes");
+    git(repo, "commit", "-m", "attrs");
+
+    const sentinel = path.join(repo, "FILTER_EXECUTED");
+    git(repo, "config", "filter.evil.clean", `sh -c 'echo ran > "${sentinel}"; cat'`);
+    // Modify the file so a cleanliness probe has to convert its contents.
+    writeFileSync(path.join(repo, "payload.txt"), "modified\n");
+    return { repo, sentinel };
+  }
+
+  it("control: git really does execute the clean filter during a status probe", () => {
+    const { repo, sentinel } = repoWithSideEffectingCleanFilter();
+    execFileSync("git", ["status", "--porcelain", "--untracked-files=normal"], {
+      cwd: repo,
+      stdio: "ignore",
+    });
+    // Without this, the assertions below could pass on a git that never ran the filter at all.
+    expect(existsSync(sentinel), "control: the filter must be executable via status").toBe(true);
+  });
+
+  it("does not execute a repository-defined clean filter for a caller-selected root", async () => {
+    const { repo, sentinel } = repoWithSideEffectingCleanFilter();
+
+    const s = await describeSourceRevision(repo, "caller_selected");
+
+    expect(existsSync(sentinel), "no repository-defined code may run for a caller-selected root")
+      .toBe(false);
+    // Revision identity survives: it came from ref reads, which execute nothing.
+    expect(s.source_revision).toBe(git(repo, "rev-parse", "HEAD"));
+    expect(s.source_provenance).toBe("caller_selected");
+    // Cleanliness is indeterminate — null, not false — and nothing is certified from it.
+    expect(s.dirty).toBeNull();
+    expect(s.dirty_paths).toBeNull();
+    expect(s.index_hidden_paths).toBeNull();
+    expect(s.trustworthy).toBe(false);
+    expect(s.warnings.join(" ")).toMatch(/cleanliness was not probed/);
+  });
+
+  it("still inspects an operator-controlled root, so the gate is what does the work", async () => {
+    const { repo, sentinel } = repoWithSideEffectingCleanFilter();
+    const s = await describeSourceRevision(repo, "controlled");
+    // The contrast matters: if nothing inspected the tree in either mode, the assertion above
+    // would hold for the wrong reason. Controlled sources ARE inspected.
+    expect(existsSync(sentinel)).toBe(true);
+    expect(s.dirty).not.toBeNull();
+  });
+
+  // End-to-end through the only tool that resolves its root from client input. The unit test
+  // above proves the primitive declines; this proves the tool actually asks it to.
+  it("icn_ops_agent_runtime does not execute the filter for a cwd the caller supplied", async () => {
+    const { repo, sentinel } = repoWithSideEffectingCleanFilter();
+    const savedRoot = process.env["ICN_ROOT"];
+    const host = originWithClone().clone;
+    process.env["ICN_ROOT"] = host;
+    try {
+      const server = new McpServer({ name: "icn-ops-test", version: "0.0.0" });
+      registerAgentOpsTools(server);
+      const [ct, st] = InMemoryTransport.createLinkedPair();
+      const client = new Client({ name: "test-client", version: "0.0.0" });
+      await Promise.all([server.connect(st), client.connect(ct)]);
+
+      const res = (await client.callTool({
+        name: "icn_ops_agent_runtime",
+        arguments: { cwd: repo, section: "session" },
+      })) as { content: Array<{ type: string; text: string }> };
+      const body = JSON.parse(res.content[0]?.text ?? "{}") as Record<string, unknown>;
+      const source = body["source"] as Record<string, unknown>;
+
+      expect(existsSync(sentinel), "the tool must not execute caller-repo code").toBe(false);
+      expect(source?.["source_provenance"]).toBe("caller_selected");
+      expect(source?.["dirty"]).toBeNull();
+      expect(source?.["trustworthy"]).toBe(false);
+    } finally {
+      if (savedRoot === undefined) delete process.env["ICN_ROOT"];
+      else process.env["ICN_ROOT"] = savedRoot;
+    }
+  });
+
+  it("a caller-selected fingerprint covers the commit without reading the tree", async () => {
+    const { repo, sentinel } = repoWithSideEffectingCleanFilter();
+    const fp = await worktreeFingerprint(repo, "caller_selected");
+    expect(existsSync(sentinel)).toBe(false);
+    expect(fp).toBe(`${git(repo, "rev-parse", "HEAD")}:worktree-not-inspected`);
+  });
+});
+
 // Repository config must not be able to decide how thoroughly the repository is inspected.
 describe("describeSourceRevision — repository config cannot suppress the cleanliness check", () => {
   it("sees untracked files even when status.showUntrackedFiles=no", async () => {

--- a/ops/mcp/src/tests/source-revision.test.ts
+++ b/ops/mcp/src/tests/source-revision.test.ts
@@ -309,6 +309,31 @@ describe("describeSourceRevision — repository config cannot suppress the clean
     expect(s.trustworthy).toBe(false);
   });
 
+  it.each([["assume-unchanged"], ["skip-worktree"]])(
+    "refuses to report clean when a tracked file is hidden by --%s",
+    async (flag) => {
+      const { clone } = originWithClone();
+      git(clone, "update-index", `--${flag}`, "README.md");
+      writeFileSync(path.join(clone, "README.md"), "modified but hidden\n");
+
+      // Control: git really does omit it, so status alone says the tree is spotless.
+      const hidden = execFileSync(
+        "git",
+        ["status", "--porcelain", "--untracked-files=normal"],
+        { cwd: clone, encoding: "utf-8" }
+      ).trim();
+      expect(hidden, `control: --${flag} must actually hide it`).toBe("");
+
+      const s = await describeSourceRevision(clone);
+      // `dirty` honestly reports what status said...
+      expect(s.dirty).toBe(false);
+      // ...but status was not the whole answer, and the stamp must not certify on it.
+      expect(s.index_hidden_paths).toBe(1);
+      expect(s.trustworthy).toBe(false);
+      expect(s.warnings.join(" ")).toMatch(/omits them from status/);
+    }
+  );
+
   it("sees local modifications even when core.worktree points elsewhere", async () => {
     const { clone } = originWithClone();
     const decoy = tempDir("decoy-worktree");

--- a/ops/mcp/src/tests/source-revision.test.ts
+++ b/ops/mcp/src/tests/source-revision.test.ts
@@ -4,6 +4,7 @@ import {
   chmodSync,
   existsSync,
   mkdtempSync,
+  readFileSync,
   rmSync,
   utimesSync,
   writeFileSync,
@@ -555,6 +556,41 @@ describe("describeSourceRevision — a read-only probe executes no repository-co
 
     await describeSourceRevision(clone);
     expect(existsSync(sentinel), "probe must not execute core.fsmonitor").toBe(false);
+  });
+});
+
+// The cost fix is that the source description REUSES the guard's second scan instead of taking
+// a third of the same tree. Witnessed by its observable consequence: when a snapshot is supplied,
+// the description must come from it.
+//
+// An earlier version of this test counted real scans with an appending clean filter. That was
+// flaky: `git status` refreshes the index stat cache, so whether a later scan re-invokes the
+// filter depends on filesystem timestamp granularity — it passed alone and failed in the full
+// suite, intermittently. A flaky witness is worse than none, so it was replaced with this one.
+describe("describeSourceRevision — a supplied snapshot is reused, not re-probed", () => {
+  it("describes cleanliness from the snapshot it was given", async () => {
+    const { clone } = originWithClone();
+    // The tree on disk is spotless...
+    expect(git(clone, "status", "--porcelain")).toBe("");
+
+    // ...but the caller hands over a snapshot taken a moment earlier, which saw two changes.
+    const s = await describeSourceRevision(clone, "controlled", {
+      fingerprint: "irrelevant-for-this-assertion",
+      status: { ok: true, out: " M README.md\n?? scratch.txt" },
+    });
+
+    // If the probe had been re-run, this would read 0/false from the real tree.
+    expect(s.dirty_paths).toBe(2);
+    expect(s.dirty).toBe(true);
+    expect(s.trustworthy).toBe(false);
+  });
+
+  it("still probes for itself when no snapshot is supplied", async () => {
+    const { clone } = originWithClone();
+    writeFileSync(path.join(clone, "README.md"), "changed\n");
+    const s = await describeSourceRevision(clone, "controlled");
+    expect(s.dirty).toBe(true);
+    expect(s.dirty_paths).toBe(1);
   });
 });
 

--- a/ops/mcp/src/tests/source-revision.test.ts
+++ b/ops/mcp/src/tests/source-revision.test.ts
@@ -408,6 +408,35 @@ describe("the safety bridge — a caller-selected checkout is not inspected", ()
     }
   });
 
+  // The bridge's earlier premise was "ref and object reads are inert". Object traversal is not:
+  // on a partial clone it can lazily fetch from a promisor remote, whose URL may be `ext::<cmd>`.
+  // That was not reproducible on this fixture, so this asserts the NARROWING rather than an
+  // exploit — the probe set for a caller-selected source is ref resolution only.
+  it("withholds divergence measurement for a caller-selected root", async () => {
+    const { origin, clone } = originWithClone();
+    const pusher = tempDir("pusher-cs");
+    git(pusher, "clone", origin, ".");
+    writeFileSync(path.join(pusher, "next.md"), "next\n");
+    git(pusher, "add", "next.md");
+    git(pusher, "commit", "-m", "next");
+    git(pusher, "push", "origin", "main");
+    git(clone, "fetch", "origin");
+
+    // Controlled: the traversal runs and the checkout is measurably behind.
+    const controlled = await describeSourceRevision(clone, "controlled");
+    expect(controlled.behind_upstream).toBe(1);
+
+    // Caller-selected: identity survives, divergence is not measured at all.
+    const s = await describeSourceRevision(clone, "caller_selected");
+    expect(s.source_revision).toBe(git(clone, "rev-parse", "HEAD"));
+    expect(s.source_ref).toBe("main");
+    expect(s.upstream).toBe("origin/main");
+    expect(s.behind_upstream).toBeNull();
+    expect(s.ahead_of_upstream).toBeNull();
+    expect(s.trustworthy).toBe(false);
+    expect(s.warnings.join(" ")).toMatch(/was not measured/);
+  });
+
   it("a caller-selected fingerprint covers the commit without reading the tree", async () => {
     const { repo, sentinel } = repoWithSideEffectingCleanFilter();
     const fp = await worktreeFingerprint(repo, "caller_selected");

--- a/ops/mcp/src/tests/source-revision.test.ts
+++ b/ops/mcp/src/tests/source-revision.test.ts
@@ -4,7 +4,6 @@ import {
   chmodSync,
   existsSync,
   mkdtempSync,
-  readFileSync,
   rmSync,
   utimesSync,
   writeFileSync,
@@ -16,6 +15,7 @@ import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
 import {
   describeSourceRevision,
+  snapshotWorktree,
   wasTruncated,
   worktreeFingerprint,
 } from "../diagnostics/source-revision.js";
@@ -576,7 +576,9 @@ describe("describeSourceRevision — a supplied snapshot is reused, not re-probe
     // ...but the caller hands over a snapshot taken a moment earlier, which saw two changes.
     const s = await describeSourceRevision(clone, "controlled", {
       fingerprint: "irrelevant-for-this-assertion",
+      head: git(clone, "rev-parse", "HEAD"),
       status: { ok: true, out: " M README.md\n?? scratch.txt" },
+      indexFlags: { ok: true, out: "H README.md" },
     });
 
     // If the probe had been re-run, this would read 0/false from the real tree.
@@ -591,6 +593,47 @@ describe("describeSourceRevision — a supplied snapshot is reused, not re-probe
     const s = await describeSourceRevision(clone, "controlled");
     expect(s.dirty).toBe(true);
     expect(s.dirty_paths).toBe(1);
+  });
+});
+
+// The before/after fingerprints guard an interval. Anything the description reads for itself
+// sits OUTSIDE that interval and can therefore disagree with what the payload saw.
+describe("the read guard covers the commit and the index, not just status output", () => {
+  it("describes the snapshot's commit, not whatever HEAD became afterwards", async () => {
+    const { clone } = originWithClone();
+    const captured = git(clone, "rev-parse", "HEAD");
+    const snapshot = await snapshotWorktree(clone, "controlled");
+    expect(snapshot.head).toBe(captured);
+
+    // The checkout moves after the snapshot — exactly the fast-forward this feature exists for.
+    writeFileSync(path.join(clone, "later.md"), "later\n");
+    git(clone, "add", "later.md");
+    git(clone, "commit", "-m", "later");
+    expect(git(clone, "rev-parse", "HEAD")).not.toBe(captured);
+
+    const s = await describeSourceRevision(clone, "controlled", snapshot);
+    // Re-reading HEAD here would attribute the payload to a commit it never saw.
+    expect(s.source_revision).toBe(captured);
+  });
+
+  it("notices a tracked file edited under an index flag and then restored and unflagged", async () => {
+    const { clone } = originWithClone();
+
+    // Before: the file is modified but hidden from status by skip-worktree.
+    git(clone, "update-index", "--skip-worktree", "README.md");
+    writeFileSync(path.join(clone, "README.md"), "transient edit\n");
+    const before = await snapshotWorktree(clone, "controlled");
+    // status alone sees a spotless tree, which is the whole problem.
+    expect(before.status?.ok === true ? before.status.out : "x").toBe("");
+
+    // After: restored and unflagged, so status is clean and no flag remains either.
+    git(clone, "update-index", "--no-skip-worktree", "README.md");
+    writeFileSync(path.join(clone, "README.md"), "seed\n");
+    const after = await snapshotWorktree(clone, "controlled");
+    expect(after.status?.ok === true ? after.status.out : "x").toBe("");
+
+    // Hashing status alone would make these identical and certify the transient edit away.
+    expect(after.fingerprint).not.toBe(before.fingerprint);
   });
 });
 

--- a/ops/mcp/src/tests/source-revision.test.ts
+++ b/ops/mcp/src/tests/source-revision.test.ts
@@ -1,0 +1,236 @@
+import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+import { describeSourceRevision } from "../diagnostics/source-revision.js";
+import { registerAgentOpsTools } from "../tools/agent-ops.js";
+
+// These tests build real git repositories in a temp directory rather than mocking git.
+// The behaviour under test IS the reading of git state, so a mock would assert that the
+// test's own idea of a dirty tree matches itself.
+
+const GIT_ENV = [
+  "-c", "user.email=test@example.invalid",
+  "-c", "user.name=ICN Test",
+  "-c", "commit.gpgsign=false",
+  "-c", "init.defaultBranch=main",
+];
+
+function git(cwd: string, ...args: string[]): string {
+  return execFileSync("git", [...GIT_ENV, ...args], {
+    cwd,
+    encoding: "utf-8",
+    stdio: ["ignore", "pipe", "pipe"],
+  }).trim();
+}
+
+const temps: string[] = [];
+function tempDir(label: string): string {
+  const d = mkdtempSync(path.join(tmpdir(), `icn-srcrev-${label}-`));
+  temps.push(d);
+  return d;
+}
+
+/** A bare origin with one commit, plus a clone that tracks it and is level with it. */
+function originWithClone(): { origin: string; clone: string } {
+  const origin = tempDir("origin");
+  git(origin, "init", "--bare", ".");
+  const seed = tempDir("seed");
+  git(seed, "clone", origin, ".");
+  writeFileSync(path.join(seed, "README.md"), "seed\n");
+  git(seed, "add", "README.md");
+  git(seed, "commit", "-m", "seed");
+  git(seed, "push", "-u", "origin", "main");
+  const clone = tempDir("clone");
+  git(clone, "clone", origin, ".");
+  return { origin, clone };
+}
+
+afterAll(() => {
+  for (const d of temps) rmSync(d, { recursive: true, force: true });
+});
+
+describe("describeSourceRevision — a clean, current source", () => {
+  it("reports its revision and is trustworthy with no warnings", async () => {
+    const { clone } = originWithClone();
+    const s = await describeSourceRevision(clone);
+
+    expect(s.source_revision).toMatch(/^[0-9a-f]{40}$/);
+    expect(s.source_checkout).toBe(clone);
+    expect(s.source_ref).toBe("main");
+    expect(s.upstream).toBe("origin/main");
+    expect(s.dirty).toBe(false);
+    expect(s.dirty_paths).toBe(0);
+    expect(s.behind_upstream).toBe(0);
+    expect(s.trustworthy).toBe(true);
+    expect(s.warnings).toEqual([]);
+  });
+
+  it("reports the same revision git itself reports", async () => {
+    const { clone } = originWithClone();
+    const s = await describeSourceRevision(clone);
+    expect(s.source_revision).toBe(git(clone, "rev-parse", "HEAD"));
+  });
+});
+
+// The other direction: each way a source can be untrustworthy must be detected.
+// A stamp that only ever says "fine" would be worse than no stamp, because it would
+// lend false confidence to exactly the stale answers it exists to expose.
+describe("describeSourceRevision — an untrustworthy source is detected", () => {
+  it("flags a tree with uncommitted changes", async () => {
+    const { clone } = originWithClone();
+    writeFileSync(path.join(clone, "README.md"), "locally edited\n");
+    writeFileSync(path.join(clone, "untracked.txt"), "new\n");
+
+    const s = await describeSourceRevision(clone);
+    expect(s.dirty).toBe(true);
+    expect(s.dirty_paths).toBe(2);
+    expect(s.trustworthy).toBe(false);
+    expect(s.warnings.join(" ")).toMatch(/uncommitted/);
+  });
+
+  it("flags a tree that is behind its upstream", async () => {
+    const { origin, clone } = originWithClone();
+
+    const pusher = tempDir("pusher");
+    git(pusher, "clone", origin, ".");
+    writeFileSync(path.join(pusher, "second.md"), "second\n");
+    git(pusher, "add", "second.md");
+    git(pusher, "commit", "-m", "second");
+    git(pusher, "push", "origin", "main");
+
+    git(clone, "fetch", "origin");
+
+    const s = await describeSourceRevision(clone);
+    expect(s.behind_upstream).toBe(1);
+    expect(s.dirty).toBe(false);
+    expect(s.trustworthy).toBe(false);
+    expect(s.warnings.join(" ")).toMatch(/behind origin\/main/);
+  });
+
+  it("flags a tree whose staleness cannot be measured (no upstream)", async () => {
+    const solo = tempDir("solo");
+    git(solo, "init", ".");
+    writeFileSync(path.join(solo, "a.md"), "a\n");
+    git(solo, "add", "a.md");
+    git(solo, "commit", "-m", "a");
+
+    const s = await describeSourceRevision(solo);
+    expect(s.source_revision).toMatch(/^[0-9a-f]{40}$/);
+    expect(s.upstream).toBeNull();
+    expect(s.behind_upstream).toBeNull();
+    // Known revision and a clean tree are not enough: unmeasurable staleness is not "current".
+    expect(s.trustworthy).toBe(false);
+    expect(s.warnings.join(" ")).toMatch(/no upstream/);
+  });
+
+  // A revision can be readable while cleanliness is not: a truncated .git/index is what a
+  // crashed process — or a host that ran out of disk — leaves behind. This is the branch the
+  // fail-open mutation lives in, so it needs a real fault rather than a mocked one.
+  it("refuses to call a tree clean when cleanliness cannot be determined", async () => {
+    const { clone } = originWithClone();
+    const head = git(clone, "rev-parse", "HEAD");
+    writeFileSync(path.join(clone, ".git", "index"), "GARBAGE-NOT-AN-INDEX");
+
+    const s = await describeSourceRevision(clone);
+    // The revision is still readable — refs are intact.
+    expect(s.source_revision).toBe(head);
+    // But cleanliness is unknown, and unknown must not be reported as clean.
+    expect(s.dirty).toBeNull();
+    expect(s.dirty_paths).toBeNull();
+    expect(s.trustworthy).toBe(false);
+    expect(s.warnings.join(" ")).toMatch(/could not determine whether the source checkout is clean/);
+  });
+
+  it("flags a directory that is not a git tree at all", async () => {
+    const plain = tempDir("plain");
+    const s = await describeSourceRevision(plain);
+
+    expect(s.source_revision).toBeNull();
+    expect(s.source_ref).toBeNull();
+    // Unknown cleanliness must never be reported as clean.
+    expect(s.dirty).toBeNull();
+    expect(s.dirty_paths).toBeNull();
+    expect(s.trustworthy).toBe(false);
+    expect(s.warnings.join(" ")).toMatch(/not a readable git tree/);
+  });
+});
+
+describe("describeSourceRevision — how the root was chosen is reported", () => {
+  const saved = process.env["ICN_ROOT"];
+  afterEach(() => {
+    if (saved === undefined) delete process.env["ICN_ROOT"];
+    else process.env["ICN_ROOT"] = saved;
+  });
+
+  it("reports ICN_ROOT when the environment pins the root", async () => {
+    const { clone } = originWithClone();
+    process.env["ICN_ROOT"] = clone;
+    const s = await describeSourceRevision(clone);
+    expect(s.resolved_from).toBe("ICN_ROOT");
+  });
+
+  it("reports server_location when nothing pins the root", async () => {
+    const { clone } = originWithClone();
+    delete process.env["ICN_ROOT"];
+    const s = await describeSourceRevision(clone);
+    expect(s.resolved_from).toBe("server_location");
+  });
+});
+
+// The policy under test: repository-DERIVED answers are stamped; statically compiled
+// catalogs are not. Both directions are asserted, because "stamp everything" and
+// "stamp nothing" would each pass a one-sided test.
+describe("icn_ops tools — the stamping policy", () => {
+  let client: Client;
+  let repo: string;
+  const saved = process.env["ICN_ROOT"];
+
+  beforeAll(async () => {
+    repo = originWithClone().clone;
+    process.env["ICN_ROOT"] = repo;
+    const server = new McpServer({ name: "icn-ops-test", version: "0.0.0" });
+    registerAgentOpsTools(server);
+    const [ct, st] = InMemoryTransport.createLinkedPair();
+    client = new Client({ name: "test-client", version: "0.0.0" });
+    await Promise.all([server.connect(st), client.connect(ct)]);
+  });
+
+  afterAll(() => {
+    if (saved === undefined) delete process.env["ICN_ROOT"];
+    else process.env["ICN_ROOT"] = saved;
+  });
+
+  async function call(name: string): Promise<Record<string, unknown>> {
+    const res = (await client.callTool({ name, arguments: {} })) as {
+      content: Array<{ type: string; text: string }>;
+    };
+    return JSON.parse(res.content[0]?.text ?? "{}") as Record<string, unknown>;
+  }
+
+  it.each(["icn_ops_repo_map", "icn_ops_state_index"])(
+    "%s carries the revision it was produced from",
+    async (tool) => {
+      const body = await call(tool);
+      const source = body["source"] as Record<string, unknown> | undefined;
+      expect(source, `${tool} must carry a source stamp`).toBeDefined();
+      expect(source?.["source_revision"]).toBe(git(repo, "rev-parse", "HEAD"));
+      expect(source?.["source_checkout"]).toBe(repo);
+      expect(source?.["trustworthy"]).toBe(true);
+      // The payload itself must survive the stamp.
+      expect(body["entries"]).toBeDefined();
+    }
+  );
+
+  it.each(["icn_ops_agent_brief", "icn_ops_command_catalog"])(
+    "%s is compiled into the build and is NOT stamped",
+    async (tool) => {
+      const body = await call(tool);
+      expect(body["source"]).toBeUndefined();
+    }
+  );
+});

--- a/ops/mcp/src/tests/source-revision.test.ts
+++ b/ops/mcp/src/tests/source-revision.test.ts
@@ -103,6 +103,23 @@ describe("describeSourceRevision — an untrustworthy source is detected", () =>
     expect(s.warnings.join(" ")).toMatch(/uncommitted/);
   });
 
+  it("flags a clean tree holding commits its upstream does not have", async () => {
+    const { clone } = originWithClone();
+    writeFileSync(path.join(clone, "unpushed.md"), "local only\n");
+    git(clone, "add", "unpushed.md");
+    git(clone, "commit", "-m", "unpushed");
+
+    const s = await describeSourceRevision(clone);
+    // The working tree is spotless and nothing is behind — the one-directional check that
+    // `HEAD..upstream` performs would call this level and certify it.
+    expect(s.dirty).toBe(false);
+    expect(s.behind_upstream).toBe(0);
+    // But it holds a commit that exists nowhere else, so it is not level.
+    expect(s.ahead_of_upstream).toBe(1);
+    expect(s.trustworthy).toBe(false);
+    expect(s.warnings.join(" ")).toMatch(/exists nowhere else/);
+  });
+
   it("flags a tree that is behind its upstream", async () => {
     const { origin, clone } = originWithClone();
 
@@ -206,27 +223,31 @@ describe("describeSourceRevision — how the root was chosen is reported", () =>
 // moves away from it — stale and confident, which is the exact state this module exists to
 // expose. Currency therefore requires evidence that the tracking refs were actually refreshed.
 describe("describeSourceRevision — a stale tracking ref cannot certify currency", () => {
-  it("refuses to certify when the upstream has not been fetched recently", async () => {
+  it("warns that distance is a lower bound when the last fetch is old", async () => {
     const { clone } = originWithClone();
     const fetchHead = path.join(clone, ".git", "FETCH_HEAD");
     const longAgo = new Date(Date.now() - 72 * 3600 * 1000);
     utimesSync(fetchHead, longAgo, longAgo);
 
     const s = await describeSourceRevision(clone);
-    // Locally everything looks perfect: clean, and level with the tracking ref.
+    // Locally everything is faithful: clean, and exactly level with the tracking ref.
     expect(s.dirty).toBe(false);
     expect(s.behind_upstream).toBe(0);
-    // But "0 behind" is only a lower bound against a three-day-old view of the remote.
-    expect(s.trustworthy).toBe(false);
+    expect(s.ahead_of_upstream).toBe(0);
+    // So `trustworthy` — a claim about local faithfulness — stays true...
+    expect(s.trustworthy).toBe(true);
+    // ...while the staleness risk is carried explicitly, never silently folded away.
+    expect(s.remote_currency).toBe("unverified");
     expect(s.warnings.join(" ")).toMatch(/lower bound/);
-    expect(s.upstream_observed_at).not.toBeNull();
   });
 
-  it("records when the tracking refs were last observed", async () => {
+  it("never claims verified remote currency, because nothing local could prove it", async () => {
     const { clone } = originWithClone();
     const s = await describeSourceRevision(clone);
     expect(s.upstream_observed_at).toMatch(/^\d{4}-\d{2}-\d{2}T/);
-    expect(s.trustworthy).toBe(true);
+    // FETCH_HEAD is repository-wide: `git fetch origin otherbranch` refreshes it without
+    // touching this upstream, so it can raise suspicion but must never certify.
+    expect(s.remote_currency).toBe("unverified");
   });
 });
 

--- a/ops/mcp/src/tools/agent-ops.ts
+++ b/ops/mcp/src/tools/agent-ops.ts
@@ -16,7 +16,7 @@ import { buildVerificationPlan } from "../diagnostics/verification-plan.js";
 import { buildRepoMap } from "../diagnostics/repo-map.js";
 import {
   describeSourceRevision,
-  headRevision,
+  worktreeFingerprint,
 } from "../diagnostics/source-revision.js";
 import {
   buildAgentContextSpineView,
@@ -57,16 +57,22 @@ export function registerAgentOpsTools(
   // stale relative to the tree holding it — precisely the condition worth surfacing.
   async function repoDerived(
     build: () => Record<string, unknown> | Promise<Record<string, unknown>>,
-    root: string = repoRoot
+    root?: string
   ): Promise<{ content: { type: "text"; text: string }[] }> {
-    const before = await headRevision(root);
+    // `root` stays undefined for the ordinary case so describeSourceRevision resolves it the
+    // way it actually was — ICN_ROOT or the server's location. Defaulting it to repoRoot here
+    // and passing that on would make every response claim `explicit_root`, which is only true
+    // of the caller-lane case.
+    const target = root ?? repoRoot;
+    const before = await worktreeFingerprint(target);
     const payload = await build();
     const source = await describeSourceRevision(root);
-    if (before !== source.source_revision) {
+    const after = await worktreeFingerprint(target);
+    if (before === null || after === null || before !== after) {
       source.trustworthy = false;
       source.warnings.push(
-        `HEAD moved from ${before ?? "unknown"} to ${source.source_revision ?? "unknown"} while ` +
-          "this answer was being read; the payload may describe a different revision than the stamp"
+        "the checkout's commit or working tree changed while this answer was being read, or " +
+          "could not be determined; the payload may describe state the stamp does not"
       );
     }
     return {

--- a/ops/mcp/src/tools/agent-ops.ts
+++ b/ops/mcp/src/tools/agent-ops.ts
@@ -14,7 +14,10 @@ import { buildStateIndex } from "../diagnostics/state-index.js";
 import { buildNextStepsReport } from "../diagnostics/next-steps.js";
 import { buildVerificationPlan } from "../diagnostics/verification-plan.js";
 import { buildRepoMap } from "../diagnostics/repo-map.js";
-import { describeSourceRevision } from "../diagnostics/source-revision.js";
+import {
+  describeSourceRevision,
+  headRevision,
+} from "../diagnostics/source-revision.js";
 import {
   buildAgentContextSpineView,
   buildPathBrief,
@@ -27,29 +30,47 @@ export function registerAgentOpsTools(
   const repoRoot = resolveMonorepoRoot();
 
   // Every repository-DERIVED answer carries the provenance of the tree it was read from, so a
-  // stale or dirty source is visible in the answer instead of looking identical to a current
-  // one. Statically compiled catalogs (agent_brief, command_catalog, verification_plan) are
-  // deliberately NOT stamped: they are baked into the build and are not reads of the checkout,
-  // so tying them to its revision would assert a relationship that does not exist.
+  // stale or dirty source is visible in the answer instead of looking identical to a current one.
+  // Statically compiled catalogs (agent_brief, command_catalog, verification_plan) are
+  // deliberately NOT stamped: they are baked into the build and are not reads of the checkout, so
+  // tying them to its revision would assert a relationship that does not exist.
   //
-  // `root` is the tree the payload was actually read from, which is not always repoRoot —
+  // `build` is a thunk rather than an already-computed value so that HEAD is captured BEFORE the
+  // payload is read. Otherwise a checkout fast-forwarded mid-call would return data read from the
+  // old tree under a stamp naming the new one — a revision-attribution bug in the very feature
+  // that exists to prevent them, and one made likelier by the host-synchronisation work this is
+  // a step towards. A revision that moves across the read fails closed.
+  //
+  // `root` is the tree the payload is read from, which is not always repoRoot —
   // icn_ops_agent_runtime deliberately reads the CALLER's lane instead.
+  //
+  // SCOPE. This covers answers whose CONTENT is read out of one checkout, where the reader
+  // cannot otherwise tell which. It does not cover `repo_status` / `worktree_status` in
+  // tools/repos.ts: those report ON a set of trees and already name each one per row, so the
+  // provenance is intrinsic rather than missing — and `repo_status` returns an array, which this
+  // object-shaped stamp cannot carry without changing its contract. Giving those surfaces
+  // staleness semantics is a separate change, tracked with the bare-store work (R1-B).
   //
   // This is distinct from a generated artifact's own `source_commit` (the Agent Context Spine
   // carries one): that records the revision the artifact was generated FROM, while `source`
   // records the checkout this answer was read OUT OF. When the two disagree, the artifact is
   // stale relative to the tree holding it — precisely the condition worth surfacing.
-  // `payload` is deliberately an object type rather than `unknown`: spreading a string or an
-  // array would silently produce an index-keyed object ({"0":"a"}) instead of failing, so the
-  // shape is constrained at the call site where it can still be checked.
   async function repoDerived(
-    payload: Record<string, unknown>,
+    build: () => Record<string, unknown> | Promise<Record<string, unknown>>,
     root: string = repoRoot
   ): Promise<{ content: { type: "text"; text: string }[] }> {
+    const before = await headRevision(root);
+    const payload = await build();
     const source = await describeSourceRevision(root);
-    const body = { ...payload, source };
+    if (before !== source.source_revision) {
+      source.trustworthy = false;
+      source.warnings.push(
+        `HEAD moved from ${before ?? "unknown"} to ${source.source_revision ?? "unknown"} while ` +
+          "this answer was being read; the payload may describe a different revision than the stamp"
+      );
+    }
     return {
-      content: [{ type: "text", text: JSON.stringify(body, null, 2) }],
+      content: [{ type: "text", text: JSON.stringify({ ...payload, source }, null, 2) }],
     };
   }
 
@@ -86,6 +107,7 @@ export function registerAgentOpsTools(
       // fallback for callers that supply no cwd.
       const identity = discoverWorktree(cwd ?? process.cwd(), null);
       const manifestRoot = identity?.worktree_path ?? repoRoot;
+      return await repoDerived(async () => {
       const manifestPath = join(
         manifestRoot,
         "docs/reference/project-index/generated/agent-capabilities.json"
@@ -160,8 +182,8 @@ export function registerAgentOpsTools(
             ? { ...manifest, session }
             : { [section]: manifest[section] ?? [], session };
       if (manifestError) payload["manifest_error"] = manifestError;
-
-      return await repoDerived(payload, manifestRoot);
+      return payload;
+      }, manifestRoot);
     }
   );
 
@@ -170,8 +192,7 @@ export function registerAgentOpsTools(
     "Structured environment snapshot (git, Node/npm, optional gh/kubectl, MCP config parity hints). Never fails on missing optional tools; see warnings array.",
     {},
     async () => {
-      const report = await buildEnvironmentReport(repoRoot);
-      return await repoDerived(report);
+      return await repoDerived(() => buildEnvironmentReport(repoRoot));
     }
   );
 
@@ -180,8 +201,7 @@ export function registerAgentOpsTools(
     "Read-only diagnosis: MCP wiring, native sqlite module, portability script, dirty tree, optional CLIs. Returns severity, checks, and suggested repair commands (not executed).",
     {},
     async () => {
-      const report = await buildDoctorReport(repoRoot);
-      return await repoDerived(report);
+      return await repoDerived(() => buildDoctorReport(repoRoot));
     }
   );
 
@@ -222,7 +242,7 @@ export function registerAgentOpsTools(
       const filtered = wantAbsent
         ? entries
         : entries.filter((e) => e.present);
-      return await repoDerived({ entries: filtered });
+      return await repoDerived(() => ({ entries: filtered }));
     }
   );
 
@@ -231,8 +251,7 @@ export function registerAgentOpsTools(
     "Read-only workflow guidance: severity, short summary, and recommended next verification or setup steps (commands are strings only; never executed by MCP). Uses environment, doctor, state index, MCP parity, and worktree hints without echoing full raw diagnostics.",
     {},
     async () => {
-      const report = await buildNextStepsReport(repoRoot);
-      return await repoDerived(report);
+      return await repoDerived(() => buildNextStepsReport(repoRoot));
     }
   );
 
@@ -261,8 +280,7 @@ export function registerAgentOpsTools(
     "Compact repo layout map for agents: key directories with present flag, one-line description, agent_use, and optional caution. Paths are checked on disk; absent paths are present:false.",
     {},
     async () => {
-      const map = buildRepoMap(repoRoot);
-      return await repoDerived(map);
+      return await repoDerived(() => buildRepoMap(repoRoot));
     }
   );
 
@@ -283,11 +301,11 @@ export function registerAgentOpsTools(
       path: z.string().optional().describe("Filter nodes whose path contains this substring (e.g. icn-gateway)."),
     },
     async ({ paths, node, type, subsystem, path }) => {
-      const view =
+      return await repoDerived(() =>
         paths && paths.length > 0
           ? buildPathBrief(repoRoot, paths)
-          : buildAgentContextSpineView(repoRoot, { node, type, subsystem, path });
-      return await repoDerived(view);
+          : buildAgentContextSpineView(repoRoot, { node, type, subsystem, path })
+      );
     }
   );
 }

--- a/ops/mcp/src/tools/agent-ops.ts
+++ b/ops/mcp/src/tools/agent-ops.ts
@@ -237,12 +237,13 @@ export function registerAgentOpsTools(
         .describe("If true, list absent entries explicitly (default true)."),
     },
     async ({ include_absent }) => {
-      const { entries } = buildStateIndex(repoRoot);
-      const wantAbsent = include_absent !== false;
-      const filtered = wantAbsent
-        ? entries
-        : entries.filter((e) => e.present);
-      return await repoDerived(() => ({ entries: filtered }));
+      // The read itself must sit inside the thunk: closing over an already-built value would
+      // let both revision probes observe a new HEAD while `entries` came from the old tree.
+      return await repoDerived(() => {
+        const { entries } = buildStateIndex(repoRoot);
+        const wantAbsent = include_absent !== false;
+        return { entries: wantAbsent ? entries : entries.filter((e) => e.present) };
+      });
     }
   );
 

--- a/ops/mcp/src/tools/agent-ops.ts
+++ b/ops/mcp/src/tools/agent-ops.ts
@@ -189,7 +189,10 @@ export function registerAgentOpsTools(
             : { [section]: manifest[section] ?? [], session };
       if (manifestError) payload["manifest_error"] = manifestError;
       return payload;
-      }, manifestRoot);
+      // Pass the lane only when discovery actually found one. When it falls back to repoRoot,
+      // the root was NOT explicitly chosen — it came from ICN_ROOT or the server's location, and
+      // the stamp should say so rather than claiming this call site picked it.
+      }, identity?.worktree_path);
     }
   );
 

--- a/ops/mcp/src/tools/agent-ops.ts
+++ b/ops/mcp/src/tools/agent-ops.ts
@@ -14,6 +14,7 @@ import { buildStateIndex } from "../diagnostics/state-index.js";
 import { buildNextStepsReport } from "../diagnostics/next-steps.js";
 import { buildVerificationPlan } from "../diagnostics/verification-plan.js";
 import { buildRepoMap } from "../diagnostics/repo-map.js";
+import { describeSourceRevision } from "../diagnostics/source-revision.js";
 import {
   buildAgentContextSpineView,
   buildPathBrief,
@@ -24,6 +25,33 @@ export function registerAgentOpsTools(
   db?: Database.Database
 ): void {
   const repoRoot = resolveMonorepoRoot();
+
+  // Every repository-DERIVED answer carries the provenance of the tree it was read from, so a
+  // stale or dirty source is visible in the answer instead of looking identical to a current
+  // one. Statically compiled catalogs (agent_brief, command_catalog, verification_plan) are
+  // deliberately NOT stamped: they are baked into the build and are not reads of the checkout,
+  // so tying them to its revision would assert a relationship that does not exist.
+  //
+  // `root` is the tree the payload was actually read from, which is not always repoRoot —
+  // icn_ops_agent_runtime deliberately reads the CALLER's lane instead.
+  //
+  // This is distinct from a generated artifact's own `source_commit` (the Agent Context Spine
+  // carries one): that records the revision the artifact was generated FROM, while `source`
+  // records the checkout this answer was read OUT OF. When the two disagree, the artifact is
+  // stale relative to the tree holding it — precisely the condition worth surfacing.
+  // `payload` is deliberately an object type rather than `unknown`: spreading a string or an
+  // array would silently produce an index-keyed object ({"0":"a"}) instead of failing, so the
+  // shape is constrained at the call site where it can still be checked.
+  async function repoDerived(
+    payload: Record<string, unknown>,
+    root: string = repoRoot
+  ): Promise<{ content: { type: "text"; text: string }[] }> {
+    const source = await describeSourceRevision(root);
+    const body = { ...payload, source };
+    return {
+      content: [{ type: "text", text: JSON.stringify(body, null, 2) }],
+    };
+  }
 
   server.tool(
     "icn_ops_agent_runtime",
@@ -133,7 +161,7 @@ export function registerAgentOpsTools(
             : { [section]: manifest[section] ?? [], session };
       if (manifestError) payload["manifest_error"] = manifestError;
 
-      return { content: [{ type: "text", text: JSON.stringify(payload, null, 2) }] };
+      return await repoDerived(payload, manifestRoot);
     }
   );
 
@@ -143,9 +171,7 @@ export function registerAgentOpsTools(
     {},
     async () => {
       const report = await buildEnvironmentReport(repoRoot);
-      return {
-        content: [{ type: "text", text: JSON.stringify(report, null, 2) }],
-      };
+      return await repoDerived(report);
     }
   );
 
@@ -155,9 +181,7 @@ export function registerAgentOpsTools(
     {},
     async () => {
       const report = await buildDoctorReport(repoRoot);
-      return {
-        content: [{ type: "text", text: JSON.stringify(report, null, 2) }],
-      };
+      return await repoDerived(report);
     }
   );
 
@@ -198,9 +222,7 @@ export function registerAgentOpsTools(
       const filtered = wantAbsent
         ? entries
         : entries.filter((e) => e.present);
-      return {
-        content: [{ type: "text", text: JSON.stringify({ entries: filtered }, null, 2) }],
-      };
+      return await repoDerived({ entries: filtered });
     }
   );
 
@@ -210,9 +232,7 @@ export function registerAgentOpsTools(
     {},
     async () => {
       const report = await buildNextStepsReport(repoRoot);
-      return {
-        content: [{ type: "text", text: JSON.stringify(report, null, 2) }],
-      };
+      return await repoDerived(report);
     }
   );
 
@@ -242,9 +262,7 @@ export function registerAgentOpsTools(
     {},
     async () => {
       const map = buildRepoMap(repoRoot);
-      return {
-        content: [{ type: "text", text: JSON.stringify(map, null, 2) }],
-      };
+      return await repoDerived(map);
     }
   );
 
@@ -269,9 +287,7 @@ export function registerAgentOpsTools(
         paths && paths.length > 0
           ? buildPathBrief(repoRoot, paths)
           : buildAgentContextSpineView(repoRoot, { node, type, subsystem, path });
-      return {
-        content: [{ type: "text", text: JSON.stringify(view, null, 2) }],
-      };
+      return await repoDerived(view);
     }
   );
 }

--- a/ops/mcp/src/tools/agent-ops.ts
+++ b/ops/mcp/src/tools/agent-ops.ts
@@ -16,7 +16,7 @@ import { buildVerificationPlan } from "../diagnostics/verification-plan.js";
 import { buildRepoMap } from "../diagnostics/repo-map.js";
 import {
   describeSourceRevision,
-  worktreeFingerprint,
+  snapshotWorktree,
   type SourceProvenance,
 } from "../diagnostics/source-revision.js";
 import {
@@ -66,11 +66,17 @@ export function registerAgentOpsTools(
     // and passing that on would make every response claim `explicit_root`, which is only true
     // of the caller-lane case.
     const target = root ?? repoRoot;
-    const before = await worktreeFingerprint(target, provenance);
+    // Two working-tree scans, not three: the before/after guard needs both, and the source
+    // description reuses the second rather than taking a third of the same tree.
+    const before = await snapshotWorktree(target, provenance);
     const payload = await build();
-    const source = await describeSourceRevision(root, provenance);
-    const after = await worktreeFingerprint(target, provenance);
-    if (before === null || after === null || before !== after) {
+    const after = await snapshotWorktree(target, provenance);
+    const source = await describeSourceRevision(root, provenance, after);
+    if (
+      before.fingerprint === null ||
+      after.fingerprint === null ||
+      before.fingerprint !== after.fingerprint
+    ) {
       source.trustworthy = false;
       source.warnings.push(
         "the checkout's commit or working tree changed while this answer was being read, or " +

--- a/ops/mcp/src/tools/agent-ops.ts
+++ b/ops/mcp/src/tools/agent-ops.ts
@@ -17,6 +17,7 @@ import { buildRepoMap } from "../diagnostics/repo-map.js";
 import {
   describeSourceRevision,
   worktreeFingerprint,
+  type SourceProvenance,
 } from "../diagnostics/source-revision.js";
 import {
   buildAgentContextSpineView,
@@ -57,17 +58,18 @@ export function registerAgentOpsTools(
   // stale relative to the tree holding it — precisely the condition worth surfacing.
   async function repoDerived(
     build: () => Record<string, unknown> | Promise<Record<string, unknown>>,
-    root?: string
+    root?: string,
+    provenance: SourceProvenance = "controlled"
   ): Promise<{ content: { type: "text"; text: string }[] }> {
     // `root` stays undefined for the ordinary case so describeSourceRevision resolves it the
     // way it actually was — ICN_ROOT or the server's location. Defaulting it to repoRoot here
     // and passing that on would make every response claim `explicit_root`, which is only true
     // of the caller-lane case.
     const target = root ?? repoRoot;
-    const before = await worktreeFingerprint(target);
+    const before = await worktreeFingerprint(target, provenance);
     const payload = await build();
-    const source = await describeSourceRevision(root);
-    const after = await worktreeFingerprint(target);
+    const source = await describeSourceRevision(root, provenance);
+    const after = await worktreeFingerprint(target, provenance);
     if (before === null || after === null || before !== after) {
       source.trustworthy = false;
       source.warnings.push(
@@ -192,7 +194,15 @@ export function registerAgentOpsTools(
       // Pass the lane only when discovery actually found one. When it falls back to repoRoot,
       // the root was NOT explicitly chosen — it came from ICN_ROOT or the server's location, and
       // the stamp should say so rather than claiming this call site picked it.
-      }, identity?.worktree_path);
+      //
+      // This is the ONLY tool that resolves its root from client input, which makes it the only
+      // one whose checkout is untrusted. `cwd` is what the caller supplied; when they supplied
+      // it and it resolved to a lane, the resulting tree is theirs to configure, so its working
+      // tree is never inspected (see SourceProvenance). Falling back to repoRoot, or resolving
+      // from the server's own cwd, is operator-controlled and keeps full inspection.
+      },
+      identity?.worktree_path,
+      cwd !== undefined && identity ? "caller_selected" : "controlled");
     }
   );
 


### PR DESCRIPTION
# Pull Request

## Delivery

- **Delivery lane**: STANDARD
- **Acceptance contract**: an icn-ops answer whose *content is read out of one checkout* names that checkout and revision, and says so when the source is dirty, behind, undeterminable, or not recently fetched.
- **Explicit non-goals**: does not change *which* tree is read, does not refuse to answer, does not touch host scripts or `mcp-host`.

<!-- ICN-DELIVERY-LIFECYCLE:BEGIN -->
```
ICN DELIVERY LIFECYCLE
State:                READY_FOR_REVIEW
Lane:                 STANDARD
Acceptance contract:  repo-derived icn-ops responses carry source_revision/source_checkout and detect stale or dirty sources
Review generation:    generations 1-10 addressed; all threads resolved
Freeze head:          8833211c7
Known blockers:       -
Follow-up ledger:     R1-B (read from the bare store at a declared SHA), R1-C (mcp-host cleanliness policy + doctor)
```
<!-- ICN-DELIVERY-LIFECYCLE:END -->

## Problem

icn-ops answers "what does the repository say" from whatever tree hosts the compiled binary (`resolveMonorepoRoot()` walks up from `import.meta.url`, or takes `ICN_ROOT`). No response says which tree that was.

On `icn-dev` today, three surfaces answer to the name `main`, measured against `origin/main` at `e1f7082d`:

| surface | revision | state |
|---|---|---|
| `origin/main` | `e1f7082d` (2026-09-10) | current |
| `mcp-host` — **what icn-ops answers from** | `5add7a48` (2026-08-30) | **23 behind, 43 uncommitted paths** |
| `main-readonly` | `8e41458e` (2026-08-28) | 35 behind, detached |

An agent orienting from icn-ops cannot distinguish a current answer from one describing a 23-commit-old tree carrying unreviewed local edits — during an identity-semantics migration. This is why operational knowledge migrated out of the tooling and into personal memory.

## Root cause

Repository truth is resolved *positionally* (where the binary sits) rather than *by revision*. Because the server never forms an opinion about which revision it is describing, it cannot be wrong about it — and cannot report it either.

## Claim

A repository-derived answer can name the revision it describes, and an untrustworthy source is visible in the answer instead of looking identical to a current one.

**Scope of "repository-derived".** Answers whose *content is read out of one checkout*, where the reader cannot otherwise tell which. It deliberately excludes `repo_status`/`worktree_status`, which report *on* a set of trees and already name each per row (and `repo_status` returns an array this object-shaped stamp cannot carry). Giving those staleness semantics belongs with R1-B.

## Scope

- `ops/mcp/src/diagnostics/source-revision.ts` **(new)** — `describeSourceRevision()`: checkout, revision, ref, upstream, dirty + path count, distance behind upstream, a derived `trustworthy` flag, and warnings explaining every "no".
- `ops/mcp/src/tools/agent-ops.ts` — one `repoDerived()` helper; applied to the seven repository-derived responses.
- `ops/mcp/src/tests/source-revision.test.ts` **(new)** — 13 tests.

**Fails closed.** When a probe cannot run, the field is `null` and `trustworthy` is `false`. An undetermined tree is never reported as clean — that specific fail-open is the bug the stamp exists to prevent.

**Seven stamped; three deliberately not.** `agent_brief`, `command_catalog` and `verification_plan` are statically compiled constants, not reads of the checkout. Stamping them with the checkout's revision would assert a relationship that does not exist. `icn_ops_agent_runtime` is stamped with the **caller's lane root**, which it already resolves deliberately, not with the server root.

This is distinct from a generated artifact's own `source_commit` (the Agent Context Spine carries one): that records the revision an artifact was generated *from*, while `source` records the checkout the answer was read *out of*. When they disagree, the artifact is stale relative to the tree holding it — which is worth seeing.

## Out of scope

- Reading repo truth from the canonical bare store at a declared SHA — **R1-B**.
- Making `mcp-host` clean and auto-fast-forwarded; `icn-dev-doctor` integration — **R1-C**.
- *Refusing* to answer when the source is dirty. Additive fields only; existing behaviour is preserved and no consumer is required to read `source`.
- Any host script, `repo-sync`, or Rust change.

## Verification

Run in `ops/mcp` at `f457b9873`:

| command | result |
|---|---|
| `npm run build` (tsc) | exit 0 |
| `npx vitest run src/tests/source-revision.test.ts` | **13 passed** |
| `npx vitest run` (full suite) | **326 passed, 19 files** |

### Live check against the three real surfaces

```
mcp-host      5add7a48d7b0 ref=main    dirty=true (43)  behind=23  trustworthy=false
              ! 43 uncommitted path(s); this answer may describe unreviewed local edits
              ! 23 commit(s) behind origin/main; this answer describes an older revision
main-readonly 8e41458e59d7 ref=HEAD    dirty=false      behind=null trustworthy=false
              ! no upstream tracking ref; its staleness cannot be measured
this lane     e1f7082d0179 ref=claude/…  dirty=false     behind=0   trustworthy=true
```

## Mutation evidence

A passing suite proves nothing until it can fail. Three mutations were applied to the committed code and the suite re-run; files were restored by copy (never `git checkout`) and verified byte-identical afterwards.

| mutation | result |
|---|---|
| `trustworthy` hardcoded `true` | **3 tests failed** |
| unknown cleanliness reported as clean (fail-open) | **initially PASSED — a real gap** |
| `icn_ops_repo_map` stamp removed | **1 test failed** |

The middle row is the reason the practice exists. The original suite exercised the "not a git tree" path, which returns early and never reaches the cleanliness branch — so the fail-open survived. A test was added using a **real fault** rather than a mock: a truncated `.git/index`, under which `rev-parse HEAD` still succeeds while `git status` fails. That is not a hypothetical — it is what a crashed process or a host that ran out of disk leaves behind. Re-run after the fix: **1 test failed**, and again after a later refactor.

## Also found while verifying

The first live run reported `main-readonly` as `dirty=null`. That was a 5s timeout on a cold `git status` over 3,451 files whose index had not been touched since Sep 1 — fail-closed behaved correctly, but produced a false "untrusted" on a healthy tree and gave no way to tell why. The budget is now 15s (matching `polling/git.ts`) and a timeout says so in the warning.

## Pre-review

Local Ollama pre-review is unavailable (nothing on `127.0.0.1:11435`; the tunnel originates off-VM), so a cheap-model pass was run instead against `review-lessons.md`. It raised one substantive point: `repoDerived(payload: unknown)` cast and spread. Its stated failure mode was wrong — `{...null}` yields `{}` and does not throw (verified) — but the underlying concern is real: spreading a string or array silently yields an index-keyed object. The signature is now `Record<string, unknown>`, which typechecks at every call site with no friction.

## Audit recommendation addressed

Development audit **R1**, slice A of A/B/C.

## What did not change

`resolveMonorepoRoot()`, `ICN_ROOT` semantics, every existing response field, and the set of registered tools. No Rust, no workflows, no docs.

## Layer classification
- [x] ops/coordination (process, refinery, hygiene)

## Type of change
- [x] New feature
- [x] Tests

## Risk

Low. Additive fields plus one new module; reverting the commit restores byte-identical prior behaviour. `describeSourceRevision()` adds up to five `git` subprocess calls per repo-derived tool call, each bounded at 15s and never throwing (`runCommand` returns structured failure). No caching is introduced — if measured call latency becomes a concern, the existing 30s `health_cache` poller is the natural place for it.

## Related
- Refs: development audit R1 (`~/icn-development-audit/12-recommendations.md`), program unit R1-A.

## Remaining unknowns

Whether `trustworthy` should eventually gate answers rather than annotate them. This PR only annotates; refusing is a behaviour change that belongs with R1-B/R1-C once the server reads from a source it controls.

## Review round 1 — `008f5aada`

Copilot and Codex each found ways this could name one tree while describing another — the exact failure the stamp exists to remove. All six threads addressed and resolved.

| # | Finding | Resolution |
|---|---|---|
| P1 | `GIT_DIR` overrides `-C` and is exported into linked worktrees — the only kind ICN uses | Reuses the exported `GIT_SANITISED_ENV` from `runtime/worktree-identity.ts` (one owner, not a copy). Test points `GIT_DIR` at a decoy repo with a different HEAD. |
| P1 | `git status` executes `core.fsmonitor`, and `cwd` is caller input | **Verified with git 2.43: it really does execute.** Now `-c core.fsmonitor=` + `core.hooksPath=/dev/null` + `GIT_OPTIONAL_LOCKS=0`. Sentinel-file test **with a control** proving git would run it unguarded. |
| P1 | An unfetched `@{u}` certifies a stale host as current | The deepest one. `behind_upstream` documented as a lower bound; `upstream_observed_at` added; currency now requires recent fetch evidence. Aligns with the existing note in `diagnostics/doctor.ts`. |
| P2 | HEAD could move between payload read and stamp | `repoDerived` takes a thunk, captures HEAD first, fails closed if it moves. |
| P2 | `resolved_from` claimed `ICN_ROOT` while describing a caller lane | Now reports `explicit_root` when a root is passed. |
| — | Contract false for `repo_status`/`worktree_status` | Contract **narrowed**, not widened — see Scope above. |

Two new guards are mutation-checked: leaking the ambient environment, and dropping the fetch-freshness term, each fail the suite.

**Verification at `008f5aada`:** tsc exit 0 · 18 tests in this suite (was 13) · **full suite 331 passed** (was 326).

## Review round 2 — `a50eea7ba`

Three more, two of which were the same mistake in different places: **claiming more than the evidence supports.** All resolved.

| # | Finding | Resolution |
|---|---|---|
| P1 | `HEAD..upstream` counts one direction, so a clean branch with an **unpushed commit** read as "0 behind" and was certified | Reproduced exactly. Now symmetric (`--left-right --count HEAD...upstream`); `ahead_of_upstream` reported; certification needs zero both ways. Mutation-checked. |
| P1 | FETCH_HEAD is repository-wide — `git fetch origin somebranch` refreshes it without touching `origin/main` | **Round 1's fix was wrong in kind, not degree.** See below. |
| P2 | `state_index` built its payload *before* entering the revision guard | The read now happens inside the thunk. |

### On the freshness finding — a reversal worth stating plainly

Round 1 made `trustworthy` require recent fetch evidence. Round 2 showed that evidence cannot be tied to a particular ref. Looking for a ref-tied alternative found none: **remote-tracking refs carry no reflog here** (`git log -g origin/main` is empty after both clone and explicit fetch). Git records nowhere, locally, when a ref was last checked against its remote.

So the fix was replaced rather than tightened:

- **`trustworthy`** now states **local faithfulness only** — known-clean and exactly level with the tracking ref. Fully provable.
- **`remote_currency`** is a new field, constant `"unverified"`, with that reasoning recorded on it. Only an actual fetch can change it — which is exactly what **R1-B** does.

Staleness is still surfaced loudly as a warning. It is no longer folded into a boolean that cannot carry it. This is the module's own stated principle applied to itself: *do not certify what you cannot prove.*

**Verification at `a50eea7ba`:** tsc exit 0 · 19 tests in this suite · **full suite 332**.

## Review round 3 — `1349088c4`

| # | Finding | Resolution |
|---|---|---|
| P1 | `status.showUntrackedFiles=no` let a tree holding uncommitted content report clean | `--untracked-files=normal` passed explicitly. Test sets the config **with a control** proving it really suppresses. |
| P2 | Every response claimed `explicit_root` — the wrapper defaulted its own root and passed it down | Wrapper leaves it undefined for the ordinary case. Now asserted **through the tool path**, which is the only path that matters. |
| P2 | The read guard watched HEAD only; a tree dirty during the read and cleaned after leaves HEAD untouched | Guard widened to the whole class — see below. |

### Widening the guard instead of patching the instance

Rounds 1–3 each found a narrower version of one thing: *the stamp can describe a different state than the payload.* HEAD race → `state_index` closure → working-tree state. Patching the third instance would have invited a fourth.

`worktreeFingerprint()` now snapshots the commit **and** a digest of the porcelain status, compared across the read; an indeterminate state returns null and never compares equal, so it fails closed. The `git restore` scenario is a test: dirty the tree, restore it, assert the fingerprint moved and returned while HEAD never changed.

**Cost, stated honestly:** two extra status probes per repository-derived call. Acceptable for a diagnostic at the latency measured here; if it stops being so, the existing 30s `health_cache` poller is the right home.

**Verification at `1349088c4`:** tsc exit 0 · 22 tests in this suite · **full suite 335**.

## Review round 4 — `6245cb601`

| # | Finding | Resolution |
|---|---|---|
| P1 | `core.worktree` redirected the cleanliness probe at another directory — a modified checkout pointing at a clean copy returns an empty status | Reproduced with git 2.43. Probes now pass `--work-tree <checkout>`. Test includes a control. Mutation-checked. |
| P2 | `agent_runtime` passed its fallback root as explicit when worktree discovery failed | Passes the lane only when one was found. |

### The family this closes

Four separate mechanisms let the *inspected* repository decide how it is inspected:

| Mechanism | Effect if unguarded |
|---|---|
| `GIT_DIR` / `GIT_WORK_TREE` in the environment | describes a different repository entirely |
| `core.fsmonitor` | executes a repository-chosen binary with the server's authority |
| `status.showUntrackedFiles=no` | hides uncommitted content, reports clean |
| `core.worktree` | inspects a different directory, reports clean |

All are closed the same way: **the probe states its own terms.** For a module whose entire purpose is trustworthy provenance, accepting the subject's configuration was the deepest recurring flaw, and it took four rounds to see it as one thing rather than four — and a fifth round to learn not to call the list complete.

**Verification at `6245cb601`:** tsc exit 0 · 23 tests in this suite · **full suite 336**.

## Review round 5 — `b204fdab8`, and a correction

Round 4 claimed the config family was "all closed." **That was an overclaim.** `git update-index --assume-unchanged` and `--skip-worktree` make git omit a tracked file from `status` entirely, so a modified payload file marked either way leaves a checkout looking spotless. Verified with git 2.43.

`ls-files -v` exposes them (lowercase = assume-unchanged, `S` = skip-worktree). They are now counted into a new **`index_hidden_paths`** field; non-zero warns, and certification requires zero. `dirty` still reports honestly what status said — the new field says whether status was the *whole* answer. Table-driven test over both flags, each with a control. Mutation-checked.

So the family is five, not four, and the list is no longer claimed to be exhaustive — only that **each known lever is closed and witnessed**:

| Mechanism | Effect if unguarded |
|---|---|
| `GIT_DIR` / `GIT_WORK_TREE` | describes a different repository |
| `core.fsmonitor` | executes a repository-chosen binary |
| `status.showUntrackedFiles=no` | hides untracked content |
| `core.worktree` | inspects a different directory |
| `assume-unchanged` / `skip-worktree` | hides modified **tracked** files |

**Verification at `b204fdab8`:** tsc exit 0 · 25 tests in this suite · **full suite 338**.

## Review round 6 — `ef1635e29`

A fail-open **in the guard round 5 added.** `runCommand` truncates oversized output and still reports success, so a probe that *counts* things reads a shortened list as "fewer findings" rather than "incomplete answer" — an `assume-unchanged` file past the cutoff would simply not be seen.

Truncation is now a probe **failure**, failing closed like every other unknown; the per-probe budget rises 256 KiB → 8 MiB, and the failure names its cause. This covers `status` too, which shared the budget.

**Correction to the report:** the 301,017-byte figure is not reproducible here — `git ls-files -v` on this repository at this revision is **162,515 bytes**, under the old cap. The defect was *latent*, not live. At 62% of the old budget that is not comfortable, and a guard that silently under-counts is worse than one that refuses, so the fix stands regardless.

The test builds the truncation marker with `runCommand` itself rather than hand-writing it, so it fails if the two modules drift apart on its shape — the real risk in a string contract between them.

**Verification at `ef1635e29`:** tsc exit 0 · 27 tests in this suite · **full suite 340**.

## Round 7 — resolved as a scope split, not a seventh knob

`.gitattributes` + `filter.<driver>.clean` is executed by `git status` (verified, git 2.43), so a read-only probe ran repository-controlled code. It was the **sixth** mechanism of its kind, and there is no per-invocation override that disables filters generically.

**Decision (2026-09-11): the levers are not a bounded set, so enumerating them is the wrong abstraction.** What *is* bounded is the line between inert and non-inert reads:

| Read | Executes repository-controlled code? |
|---|---|
| `rev-parse HEAD`, `rev-list --count` | no — verified |
| `git status` | **yes** — verified |

### R1-A (this PR) — the bounded safety bridge

A checkout **selected by the caller** gets ref and object reads only. `icn_ops_agent_runtime` is the only tool resolving its root from client input, and only when `cwd` was supplied and resolved to a lane; such a source is marked `caller_selected` and its working tree is never read.

Revision identity **survives** (it came from ref reads). Cleanliness is **indeterminate — null, not false** — and `trustworthy` is false. Operator-controlled roots are unaffected. No further git configuration mechanisms are enumerated.

**Witness:** a repo whose clean filter writes a sentinel when git runs it — with a control proving `git status` really executes it, an end-to-end case through `icn_ops_agent_runtime`, and a contrast case showing a controlled root still *is* inspected, so the gate is doing the work rather than nothing being inspected. Mutation-checked: removing the gate executes the filter and fails two tests.

**Honest note:** the `inspectWorkingTree &&` term in `trustworthy` is deliberately **unwitnessed** defence-in-depth — redundant today, since `dirty === null` already blocks certification, and removing it fails no test. It stays so a future non-null default cannot quietly re-certify an uninspected source, and it is labelled rather than counted as proven.

### R1-B (not this PR) — the architectural cure

Authoritative reads from a declared revision in **controlled canonical storage**, with no dependence on mutable caller working-tree state — eliminating this family **by construction**. It carries an explicit threat model over repository config, process environment, attributes, filters, hooks, alternates, and any other ambient mechanism that could make a purportedly inert read execute code or describe the wrong object set. **Deliberately not absorbed into this PR.**

**Verification at `b5106d92a`:** tsc exit 0 · 32 tests in this suite · **full suite 345**.

## Round 8 — the bridge's premise was falsified

Round 7's bridge drew its line at *"ref and object reads are inert."* Round 8 showed that is not safe to assert: on a partial clone, object traversal can trigger a lazy fetch from a promisor remote, and a remote URL may be `ext::<command>`. Both are documented git behaviours.

**Honest limit — stated because a vacuous test is worse than none.** The execution was **not reproducible** here: two fixtures failed to produce a partial clone with missing objects (`extensions.partialClone` stayed empty even with `uploadpack.allowFilter` on the origin). A sentinel witness would have passed for the wrong reason, so none is claimed. This change is **fail-closed narrowing of a premise that cannot be proven**, not a fix for a demonstrated exploit.

The line now sits where it can be held:

> A caller-selected checkout gets **ref resolution only** — no working-tree inspection, and no object traversal.

Identity survives (`HEAD`, its ref name, the upstream's name). Divergence joins cleanliness as indeterminate, with a warning saying why. Operator-controlled roots are unchanged and still measure both. `GIT_NO_LAZY_FETCH=1` is added as defence in depth — one environment variable on the probe, not an enumeration of repository config; what closes the path is that caller-selected sources no longer traverse objects at all.

**Witness** uses a controlled contrast: the same checkout reports **1 behind** under `controlled` and **null** under `caller_selected`, so the gate is doing the work rather than nothing being measured. Mutation-checked: traversing anyway fails the suite.

**Verification at `04fbd92b1`:** tsc exit 0 · 33 tests in this suite · **full suite 346**.

## Round 9 — cost of the guard, and a flaky witness withdrawn

The guard this PR adds took **three** working-tree scans per response: before-guard, the source description re-scanning the same tree, after-guard — each with a 15s budget, worst case `icn_ops_next_steps`. I had flagged the cost earlier without acting on it; the review quantified it.

The before/after guard needs two scans. The third bought nothing. `snapshotWorktree()` now returns the probe alongside the fingerprint, and `describeSourceRevision` describes cleanliness from that snapshot instead of re-probing. **Two scans, guard intact.**

### The first witness was flaky and was withdrawn, not patched

I initially counted real scans using an appending clean filter as an instrument. It passed alone and failed in the full suite, intermittently. The cause is worth recording: **a plain `git status` refreshes and writes the index stat cache**, after which later scans see the file as unchanged and skip the filter — so whether the instrument registers anything depends on filesystem timestamp granularity. *The calibration step was perturbing the thing it calibrated.*

`GIT_OPTIONAL_LOCKS=0` on the calibration plus re-dirtying the file narrowed it but did not remove it — still one failure in two runs. A flaky witness is worse than none, so it was **replaced**: the reuse is now witnessed by its observable consequence — a supplied snapshot is what the description reports. Deterministic, and mutation-checked.

**Verification at `c0b1bd15f`:** tsc exit 0 · 35 tests in this suite · **full suite 348, stable across three consecutive runs**.

## Round 10 — guard width, and a baseline that went stale mid-session

| # | Finding | Resolution |
|---|---|---|
| P2 | the description re-read `HEAD` **outside** the guarded interval — introduced by round 9's own reuse fix | The snapshot carries its commit; the description uses it; divergence is measured from that commit, not live `HEAD`. Mutation-checked. |
| P2 | the fingerprint hashed `status` only, which omits index-flagged files | `ls-files -v` is now part of the fingerprint, and the description reuses that probe — no extra scan. Mutation-checked. |
| lint | unused `readFileSync` left by round 9's withdrawal | removed |

**The recurring shape, stated once:** *a guard is only as wide as the state it samples.* Ten rounds repeatedly found a slice it wasn't sampling — `HEAD`, then the working tree, then index flags, then the commit read outside the bracket. The structural answer is that the guard now samples everything the description reports, instead of the description sampling for itself.

### `main` moved, and this branch was updated by merge

`origin/main` advanced for the first time during this work: `e1f7082d` → `d76c1ddf` (#2773, one commit, touching no `ops/mcp` path). Strict protection put this branch `BEHIND`; it was updated by **merge, not rebase**, because force-pushing a shared branch was outside the capability this work held.

Worth noting plainly: the PR body and the campaign records had both said "main has not moved," written hours earlier and already false. That is this PR's own thesis landing on its own artifacts — a revision claim is only worth what its re-resolution is worth.

**Verification at `8833211c7`:** tsc exit 0 · 39 tests in this suite · **full suite 350**, post-merge.

### Review arc

6 → 3 → 3 → 2 → 1 → 1 → 1 → 1 → 1 → 3 findings, every one a real defect, all resolved. At least one guard was mutation-checked every round. One round-1 fix was **reverted** in round 2 rather than tightened, because the evidence it relied on turned out not to exist; one round-4 claim was **corrected** in round 5; round 6 fixed a fail-open introduced by round 5's own guard. Two findings were closed as *classes* rather than instances, after the same shape recurred.

Started at 13 tests and 326 in the full suite; now **39 and 350**. Sixteen mutations verified across the arc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)










