### PR TITLE
fix(cli): local mutators join one exclusion domain, and the domain stops moving (#2758, #2759)

### DIFF
--- a/docs/manual/ICN_USER_MANUAL.md
+++ b/docs/manual/ICN_USER_MANUAL.md
@@ -995,6 +995,20 @@ icnctl backup ~/backups/icn-$(date +%Y%m%d).tar.gz.age
 
 ### Restore Procedures
 
+Restore is **exclusive**. It replaces every byte under the data directory and
+republishes the configuration in it, so it joins the same exclusion domain the
+daemon and `icnctl institution runtime-root create` use, and is refused while
+either of them holds that directory. `--force` overrides "this directory is not
+empty"; it has never overridden "another ICN process is using it", and since
+icn#2758 the command enforces that rather than leaving it to procedure.
+
+Stopping the daemon is therefore still the first step, and now the command says
+so instead of proceeding:
+
+```
+Refusing to start this restore: another ICN process already holds /var/lib/icn.
+```
+
 ```bash
 # Stop daemon first
 sudo systemctl stop icnd

--- a/icn/bins/icnctl/src/institution_runtime_root.rs
+++ b/icn/bins/icnctl/src/institution_runtime_root.rs
@@ -1530,19 +1530,13 @@ impl Drop for ObserverGuard {
 /// answer is no and no lock exists, inspection refuses rather than proceeding
 /// unlocked — being outside the exclusion domain is the failure this whole
 /// mechanism exists to prevent.
-#[cfg(unix)]
+///
+/// One definition, in `icn-core` beside the lock whose invariant it is. It was
+/// written here first; the maintenance commands then needed the same question
+/// answered (icn#2759) and a second spelling of an ownership rule is how the
+/// first one comes to be applied at five sites out of six.
 fn inspection_may_create_the_lock(data_dir: &Path) -> Result<bool> {
-    let owner = data_root_account(data_dir)
-        .with_context(|| format!("Failed to inspect {}", data_dir.display()))?;
-    Ok(matches!(
-        classify_ownership_transfer(owner, identity_new_files_receive(data_dir)?),
-        OwnershipTransfer::Preserved
-    ))
-}
-
-#[cfg(not(unix))]
-fn inspection_may_create_the_lock(_data_dir: &Path) -> Result<bool> {
-    Ok(true)
+    icn_core::new_files_here_belong_to_the_directory_account(data_dir)
 }
 
 /// A test-only barrier inside `show`, between deciding about the lock and
@@ -1711,9 +1705,11 @@ fn provision_runtime_root_inner(
     // all — republishing its configuration without the first lock would leave
     // it running on bytes that no longer exist. Taken in the same order the
     // daemon takes them, and non-blocking, so neither ordering can hang.
-    let _ceremony_config =
+    // Named rather than `_`-prefixed: both guards are read again at (11c),
+    // where the ceremony asks whether its exclusion still covers this root.
+    let ceremony_config =
         icn_core::DataDirLock::acquire_config(data_dir, "runtime-root provisioning")?;
-    let _ceremony = icn_core::DataDirLock::acquire(data_dir, "runtime-root provisioning")?;
+    let ceremony_storage = icn_core::DataDirLock::acquire(data_dir, "runtime-root provisioning")?;
 
     // (2) Before anything opens or writes a store. The gate takes exclusive
     // locks while it audits, so this also fails fast when the daemon is running
@@ -2070,6 +2066,28 @@ fn provision_runtime_root_inner(
     // durability *inside* its own directory; nothing else does the outside.
     sync_directory_entries(&icn_core::config::store_path(data_dir))?;
     sync_directory_entries(data_dir)?;
+
+    // (11c) The exclusion that has covered every step above must still cover
+    // this root.
+    //
+    // `flock(2)` attaches to an open file description while this domain's
+    // identity is a pathname, so a `rename(2)` of the data root separates the
+    // two: these guards would travel into the renamed directory while a fresh,
+    // unlocked lock file appeared at `<data_dir>`, and a second ceremony or
+    // daemon could take it without ever contending (icn#2758). The consequence
+    // is specific to this point in the ceremony — handle-based state (the open
+    // sled stores, the cooperative row, the treasury registration) follows the
+    // renamed inode, while pathname-based work (configuration publication, the
+    // keystores) resolves to the replacement — so the receipt about to be
+    // committed could certify state living in a different directory from the
+    // configuration linkage it re-verifies.
+    //
+    // Restore no longer renames a data root, which is where that sequence came
+    // from. This is the check that says so rather than assuming it: a marker
+    // claiming verified durable state must not be written by a process whose
+    // exclusion has stopped covering the root it names.
+    ceremony_storage.assert_still_anchored("this provisioning ceremony")?;
+    ceremony_config.assert_still_anchored("this provisioning ceremony")?;
 
     // (12) The completion marker, written last and only over verified state.
     {
@@ -5341,6 +5359,133 @@ mod failpoint_tests {
         drop(daemon_side);
         provision_runtime_root_inner(dir.path(), "Unblocked", "HOURS", None)
             .expect("the ceremony must proceed once the holder releases");
+    }
+
+    /// A restore cannot split a ceremony that is in flight (icn#2758).
+    ///
+    /// This is the witness icn#2758 was filed without. Its empirical evidence
+    /// showed a *daemon-shaped* holder losing its anchor to `restore --force`,
+    /// and recorded that the ceremony-overlap consequence — a receipt committed
+    /// into one directory while the configuration linkage it re-verifies lands
+    /// in another — remained reasoned from mechanism rather than executed.
+    ///
+    /// It runs here because it cannot be driven any other way: the interleaving
+    /// has to be observed from *inside* the ceremony's own stack frame, while
+    /// its guards are alive. Timing would prove nothing repeatable, and the
+    /// shipped binary has no failpoint to park on.
+    ///
+    /// Two things are asserted, and they are separate claims:
+    ///
+    /// * the restore is refused — the ceremony's exclusion now reaches it;
+    /// * the ceremony's anchor is unchanged across the attempt — so even a
+    ///   restore that got further could not have moved the root out from under
+    ///   the receipt this ceremony is about to write.
+    #[cfg(unix)]
+    #[test]
+    fn a_restore_cannot_split_a_ceremony_in_flight() {
+        use std::sync::atomic::{AtomicBool, Ordering};
+        use std::sync::Mutex;
+
+        static OBSERVED: AtomicBool = AtomicBool::new(false);
+        static RESTORE_REFUSED: AtomicBool = AtomicBool::new(false);
+        static MAINTENANCE_REFUSED: AtomicBool = AtomicBool::new(false);
+        static ANCHOR_INTACT: AtomicBool = AtomicBool::new(false);
+        static ARCHIVE: Mutex<Option<PathBuf>> = Mutex::new(None);
+
+        fn inode_at(path: &Path) -> Option<(u64, u64)> {
+            use std::os::unix::fs::MetadataExt as _;
+            std::fs::symlink_metadata(path)
+                .ok()
+                .map(|m| (m.dev(), m.ino()))
+        }
+
+        fn observe(data_dir: &Path, point: RuntimeRootFailpoint) {
+            // The latest boundary: every store handle dropped, the
+            // configuration published, the receipt not yet written. Exactly the
+            // window in which handle-based and pathname-based state would part
+            // company under a root rename.
+            if point != RuntimeRootFailpoint::AfterConfigPublish {
+                return;
+            }
+            OBSERVED.store(true, Ordering::SeqCst);
+
+            let lock_path = icn_core::DataDirLock::lock_path(data_dir);
+            let before = inode_at(&lock_path);
+
+            let archive = ARCHIVE
+                .lock()
+                .ok()
+                .and_then(|slot| slot.clone())
+                .expect("the witness archive must be registered");
+            // The real handler the dispatch calls, not a stand-in for it.
+            RESTORE_REFUSED.store(
+                crate::handle_restore_command(data_dir, &archive, true).is_err(),
+                Ordering::SeqCst,
+            );
+            // And the maintenance participation from the same dispatch
+            // (icn#2759): the ceremony holds no sled handles right here, so
+            // sled's own lock is not what refuses this.
+            MAINTENANCE_REFUSED.store(
+                crate::StorageDomain::join(data_dir, "coop maintenance").is_err(),
+                Ordering::SeqCst,
+            );
+
+            ANCHOR_INTACT.store(
+                before.is_some() && inode_at(&lock_path) == before,
+                Ordering::SeqCst,
+            );
+        }
+
+        let dir = provisioned();
+
+        // A real archive, produced by the real backup command, so the refusal
+        // cannot be an artefact of an unreadable input.
+        let source = dir.path().join("witness-source");
+        std::fs::create_dir_all(source.join("store")).unwrap();
+        std::fs::write(source.join("store").join("marker"), b"other root\n").unwrap();
+        let archive = dir.path().join("witness-backup.tar");
+        crate::handle_backup_command(&source, &archive).unwrap();
+        *ARCHIVE.lock().unwrap() = Some(archive);
+
+        OBSERVED.store(false, Ordering::SeqCst);
+        RESTORE_REFUSED.store(false, Ordering::SeqCst);
+        MAINTENANCE_REFUSED.store(false, Ordering::SeqCst);
+        ANCHOR_INTACT.store(false, Ordering::SeqCst);
+
+        let _observer = ObserverGuard::install(dir.path(), observe);
+        let outcome = provision_runtime_root_inner(
+            dir.path(),
+            "Uninterruptible Coop",
+            "HOURS",
+            Some(RuntimeRootFailpoint::AfterConfigPublish),
+        );
+        drop(_observer);
+
+        assert!(
+            OBSERVED.load(Ordering::SeqCst),
+            "the ceremony must have reached the boundary; otherwise this proves nothing"
+        );
+        assert!(
+            RESTORE_REFUSED.load(Ordering::SeqCst),
+            "a restore must not be able to replace the root a ceremony is provisioning"
+        );
+        assert!(
+            MAINTENANCE_REFUSED.load(Ordering::SeqCst),
+            "a maintenance command must not be able to open the stores mid-ceremony"
+        );
+        assert!(
+            ANCHOR_INTACT.load(Ordering::SeqCst),
+            "the ceremony's exclusion anchor must be the same file after the attempt"
+        );
+        // The failpoint is what ends this ceremony, not the restore.
+        let err = format!(
+            "{:#}",
+            outcome.expect_err("the failpoint stops the ceremony")
+        );
+        assert!(
+            err.contains("injected runtime-root fault"),
+            "the ceremony must have failed at its failpoint, not somewhere else: {err}"
+        );
     }
 
     /// The ceremony still owns the root at its LATEST boundary — after every

--- a/icn/bins/icnctl/src/main.rs
+++ b/icn/bins/icnctl/src/main.rs
@@ -2284,7 +2284,7 @@ fn is_root_coordination_file(relative: &Path) -> bool {
 /// changes is membership of the domain a holder can be in **without** holding
 /// sled handles — the ceremony between its phases, and `restore`.
 enum StorageDomain {
-    /// The root exists and this process holds its storage lock.
+    /// The root exists, is a directory, and this process holds its storage lock.
     Held {
         /// Held for the whole command. Never read; dropping it is the release.
         _storage: icn_core::DataDirLock,
@@ -2295,20 +2295,57 @@ enum StorageDomain {
         /// containment has to be judged against.
         canonical_root: PathBuf,
     },
-    /// The root did not exist when the command started.
+    /// There is no directory here to hold, so nothing is held — and, critically,
+    /// nothing may be opened either.
     ///
-    /// There is no state to open and no holder to exclude, and these commands
-    /// are contracted to report an empty result rather than materialize
-    /// anything — `report_on_missing_ledger_store_reports_empty` pins that, and
-    /// creating a root merely to hold a lock in it would be the retained-file
-    /// poisoning this whole mechanism exists to avoid.
+    /// Two shapes reach this, and both are cases where taking a lock would be
+    /// the wrong answer rather than a missing one:
     ///
-    /// The window that leaves — a ceremony creating the root immediately
-    /// afterwards — is closed at the only place it could matter:
-    /// [`Self::open_store`] refuses here rather than opening unlocked. So an
-    /// absent root can never become a way *into* the stores; it can only be a
-    /// way to report that there are none.
-    AbsentRoot { data_dir: PathBuf },
+    /// * **the root does not exist.** These commands are contracted to report an
+    ///   empty result rather than materialize anything —
+    ///   `report_on_missing_ledger_store_reports_empty` pins that — and creating
+    ///   a root merely to hold a lock in it would be the retained-file poisoning
+    ///   this whole mechanism exists to avoid.
+    /// * **the path is not a directory.** A misconfigured `--data-dir` is the
+    ///   N2-A gate's refusal to make, and it makes it by name
+    ///   (`a_data_dir_that_is_not_a_directory_is_refused_not_skipped`). Probing
+    ///   the account of a regular file would report `ENOTDIR` from a probe file
+    ///   instead, burying the actual operator error under a coordination detail.
+    ///
+    /// The window either shape leaves — something creating a real directory at
+    /// that path immediately afterwards — is closed at [`Self::open_store`],
+    /// which refuses here rather than opening unlocked. Nothing to hold can
+    /// never become a way *into* the stores.
+    Unheld {
+        data_dir: PathBuf,
+        why: &'static str,
+    },
+}
+
+/// What is actually at a `--data-dir` path.
+///
+/// Classified explicitly rather than through `Path::is_dir`, which reports a
+/// permission or traversal error as "not a directory" — and being unable to tell
+/// what is there is not evidence about what is there.
+enum RootShape {
+    Directory,
+    Absent,
+    NotADirectory,
+}
+
+fn classify_root(data_dir: &Path, holder: &str) -> Result<RootShape> {
+    match std::fs::metadata(data_dir) {
+        Ok(meta) if meta.is_dir() => Ok(RootShape::Directory),
+        Ok(_) => Ok(RootShape::NotADirectory),
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(RootShape::Absent),
+        Err(e) => Err(e).with_context(|| {
+            format!(
+                "Refusing to run {holder}: could not determine what is at the data directory \
+                 {}, so it cannot be established that no other ICN process holds it",
+                data_dir.display()
+            )
+        }),
+    }
 }
 
 impl StorageDomain {
@@ -2322,29 +2359,25 @@ impl StorageDomain {
     /// outcomes — create, join, refuse — are the primitive's, not this
     /// caller's.
     fn join(data_dir: &Path, holder: &str) -> Result<Self> {
-        // Classified explicitly rather than through `Path::exists`, which
-        // reports a permission or traversal error as absence — and "I could not
-        // tell whether this root exists" is not evidence that it does not.
-        match std::fs::metadata(data_dir) {
-            Ok(_) => {}
-            Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
-                return Ok(Self::AbsentRoot {
-                    data_dir: data_dir.to_path_buf(),
-                })
+        let unheld = |why| {
+            Ok(Self::Unheld {
+                data_dir: data_dir.to_path_buf(),
+                why,
+            })
+        };
+        match classify_root(data_dir, holder)? {
+            RootShape::Directory => {
+                let storage = icn_core::DataDirLock::acquire_joining_or_creating(data_dir, holder)?;
+                Self::held(storage, data_dir)
             }
-            Err(e) => {
-                return Err(e).with_context(|| {
-                    format!(
-                        "Refusing to run {holder}: could not determine whether the data \
-                         directory {} exists, so it cannot be established that no other ICN \
-                         process holds it",
-                        data_dir.display()
-                    )
-                })
+            RootShape::Absent => {
+                unheld("the data directory did not exist when this command started")
             }
+            // Left to the N2-A gate on the next line, which refuses a
+            // misconfigured `--data-dir` by name. Probing this path's account
+            // first would replace that refusal with `ENOTDIR` from a probe file.
+            RootShape::NotADirectory => unheld("the --data-dir path is not a directory"),
         }
-        let storage = icn_core::DataDirLock::acquire_joining_or_creating(data_dir, holder)?;
-        Self::held(storage, data_dir)
     }
 
     /// Take the domain for a command that provisions the root itself.
@@ -2355,6 +2388,15 @@ impl StorageDomain {
     /// legitimately creates the directory, so there is no owning account to
     /// defer to yet.
     fn create(data_dir: &Path, holder: &str) -> Result<Self> {
+        // A non-directory path is the gate's refusal here too. `create`
+        // legitimately makes the root when it is absent, so only that one shape
+        // is diverted.
+        if matches!(classify_root(data_dir, holder)?, RootShape::NotADirectory) {
+            return Ok(Self::Unheld {
+                data_dir: data_dir.to_path_buf(),
+                why: "the --data-dir path is not a directory",
+            });
+        }
         institution_runtime_root::refuse_if_new_files_would_not_belong_to_the_data_root_account(
             data_dir,
         )?;
@@ -2380,7 +2422,7 @@ impl StorageDomain {
     /// The data directory as the caller spelled it.
     fn data_dir(&self) -> &Path {
         match self {
-            Self::Held { data_dir, .. } | Self::AbsentRoot { data_dir } => data_dir,
+            Self::Held { data_dir, .. } | Self::Unheld { data_dir, .. } => data_dir,
         }
     }
 
@@ -2397,11 +2439,15 @@ impl StorageDomain {
     /// not addressed here.
     fn open_store(&self, db: &Path) -> Result<SledStore> {
         let Self::Held { canonical_root, .. } = self else {
+            let why = match self {
+                Self::Unheld { why, .. } => *why,
+                Self::Held { .. } => unreachable!(),
+            };
             bail!(
-                "Refusing to open the store at {}: the data directory {} did not exist when \
-                 this command started, so no exclusion was taken over it. Something has \
-                 created it since — a provisioning ceremony, most likely — and opening it now \
-                 would proceed with no exclusion at all. Re-run once that has finished.",
+                "Refusing to open the store at {}: no exclusion was taken over the data \
+                 directory {}, because {why}. Opening it now would proceed with no exclusion \
+                 at all — something has put a real directory there since this command \
+                 started, a provisioning ceremony most likely. Re-run once that has finished.",
                 db.display(),
                 self.data_dir().display()
             );
@@ -14421,9 +14467,40 @@ mod exclusion_domain_tests {
             Err(e) => e,
         };
         assert!(
-            format!("{err:#}").contains("no exclusion was taken"),
+            format!("{err:#}").contains("no exclusion was taken over the data directory"),
             "the refusal must say why: {err:#}"
         );
+    }
+
+    /// A misconfigured `--data-dir` stays the N2-A gate's refusal to make.
+    ///
+    /// Joining the domain happens before the gate, so the join must not be what
+    /// speaks for a path that is not a directory. It did: probing the account of
+    /// a regular file reported `ENOTDIR` from a probe filename, burying the
+    /// operator's actual mistake under a coordination detail and breaking
+    /// `a_data_dir_that_is_not_a_directory_is_refused_not_skipped`. Holding
+    /// nothing here is correct; opening anything is not.
+    #[test]
+    fn a_data_dir_that_is_not_a_directory_holds_nothing_and_opens_nothing() {
+        let scratch = tempfile::TempDir::new().unwrap();
+        let not_a_dir = scratch.path().join("data-dir-is-a-file");
+        std::fs::write(&not_a_dir, b"oops").unwrap();
+
+        // The join itself must succeed and hold nothing, so the gate that runs
+        // next is what reports the misconfiguration.
+        let domain = StorageDomain::join(&not_a_dir, "coop maintenance")
+            .expect("a non-directory root must be left to the gate, not refused here");
+        let err = match domain.open_store(&not_a_dir.join("store").join("cooperative")) {
+            Ok(_) => panic!("a store under a non-directory root must not be opened"),
+            Err(e) => e,
+        };
+        assert!(
+            format!("{err:#}").contains("not a directory"),
+            "the refusal must name the shape it found: {err:#}"
+        );
+        // Nothing was minted beside it, and the file itself is untouched.
+        assert_eq!(std::fs::read(&not_a_dir).unwrap(), b"oops");
+        assert!(!scratch.path().join(".icn-data-dir.lock").exists());
     }
 
     /// The lock names a directory, so an open outside it is unprotected.

--- a/icn/bins/icnctl/src/main.rs
+++ b/icn/bins/icnctl/src/main.rs
@@ -2235,6 +2235,227 @@ fn get_store_path(data_dir: &Path) -> PathBuf {
     icn_core::config::store_path(data_dir)
 }
 
+/// The coordination files this exclusion domain is anchored on.
+///
+/// Retained after release and mode `0600`, they are the *anchor* of the domain
+/// rather than any part of the state it protects. Restore therefore neither
+/// moves them aside nor unpacks over them: replacing one of these inodes is
+/// exactly the split `DataDirLock`'s own anchor check exists to detect
+/// (icn#2758).
+const COORDINATION_FILE_NAMES: [&str; 2] = [".icn-data-dir.lock", ".icn-config.lock"];
+
+/// Is this the relative path of a coordination file at the root of a data
+/// directory?
+///
+/// Anchored at the top level on purpose: `DataDirLock` names a directory, so a
+/// file called `.icn-data-dir.lock` nested inside `store/` is ordinary content
+/// and no lock is held on it.
+fn is_root_coordination_file(relative: &Path) -> bool {
+    COORDINATION_FILE_NAMES
+        .iter()
+        .any(|name| relative == Path::new(name))
+}
+
+/// Proof that this process is inside the storage exclusion domain of the data
+/// root whose stores it is about to open.
+///
+/// # Why this is a type rather than a rule
+///
+/// The maintenance commands crossed the N2-A gate and then opened the
+/// ceremony's own sled databases while holding nothing (icn#2759). Sled's
+/// per-database lock was the only thing between them and a runtime-root
+/// ceremony — and the ceremony deliberately closes its handles to re-read state
+/// through fresh ones, so there is an interval in which sled locks nothing at
+/// all. A maintenance open landing there takes the database, the ceremony's
+/// verification reopen fails, and the root is left half-provisioned by nothing
+/// worse than arrival order.
+///
+/// Taking the lock at each call site is the rule that was already being
+/// forgotten, so the open is placed behind the guard instead: [`Self::open_store`]
+/// cannot be reached without one. This is deliberately *narrow* — one binary's
+/// data-root opens — and is not the general "the primitive rejects an
+/// unanswered ownership question" work, which is icn#2775.
+///
+/// # What it does not add
+///
+/// It does not newly serialize these commands against a running daemon. Every
+/// caller already crossed [`enforce_n2a_gate`], which opens each sled root
+/// *exclusively* while it audits, so a live daemon already refused them. What
+/// changes is membership of the domain a holder can be in **without** holding
+/// sled handles — the ceremony between its phases, and `restore`.
+enum StorageDomain {
+    /// The root exists and this process holds its storage lock.
+    Held {
+        /// Held for the whole command. Never read; dropping it is the release.
+        _storage: icn_core::DataDirLock,
+        /// The caller's spelling, so messages and derived store paths read
+        /// exactly as they did before this guard existed.
+        data_dir: PathBuf,
+        /// The same directory as the kernel resolves it, which is what
+        /// containment has to be judged against.
+        canonical_root: PathBuf,
+    },
+    /// The root did not exist when the command started.
+    ///
+    /// There is no state to open and no holder to exclude, and these commands
+    /// are contracted to report an empty result rather than materialize
+    /// anything — `report_on_missing_ledger_store_reports_empty` pins that, and
+    /// creating a root merely to hold a lock in it would be the retained-file
+    /// poisoning this whole mechanism exists to avoid.
+    ///
+    /// The window that leaves — a ceremony creating the root immediately
+    /// afterwards — is closed at the only place it could matter:
+    /// [`Self::open_store`] refuses here rather than opening unlocked. So an
+    /// absent root can never become a way *into* the stores; it can only be a
+    /// way to report that there are none.
+    AbsentRoot { data_dir: PathBuf },
+}
+
+impl StorageDomain {
+    /// Join the domain for a command that reads or repairs an existing root.
+    ///
+    /// `acquire_joining_or_creating`, not `acquire`: a maintenance command run
+    /// under `sudo` against a service-owned root must not mint a retained
+    /// `0600` coordination file the daemon's own account cannot reopen. That
+    /// mistake is a permanent daemon startup failure, and #2749 had to remove
+    /// creating acquisition from two read paths after making it. The three
+    /// outcomes — create, join, refuse — are the primitive's, not this
+    /// caller's.
+    fn join(data_dir: &Path, holder: &str) -> Result<Self> {
+        // Classified explicitly rather than through `Path::exists`, which
+        // reports a permission or traversal error as absence — and "I could not
+        // tell whether this root exists" is not evidence that it does not.
+        match std::fs::metadata(data_dir) {
+            Ok(_) => {}
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+                return Ok(Self::AbsentRoot {
+                    data_dir: data_dir.to_path_buf(),
+                })
+            }
+            Err(e) => {
+                return Err(e).with_context(|| {
+                    format!(
+                        "Refusing to run {holder}: could not determine whether the data \
+                         directory {} exists, so it cannot be established that no other ICN \
+                         process holds it",
+                        data_dir.display()
+                    )
+                })
+            }
+        }
+        let storage = icn_core::DataDirLock::acquire_joining_or_creating(data_dir, holder)?;
+        Self::held(storage, data_dir)
+    }
+
+    /// Take the domain for a command that provisions the root itself.
+    ///
+    /// The creating holder's shape, identical to the ceremony's: refuse a
+    /// wrong-account run *before* any coordination file exists, then acquire
+    /// outright. `join`'s create-or-join decision is wrong here — this caller
+    /// legitimately creates the directory, so there is no owning account to
+    /// defer to yet.
+    fn create(data_dir: &Path, holder: &str) -> Result<Self> {
+        institution_runtime_root::refuse_if_new_files_would_not_belong_to_the_data_root_account(
+            data_dir,
+        )?;
+        let storage = icn_core::DataDirLock::acquire(data_dir, holder)?;
+        Self::held(storage, data_dir)
+    }
+
+    fn held(storage: icn_core::DataDirLock, data_dir: &Path) -> Result<Self> {
+        // After acquisition, so a root the lock itself created resolves.
+        let canonical_root = std::fs::canonicalize(data_dir).with_context(|| {
+            format!(
+                "Failed to resolve the data directory {}",
+                data_dir.display()
+            )
+        })?;
+        Ok(Self::Held {
+            _storage: storage,
+            data_dir: data_dir.to_path_buf(),
+            canonical_root,
+        })
+    }
+
+    /// The data directory as the caller spelled it.
+    fn data_dir(&self) -> &Path {
+        match self {
+            Self::Held { data_dir, .. } | Self::AbsentRoot { data_dir } => data_dir,
+        }
+    }
+
+    /// Open one of this root's sled databases, under this guard's exclusion.
+    ///
+    /// Refuses a database that resolves outside the locked root. The lock names
+    /// a directory, so an open that lands elsewhere is an open this process
+    /// holds no exclusion over — the same reasoning that makes the ceremony
+    /// refuse a symlinked store path, asked here as a containment question
+    /// rather than a link question.
+    ///
+    /// The claim is exactly that and no more: the *database directory* is under
+    /// the locked root. A link planted deeper inside an existing database is
+    /// not addressed here.
+    fn open_store(&self, db: &Path) -> Result<SledStore> {
+        let Self::Held { canonical_root, .. } = self else {
+            bail!(
+                "Refusing to open the store at {}: the data directory {} did not exist when \
+                 this command started, so no exclusion was taken over it. Something has \
+                 created it since — a provisioning ceremony, most likely — and opening it now \
+                 would proceed with no exclusion at all. Re-run once that has finished.",
+                db.display(),
+                self.data_dir().display()
+            );
+        };
+        Self::assert_covers(canonical_root, db)?;
+        SledStore::open(db).with_context(|| {
+            format!(
+                "Failed to open store at {} (stop the daemon first; it holds an exclusive lock)",
+                db.display()
+            )
+        })
+    }
+
+    /// Refuse a path this guard's lock does not cover.
+    ///
+    /// `db` need not exist yet — sled creates it — so the deepest *existing*
+    /// ancestor is resolved and judged instead. Resolving nothing at all is a
+    /// refusal, not a pass.
+    fn assert_covers(canonical_root: &Path, db: &Path) -> Result<()> {
+        let mut probe = db.to_path_buf();
+        let resolved = loop {
+            match std::fs::canonicalize(&probe) {
+                Ok(resolved) => break resolved,
+                Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+                    if !probe.pop() {
+                        bail!(
+                            "Refusing to open the store at {}: none of its path exists, so it \
+                             cannot be established that it lies under the data directory this \
+                             process holds.",
+                            db.display()
+                        );
+                    }
+                }
+                Err(e) => {
+                    return Err(e).with_context(|| {
+                        format!("Failed to resolve the store path {}", db.display())
+                    })
+                }
+            }
+        };
+        if !resolved.starts_with(canonical_root) {
+            bail!(
+                "Refusing to open the store at {}: it resolves to {}, outside the data \
+                 directory {} this process holds. The exclusion lock names a directory, so an \
+                 open landing elsewhere would proceed with no exclusion at all.",
+                db.display(),
+                resolved.display(),
+                canonical_root.display()
+            );
+        }
+        Ok(())
+    }
+}
+
 /// Refuse to touch a data directory the N2-A startup gate would refuse to open
 /// (#2627 M4d).
 ///
@@ -2305,36 +2526,43 @@ fn enforce_n2a_gate(dir: &Path, what: &str) -> Result<()> {
 }
 
 /// Dispatch cooperative maintenance subcommands.
-fn handle_coop_maintenance_command(cmd: CoopMaintenanceCommands, data_dir: &Path) -> Result<()> {
+///
+/// Takes the [`StorageDomain`] rather than a bare path: every arm below opens
+/// the ceremony's own cooperative database, and the guard is what says this
+/// process is inside the exclusion while it does (icn#2759).
+fn handle_coop_maintenance_command(
+    cmd: CoopMaintenanceCommands,
+    domain: &StorageDomain,
+) -> Result<()> {
     match cmd {
         CoopMaintenanceCommands::EntityReport {
             json,
             preview_surrogates,
-        } => coop_entity_report(data_dir, json, preview_surrogates),
+        } => coop_entity_report(domain, json, preview_surrogates),
         CoopMaintenanceCommands::UnknownLegacyReport { json } => {
-            coop_entity_unknown_legacy_report(data_dir, json)
+            coop_entity_unknown_legacy_report(domain, json)
         }
         CoopMaintenanceCommands::EntityBackfillSurrogates {
             apply,
             dry_run: _,
             json,
-        } => coop_entity_backfill_surrogates(data_dir, json, apply),
+        } => coop_entity_backfill_surrogates(domain, json, apply),
     }
 }
 
 fn handle_treasury_maintenance_command(
     cmd: TreasuryMaintenanceCommands,
-    data_dir: &Path,
+    domain: &StorageDomain,
 ) -> Result<()> {
     match cmd {
         TreasuryMaintenanceCommands::EntityBackfillReport { json } => {
-            treasury_entity_backfill_report(data_dir, json)
+            treasury_entity_backfill_report(domain, json)
         }
         TreasuryMaintenanceCommands::EntityBackfillApply {
             apply,
             confirm_apply,
             json,
-        } => treasury_entity_backfill_apply(data_dir, json, apply, confirm_apply),
+        } => treasury_entity_backfill_apply(domain, json, apply, confirm_apply),
     }
 }
 
@@ -2348,11 +2576,16 @@ fn handle_treasury_maintenance_command(
 /// binding only and grants no authority. Mutation belongs to a later, separately
 /// reviewed rung (populating `entity_id` is not authorization-neutral under the
 /// treasury entity-auth gate).
-fn treasury_entity_backfill_report(data_dir: &Path, json: bool) -> Result<()> {
+fn treasury_entity_backfill_report(domain: &StorageDomain, json: bool) -> Result<()> {
     use icn_entity::{InMemoryCoopEntityMap, SledCoopEntityMap};
     use icn_ledger::TreasuryManager;
     use icn_store::Store;
     use std::sync::Arc;
+
+    // The guard is the parameter, not the path: these opens are the ones that
+    // used to reach sled with nothing held (icn#2759). `data_dir` is still the
+    // caller's spelling, so every path and message below reads as before.
+    let data_dir = domain.data_dir();
 
     let ledger_store_path = icn_core::config::ledger_store_path(data_dir);
 
@@ -2370,14 +2603,7 @@ fn treasury_entity_backfill_report(data_dir: &Path, json: bool) -> Result<()> {
         return render_treasury_entity_backfill_plan(&empty, json);
     }
 
-    let ledger_store: Arc<dyn Store> = Arc::new(SledStore::open(&ledger_store_path).with_context(
-        || {
-            format!(
-                "Failed to open ledger store at {} (stop the daemon first; it holds an exclusive lock)",
-                ledger_store_path.display()
-            )
-        },
-    )?);
+    let ledger_store: Arc<dyn Store> = Arc::new(domain.open_store(&ledger_store_path)?);
     let treasury_mgr = TreasuryManager::with_store(ledger_store)
         .context("Failed to hydrate treasuries from the ledger store")?;
 
@@ -2388,12 +2614,7 @@ fn treasury_entity_backfill_report(data_dir: &Path, json: bool) -> Result<()> {
     // every hydrated treasury against an explicit empty map, so each safely
     // surfaces as `skipped_no_mapping`. Never create the cooperative store.
     let plan = if coop_store_path.exists() {
-        let coop_store = SledStore::open(&coop_store_path).with_context(|| {
-            format!(
-                "Failed to open cooperative store at {} (stop the daemon first; it holds an exclusive lock)",
-                coop_store_path.display()
-            )
-        })?;
+        let coop_store = domain.open_store(&coop_store_path)?;
         // Share one Db with the canonical map, exactly as the daemon does in
         // init_coop — no separate database is opened.
         let db = Arc::new(coop_store.db().clone());
@@ -2495,7 +2716,7 @@ fn print_treasury_backfill_plan_body(plan: &icn_ledger::TreasuryEntityIdBackfill
 /// identity target only. Mirrors the read-only report's store handling: a
 /// missing store is reported, never materialized on disk (apply included).
 fn treasury_entity_backfill_apply(
-    data_dir: &Path,
+    domain: &StorageDomain,
     json: bool,
     apply: bool,
     confirm_apply: bool,
@@ -2504,6 +2725,11 @@ fn treasury_entity_backfill_apply(
     use icn_ledger::TreasuryManager;
     use icn_store::Store;
     use std::sync::Arc;
+
+    // The guard is the parameter, not the path: these opens are the ones that
+    // used to reach sled with nothing held (icn#2759). `data_dir` is still the
+    // caller's spelling, so every path and message below reads as before.
+    let data_dir = domain.data_dir();
 
     let ledger_store_path = icn_core::config::ledger_store_path(data_dir);
 
@@ -2522,14 +2748,7 @@ fn treasury_entity_backfill_apply(
         return render_treasury_entity_backfill_apply_plan(&empty, json, mode);
     }
 
-    let ledger_store: Arc<dyn Store> = Arc::new(SledStore::open(&ledger_store_path).with_context(
-        || {
-            format!(
-                "Failed to open ledger store at {} (stop the daemon first; it holds an exclusive lock)",
-                ledger_store_path.display()
-            )
-        },
-    )?);
+    let ledger_store: Arc<dyn Store> = Arc::new(domain.open_store(&ledger_store_path)?);
     let mut treasury_mgr = TreasuryManager::with_store(ledger_store)
         .context("Failed to hydrate treasuries from the ledger store")?;
 
@@ -2541,12 +2760,7 @@ fn treasury_entity_backfill_apply(
     // surfaces as `skipped_no_mapping` and nothing is eligible. Never create the
     // cooperative store (apply included).
     let map: Box<dyn CoopEntityMap> = if coop_store_path.exists() {
-        let coop_store = SledStore::open(&coop_store_path).with_context(|| {
-            format!(
-                "Failed to open cooperative store at {} (stop the daemon first; it holds an exclusive lock)",
-                coop_store_path.display()
-            )
-        })?;
+        let coop_store = domain.open_store(&coop_store_path)?;
         // Share one Db with the canonical map, exactly as the daemon does in
         // init_coop — no separate database is opened. Apply never writes the map.
         let db = Arc::new(coop_store.db().clone());
@@ -2702,7 +2916,11 @@ fn render_treasury_entity_backfill_apply_report(
 /// writes**, allocates **no** surrogate IDs, normalizes nothing, and changes
 /// no authorization state — a mapping is a name binding only and grants no
 /// authority.
-fn coop_entity_report(data_dir: &Path, json: bool, preview_surrogates: bool) -> Result<()> {
+fn coop_entity_report(domain: &StorageDomain, json: bool, preview_surrogates: bool) -> Result<()> {
+    // The guard is the parameter, not the path: these opens are the ones that
+    // used to reach sled with nothing held (icn#2759). `data_dir` is still the
+    // caller's spelling, so every path and message below reads as before.
+    let data_dir = domain.data_dir();
     use icn_coop::CoopStore;
     use icn_entity::{
         classify_coop_ids, classify_coop_ids_with_surrogate_preview, CoopEntityInventory,
@@ -2729,12 +2947,7 @@ fn coop_entity_report(data_dir: &Path, json: bool, preview_surrogates: bool) -> 
         );
     }
 
-    let sled_store = SledStore::open(&coop_store_path).with_context(|| {
-        format!(
-            "Failed to open cooperative store at {} (stop the daemon first; it holds an exclusive lock)",
-            coop_store_path.display()
-        )
-    })?;
+    let sled_store = domain.open_store(&coop_store_path)?;
 
     // Share one Db between the cooperative store and the canonical map, exactly
     // as the daemon does in init_coop — no separate database is opened.
@@ -2855,7 +3068,11 @@ fn render_coop_entity_inventory(
 /// nothing, normalizes nothing, and changes no authorization state — a mapping
 /// grants no authority. Reads the cooperative store directly, so run it with the
 /// daemon stopped (it holds an exclusive lock).
-fn coop_entity_unknown_legacy_report(data_dir: &Path, json: bool) -> Result<()> {
+fn coop_entity_unknown_legacy_report(domain: &StorageDomain, json: bool) -> Result<()> {
+    // The guard is the parameter, not the path: these opens are the ones that
+    // used to reach sled with nothing held (icn#2759). `data_dir` is still the
+    // caller's spelling, so every path and message below reads as before.
+    let data_dir = domain.data_dir();
     use icn_coop::CoopStore;
     use icn_entity::{report_unknown_legacy, SledCoopEntityMap, UnknownLegacyReport};
     use std::sync::Arc;
@@ -2874,12 +3091,7 @@ fn coop_entity_unknown_legacy_report(data_dir: &Path, json: bool) -> Result<()> 
         return render_unknown_legacy_report(&UnknownLegacyReport::default(), json);
     }
 
-    let sled_store = SledStore::open(&coop_store_path).with_context(|| {
-        format!(
-            "Failed to open cooperative store at {} (stop the daemon first; it holds an exclusive lock)",
-            coop_store_path.display()
-        )
-    })?;
+    let sled_store = domain.open_store(&coop_store_path)?;
 
     // Share one Db between the cooperative store and the canonical map, exactly
     // as the daemon does in init_coop — no separate database is opened.
@@ -2986,7 +3198,11 @@ fn render_unknown_legacy_report(
 /// authority. In dry-run mode it writes nothing. Returns a non-zero exit (via
 /// `Err`) when an `--apply` run hits a bind conflict/error, a refused surrogate
 /// collision, or a storage error.
-fn coop_entity_backfill_surrogates(data_dir: &Path, json: bool, apply: bool) -> Result<()> {
+fn coop_entity_backfill_surrogates(domain: &StorageDomain, json: bool, apply: bool) -> Result<()> {
+    // The guard is the parameter, not the path: these opens are the ones that
+    // used to reach sled with nothing held (icn#2759). `data_dir` is still the
+    // caller's spelling, so every path and message below reads as before.
+    let data_dir = domain.data_dir();
     use icn_coop::CoopStore;
     use icn_entity::{
         backfill_coop_surrogates, InMemoryCoopEntityMap, SledCoopEntityMap, SurrogateBackfillMode,
@@ -3015,12 +3231,7 @@ fn coop_entity_backfill_surrogates(data_dir: &Path, json: bool, apply: bool) -> 
         return render_coop_surrogate_backfill(&empty, json);
     }
 
-    let sled_store = SledStore::open(&coop_store_path).with_context(|| {
-        format!(
-            "Failed to open cooperative store at {} (stop the daemon first; it holds an exclusive lock)",
-            coop_store_path.display()
-        )
-    })?;
+    let sled_store = domain.open_store(&coop_store_path)?;
 
     // Share one Db between the cooperative store and the canonical map, exactly
     // as the daemon does in init_coop — no separate database is opened.
@@ -3316,18 +3527,49 @@ async fn main() -> Result<()> {
             yes,
             no_start,
         } => {
-            // Opens `<data_dir>/store` and writes trust edges; gate first.
+            // Two resources, so two locks, taken in the order every other
+            // holder takes them (configuration, then storage).
+            //
+            // `init-coop` writes `<data_dir>/icn.toml` with a check-then-write,
+            // which is the same stale-snapshot shape the federation writers had
+            // before `ManagedConfigEdit`: it can decide the file is absent, a
+            // ceremony can publish one carrying `[cooperative]`, and this can
+            // then write over it. The sweep that gave the federation writers
+            // this lock did not reach here. Held for the whole command, not
+            // just across the write, because the decision is what goes stale.
+            //
+            // It also opens `<data_dir>/store/trust` and writes bootstrap edges
+            // — the same store a runtime-root ceremony writes its authority
+            // edges into (icn#2759).
+            //
+            // The creating shape, not the joining one: this command
+            // legitimately creates the data root on a fresh machine, so there
+            // is no owning account to defer to yet.
+            institution_runtime_root::refuse_if_new_files_would_not_belong_to_the_data_root_account(
+                &data_dir,
+            )?;
+            let _init_coop_config = icn_core::DataDirLock::acquire_config(&data_dir, "init-coop")?;
+            let domain = StorageDomain::create(&data_dir, "init-coop")?;
+            // Inside the lock, so nothing can open these stores between the
+            // gate's verdict and the work it clears.
             enforce_n2a_gate(&data_dir, "init-coop")?;
-            handle_init_coop_command(&data_dir, name, members, yes, no_start).await?
+            handle_init_coop_command(&domain, name, members, yes, no_start).await?
         }
 
         Commands::Coop(coop_cmd) => {
+            // Joined *before* the gate, and held past it. The gate takes its own
+            // exclusive sled locks and releases them when it returns, so passing
+            // it says nothing about the next instant — which is exactly the
+            // interval a ceremony's handle-free re-read window lands in
+            // (icn#2759).
+            let domain = StorageDomain::join(&data_dir, "coop maintenance")?;
             enforce_n2a_gate(&data_dir, "coop maintenance")?;
-            handle_coop_maintenance_command(coop_cmd, &data_dir)?
+            handle_coop_maintenance_command(coop_cmd, &domain)?
         }
         Commands::Treasury(treasury_cmd) => {
+            let domain = StorageDomain::join(&data_dir, "treasury maintenance")?;
             enforce_n2a_gate(&data_dir, "treasury maintenance")?;
-            handle_treasury_maintenance_command(treasury_cmd, &data_dir)?
+            handle_treasury_maintenance_command(treasury_cmd, &domain)?
         }
 
         Commands::Auth(auth_cmd) => handle_auth_command(auth_cmd, &data_dir).await?,
@@ -6881,19 +7123,118 @@ fn handle_backup_command(data_dir: &Path, output: &Path) -> Result<()> {
     Ok(())
 }
 
+/// Move everything under a data root aside, leaving the root itself in place.
+///
+/// The *contents* move, never the directory. That distinction is the whole
+/// repair for icn#2758: `rename(2)` of the root carried the locked
+/// `.icn-data-dir.lock` inode into the backup while a fresh, unlocked file
+/// appeared at the stable pathname, so restore and a daemon could hold two
+/// valid exclusive locks over "the data directory" and never contend. Keeping
+/// the root — and with it the coordination files this process is holding —
+/// means the exclusion is continuous across the replacement, with no instant in
+/// which the stable path is unlocked.
+///
+/// The coordination files are skipped rather than moved: they are the anchor of
+/// the domain, not state, and moving one is precisely the split above.
+///
+/// Honest limit: entry-by-entry renames are not atomic the way the single
+/// directory rename was. A failure part-way is reported with both directories
+/// named, so an operator can see where the contents are.
+fn move_data_root_contents_aside(data_dir: &Path, backup_dir: &Path) -> Result<usize> {
+    // `create_dir`, not `create_dir_all`: the destination must be *new*.
+    //
+    // The name is derived from the archive's own timestamp, so restoring one
+    // archive twice picks the same one both times. The single `rename` this
+    // replaced failed outright in that case (`ENOTEMPTY`); moving entries
+    // individually would instead overwrite the earlier backup file by file
+    // until it hit a directory collision. Refusing by name is clearer than
+    // either.
+    match std::fs::create_dir(backup_dir) {
+        Ok(()) => {}
+        Err(e) if e.kind() == std::io::ErrorKind::AlreadyExists => bail!(
+            "Refusing to move the existing data aside: {} is already there. It holds the data \
+             moved aside by an earlier restore of this same backup — the directory is named \
+             after the archive's own timestamp — and writing into it would overwrite that copy \
+             entry by entry. Move or remove it first.",
+            backup_dir.display()
+        ),
+        Err(e) => {
+            return Err(e).with_context(|| {
+                format!(
+                    "Failed to create the directory {} to move existing data into",
+                    backup_dir.display()
+                )
+            })
+        }
+    }
+    let mut moved = 0usize;
+    for entry in std::fs::read_dir(data_dir)
+        .with_context(|| format!("Failed to read {}", data_dir.display()))?
+    {
+        let entry =
+            entry.with_context(|| format!("Failed to read an entry of {}", data_dir.display()))?;
+        let name = entry.file_name();
+        if is_root_coordination_file(Path::new(&name)) {
+            continue;
+        }
+        std::fs::rename(entry.path(), backup_dir.join(&name)).with_context(|| {
+            format!(
+                "Failed to move {} aside into {}. {moved} of this data directory's entries had \
+                 already been moved, so its contents are now split between {} and {}.",
+                entry.path().display(),
+                backup_dir.display(),
+                data_dir.display(),
+                backup_dir.display()
+            )
+        })?;
+        moved += 1;
+    }
+    Ok(moved)
+}
+
 fn handle_restore_command(data_dir: &Path, input: &Path, force: bool) -> Result<()> {
     // Check if input backup file exists
     if !input.exists() {
         bail!("Backup file not found: {}", input.display());
     }
 
-    // Check if data directory already exists
-    if data_dir.exists() && !force {
+    // Check if data directory already exists.
+    //
+    // Asked *before* the locks below, because acquiring one creates the root.
+    // `--force` is the operator saying "replace what is there"; it was never a
+    // licence to replace what another ICN process is using, which is the
+    // remaining half of icn#2758.
+    let replacing_existing = data_dir.exists();
+    if replacing_existing && !force {
         bail!(
             "Data directory already exists: {}. Use --force to overwrite.",
             data_dir.display()
         );
     }
+
+    // Join both exclusion domains over the DESTINATION before reading, moving
+    // or writing anything.
+    //
+    // Two locks for the ceremony's two reasons: restore rewrites every byte of
+    // the storage under this root *and* republishes `<data_dir>/icn.toml`. A
+    // daemon holding the configuration of this directory with its storage
+    // somewhere else does not contend for the storage lock at all, so the
+    // configuration side is not redundant.
+    //
+    // Before this, restore took nothing. It would replace a root a daemon was
+    // actively using, and — worse — a ceremony in flight would keep writing
+    // handle-based state into the moved-aside tree while its pathname-based
+    // work landed in the replacement, splitting one logical root in two with
+    // both sides "correctly" locked.
+    //
+    // Creating acquisitions, so the account question comes first: these files
+    // are retained after release and mode 0600, and a `sudo` restore over a
+    // service-owned root would otherwise leave ones the daemon cannot reopen.
+    institution_runtime_root::refuse_if_new_files_would_not_belong_to_the_data_root_account(
+        data_dir,
+    )?;
+    let restore_config = icn_core::DataDirLock::acquire_config(data_dir, "this restore")?;
+    let restore_storage = icn_core::DataDirLock::acquire(data_dir, "this restore")?;
 
     println!("Restoring backup from {}...", input.display());
 
@@ -6917,13 +7258,16 @@ fn handle_restore_command(data_dir: &Path, input: &Path, force: bool) -> Result<
     println!("  Checksum: {}", metadata.checksum);
     println!();
 
-    // If force, backup existing data directory
-    if data_dir.exists() {
+    // If force, move the existing data aside — contents only, never the root.
+    if replacing_existing {
         println!("Backing up existing data directory...");
-        let backup_dir = format!("{}.backup-{}", data_dir.display(), metadata.created_at);
-        std::fs::rename(data_dir, &backup_dir)
-            .with_context(|| "Failed to backup existing data directory".to_string())?;
-        println!("  Existing data moved to: {backup_dir}");
+        let backup_dir = PathBuf::from(format!(
+            "{}.backup-{}",
+            data_dir.display(),
+            metadata.created_at
+        ));
+        move_data_root_contents_aside(data_dir, &backup_dir)?;
+        println!("  Existing data moved to: {}", backup_dir.display());
     }
 
     // Create data directory if it doesn't exist
@@ -6935,6 +7279,12 @@ fn handle_restore_command(data_dir: &Path, input: &Path, force: bool) -> Result<
         .with_context(|| format!("Failed to reopen backup file: {}", input.display()))?;
     let mut archive = Archive::new(input_file);
 
+    // Which coordination files the archive itself carried. A backup taken after
+    // #2749 contains them, because `append_dir_all` includes dotfiles; one taken
+    // before does not. The difference decides what the checksum below compares.
+    let mut coordination_files_in_archive: std::collections::BTreeSet<PathBuf> =
+        std::collections::BTreeSet::new();
+
     for entry in archive.entries()? {
         let mut entry = entry?;
         let path = entry.path()?;
@@ -6944,12 +7294,48 @@ fn handle_restore_command(data_dir: &Path, input: &Path, force: bool) -> Result<
             continue;
         }
 
+        // Never unpack over a coordination file this process is holding.
+        //
+        // `unpack` replaces the file at that path, and a replaced inode is a
+        // lost anchor — restore would break its own exclusion halfway through
+        // the extraction it is protecting.
+        //
+        // Skipping is checksum-neutral because no ICN process ever writes to
+        // these files: the empty one standing here hashes exactly as the empty
+        // archived one it stands in for. An archived coordination file that is
+        // *not* empty has been written to by something outside ICN, and the
+        // checksum below will refuse the restore rather than quietly accept a
+        // tree that differs from the archive — which is the right outcome.
+        let relative: PathBuf = path
+            .components()
+            .filter(|c| !matches!(c, std::path::Component::CurDir))
+            .collect();
+        if is_root_coordination_file(&relative) {
+            coordination_files_in_archive.insert(relative);
+            continue;
+        }
+
         entry.unpack_in(data_dir)?;
     }
 
-    // Verify checksum
+    // Verify checksum.
+    //
+    // The comparison is against the archive's contents, so the coordination
+    // files *this restore minted* are excluded from it — they were never part
+    // of the backed-up state and counting them would fail every restore of an
+    // archive taken before these files existed. Ones the archive did carry are
+    // included exactly as before: the file standing at that path is this
+    // process's own, empty, and therefore hashes identically to the archived
+    // one it stood in for.
     println!("Verifying checksum...");
-    let restored_checksum = calculate_dir_checksum(data_dir)?;
+    let minted_here: Vec<PathBuf> = COORDINATION_FILE_NAMES
+        .iter()
+        .map(PathBuf::from)
+        .filter(|name| {
+            !coordination_files_in_archive.contains(name) && data_dir.join(name).exists()
+        })
+        .collect();
+    let restored_checksum = calculate_dir_checksum_ignoring(data_dir, &minted_here)?;
     if restored_checksum != metadata.checksum {
         bail!(
             "Checksum mismatch! Expected: {}, Got: {}. Restore may be corrupted.",
@@ -6957,6 +7343,18 @@ fn handle_restore_command(data_dir: &Path, input: &Path, force: bool) -> Result<
             restored_checksum
         );
     }
+
+    // The exclusion that covered all of the above must still cover this root.
+    //
+    // Checked rather than assumed: this is the invariant icn#2758 is about, and
+    // asserting it here is what turns "restore no longer renames the root" from
+    // a property of the code above into one the command verifies before it
+    // reports success. Anything that moved or replaced the anchor mid-restore —
+    // a concurrent rename, a hand repair — means some other process can now
+    // hold this pathname, and this restore must not certify a root it no longer
+    // excludes anyone from.
+    restore_storage.assert_still_anchored("this restore")?;
+    restore_config.assert_still_anchored("this restore")?;
 
     println!("✓ Backup restored successfully");
     println!("  Restored to: {}", data_dir.display());
@@ -7669,6 +8067,21 @@ fn verify_ledger_in_backup(restore_dir: &Path) -> Result<LedgerCheck> {
 
 /// Calculate SHA256 checksum of all files in a directory
 fn calculate_dir_checksum(dir: &Path) -> Result<String> {
+    calculate_dir_checksum_ignoring(dir, &[])
+}
+
+/// The same checksum, with named top-level entries left out of it.
+///
+/// `ignored` holds paths *relative to `dir`*, and exists for exactly one
+/// caller: `restore` holds this root's coordination files open while it works,
+/// so those files are present in the restored tree whether or not the archive
+/// carried them. Hashing one the archive never contained would make every
+/// restore of a pre-#2749 backup report a mismatch.
+///
+/// Deliberately not a filter on "dotfiles" or on the coordination *names*: the
+/// caller passes the specific entries it created, so a lock file that really
+/// was part of the backed-up state is still hashed.
+fn calculate_dir_checksum_ignoring(dir: &Path, ignored: &[PathBuf]) -> Result<String> {
     use std::collections::BTreeMap;
 
     let mut file_hashes: BTreeMap<String, String> = BTreeMap::new();
@@ -7681,11 +8094,11 @@ fn calculate_dir_checksum(dir: &Path) -> Result<String> {
     {
         if entry.file_type().is_file() {
             let path = entry.path();
-            let relative_path = path
-                .strip_prefix(dir)
-                .unwrap_or(path)
-                .to_string_lossy()
-                .to_string();
+            let relative = path.strip_prefix(dir).unwrap_or(path);
+            if ignored.iter().any(|skip| skip == relative) {
+                continue;
+            }
+            let relative_path = relative.to_string_lossy().to_string();
 
             // Read file and calculate hash
             let mut file = File::open(path)
@@ -8904,12 +9317,16 @@ async fn handle_auth_command(cmd: AuthCommands, data_dir: &Path) -> Result<()> {
 
 /// Interactive wizard for setting up a new cooperative
 async fn handle_init_coop_command(
-    data_dir: &Path,
+    domain: &StorageDomain,
     name: Option<String>,
     members: Option<String>,
     yes: bool,
     no_start: bool,
 ) -> Result<()> {
+    // The guard is the parameter, not the path. `init-coop` opens the trust
+    // store the ceremony writes its authority edges into, so it belongs to the
+    // same exclusion domain (icn#2759).
+    let data_dir = domain.data_dir();
     println!();
     println!("╔════════════════════════════════════════╗");
     println!("║   ICN Cooperative Setup Wizard         ║");
@@ -9228,7 +9645,9 @@ token_expiry_hours = 24
     // the daemon uses, so the two cannot drift apart again.
     let trust_store_path = icn_core::config::trust_store_path(data_dir);
     std::fs::create_dir_all(&trust_store_path)?;
-    let store = SledStore::open(&trust_store_path).context("Failed to open trust store")?;
+    let store = domain
+        .open_store(&trust_store_path)
+        .context("Failed to open trust store")?;
     let store = Arc::new(store);
     let mut trust_graph = TrustGraph::new(store, my_did.clone());
 
@@ -13713,5 +14132,351 @@ mod managed_config_edit_tests {
         // The refusal must not have retained the lock.
         ManagedConfigEdit::open(dir.path(), "witness add", MissingConfig::StartFromDefaults)
             .expect("a writer that starts from defaults must be admitted");
+    }
+}
+
+/// icn#2758 / icn#2759: the local exclusion domain, at the two places it was
+/// not being honoured.
+///
+/// These drive the real handlers — `handle_restore_command`, `handle_backup_command`
+/// and `StorageDomain` — rather than re-deriving their behaviour, so a change
+/// that removes the participation cannot leave the witness passing.
+#[cfg(test)]
+mod exclusion_domain_tests {
+    #![allow(clippy::unwrap_used, clippy::expect_used)]
+
+    use super::{
+        calculate_dir_checksum, handle_backup_command, handle_restore_command, StorageDomain,
+    };
+    use std::path::{Path, PathBuf};
+
+    #[cfg(unix)]
+    fn inode_at(path: &Path) -> Option<(u64, u64)> {
+        use std::os::unix::fs::MetadataExt as _;
+        std::fs::symlink_metadata(path)
+            .ok()
+            .map(|m| (m.dev(), m.ino()))
+    }
+
+    /// A data root with a little recognisable state in it.
+    fn seeded_root(root: &Path) {
+        std::fs::create_dir_all(root.join("store")).unwrap();
+        std::fs::write(root.join("icn.toml"), b"# fixture configuration\n").unwrap();
+        std::fs::write(root.join("store").join("marker"), b"original\n").unwrap();
+    }
+
+    /// Back up a freshly seeded root and return the archive path.
+    fn archive_of_a_seeded_root(scratch: &Path) -> PathBuf {
+        let source = scratch.join("source");
+        seeded_root(&source);
+        let archive = scratch.join("backup.tar");
+        handle_backup_command(&source, &archive).expect("the fixture backup must succeed");
+        archive
+    }
+
+    // -----------------------------------------------------------------------
+    // icn#2758 — restore
+    // -----------------------------------------------------------------------
+
+    /// `restore --force` must not replace a root another ICN process holds.
+    ///
+    /// The defect exactly as reported: the only guard was `exists() && !force`,
+    /// and `--force` exists to bypass it. Nothing in the handler referred to a
+    /// daemon, a lock or a running process.
+    #[test]
+    fn restore_force_is_refused_while_another_process_holds_the_data_root() {
+        let scratch = tempfile::TempDir::new().unwrap();
+        let archive = archive_of_a_seeded_root(scratch.path());
+        let dest = scratch.path().join("data");
+        seeded_root(&dest);
+
+        let holder = icn_core::DataDirLock::acquire(&dest, "a running daemon").unwrap();
+
+        let err = handle_restore_command(&dest, &archive, true)
+            .expect_err("restore must not replace a root a daemon is using");
+        let msg = format!("{err:#}");
+        assert!(
+            msg.contains("already holds"),
+            "the refusal must name the conflicting holder: {msg}"
+        );
+        // And it must have refused *before* touching anything.
+        assert_eq!(
+            std::fs::read(dest.join("store").join("marker")).unwrap(),
+            b"original\n",
+            "a refused restore must not have moved or replaced any state"
+        );
+
+        drop(holder);
+        handle_restore_command(&dest, &archive, true)
+            .expect("restore must proceed once the holder releases");
+    }
+
+    /// The configuration side is not redundant.
+    ///
+    /// Restore republishes `<data_dir>/icn.toml`, so it must be refused by a
+    /// daemon holding that directory's configuration even when it holds no
+    /// storage lock — the `--config /A --data-dir /B` deployment.
+    #[test]
+    fn restore_is_refused_while_a_daemon_holds_the_configuration() {
+        let scratch = tempfile::TempDir::new().unwrap();
+        let archive = archive_of_a_seeded_root(scratch.path());
+        let dest = scratch.path().join("data");
+        seeded_root(&dest);
+
+        let reader =
+            icn_core::DataDirLock::acquire_config_shared_if_manageable(&dest, "the daemon")
+                .unwrap()
+                .expect("manageable");
+
+        let err = handle_restore_command(&dest, &archive, true)
+            .expect_err("a configuration reader must refuse a republisher");
+        assert!(
+            format!("{err:#}").contains("already holds"),
+            "the refusal must name the conflict"
+        );
+        drop(reader);
+        handle_restore_command(&dest, &archive, true).expect("and admit it once released");
+    }
+
+    /// The exclusion anchor must survive the replacement.
+    ///
+    /// This is the load-bearing half of icn#2758. `rename(2)` of the data root
+    /// carried the locked `.icn-data-dir.lock` inode into the backup directory
+    /// while a fresh, unlocked one appeared at the stable pathname — so a
+    /// daemon or ceremony that had the root before the restore and one that
+    /// takes it afterwards both hold valid exclusive locks and never contend.
+    ///
+    /// Asserted on the inode, not on the file existing: a fresh file at the
+    /// same path is precisely the split.
+    #[cfg(unix)]
+    #[test]
+    fn restore_does_not_move_the_exclusion_anchor_out_from_under_the_path() {
+        let scratch = tempfile::TempDir::new().unwrap();
+        let archive = archive_of_a_seeded_root(scratch.path());
+        let dest = scratch.path().join("data");
+        seeded_root(&dest);
+
+        // Establish the anchor the way a daemon would, then step out of the way.
+        let lock_path = {
+            let held = icn_core::DataDirLock::acquire(&dest, "a daemon").unwrap();
+            held.path().to_path_buf()
+        };
+        let before = inode_at(&lock_path).expect("the anchor must exist");
+
+        handle_restore_command(&dest, &archive, true).expect("restore must succeed");
+
+        assert_eq!(
+            inode_at(&lock_path),
+            Some(before),
+            "the exclusion anchor must still be the same file after a restore; a new inode \
+             at this path is the split icn#2758 describes"
+        );
+        // The restored state really is the archive's, not the old root's.
+        assert_eq!(
+            std::fs::read(dest.join("store").join("marker")).unwrap(),
+            b"original\n"
+        );
+        // And the contents that were replaced are recoverable.
+        let backups: Vec<_> = std::fs::read_dir(scratch.path())
+            .unwrap()
+            .filter_map(|e| e.ok())
+            .filter(|e| e.file_name().to_string_lossy().starts_with("data.backup-"))
+            .collect();
+        assert_eq!(backups.len(), 1, "the replaced contents must be kept aside");
+        assert!(
+            backups[0].path().join("icn.toml").exists(),
+            "the moved-aside copy must carry the state, not just exist"
+        );
+    }
+
+    /// Restore is still a restore: an archive taken before these coordination
+    /// files existed must verify.
+    ///
+    /// The checksum covers every file in the tree, so the lock files this
+    /// restore holds open would otherwise be counted against an archive that
+    /// never contained them and fail every such restore.
+    #[test]
+    fn an_archive_without_coordination_files_still_verifies() {
+        let scratch = tempfile::TempDir::new().unwrap();
+        let source = scratch.path().join("source");
+        seeded_root(&source);
+        let archive = scratch.path().join("backup.tar");
+        handle_backup_command(&source, &archive).unwrap();
+        // Nothing in the source ever took a lock, so the archive has none.
+        assert!(!source.join(".icn-data-dir.lock").exists());
+
+        let dest = scratch.path().join("data");
+        handle_restore_command(&dest, &archive, false).expect("restore must verify and succeed");
+        assert!(
+            dest.join(".icn-data-dir.lock").exists(),
+            "the restore held a coordination file over this root"
+        );
+    }
+
+    /// And one taken after they existed must verify too, with the archived
+    /// entries accounted for rather than skipped out of the comparison.
+    #[test]
+    fn an_archive_carrying_coordination_files_still_verifies() {
+        let scratch = tempfile::TempDir::new().unwrap();
+        let source = scratch.path().join("source");
+        seeded_root(&source);
+        drop(icn_core::DataDirLock::acquire(&source, "an earlier command").unwrap());
+        assert!(source.join(".icn-data-dir.lock").exists());
+
+        let archive = scratch.path().join("backup.tar");
+        handle_backup_command(&source, &archive).unwrap();
+        // The recorded checksum counts the archived lock file.
+        assert_eq!(
+            calculate_dir_checksum(&source).unwrap().len(),
+            64,
+            "sanity: the fixture checksum is a sha256"
+        );
+
+        let dest = scratch.path().join("data");
+        handle_restore_command(&dest, &archive, false).expect("restore must verify and succeed");
+    }
+
+    /// Readers stay readers.
+    ///
+    /// `backup` walks the same tree restore replaces, and it is *not* brought
+    /// into the exclusion by this repair: serializing every observer of a data
+    /// root against every holder is the over-correction #2749 had to undo twice.
+    /// A torn archive taken against a live daemon is a separate question from
+    /// the one these issues ask, and is recorded rather than silently changed.
+    #[test]
+    fn a_read_only_observer_is_not_serialized_by_this_repair() {
+        let scratch = tempfile::TempDir::new().unwrap();
+        let source = scratch.path().join("source");
+        seeded_root(&source);
+        let _holder = icn_core::DataDirLock::acquire(&source, "a running daemon").unwrap();
+
+        handle_backup_command(&source, &scratch.path().join("out.tar"))
+            .expect("reading a held root must not be refused");
+    }
+
+    // -----------------------------------------------------------------------
+    // icn#2759 — the store openers
+    // -----------------------------------------------------------------------
+
+    /// The guard is a real hold, and it is the one the dispatch takes.
+    #[test]
+    fn joining_the_storage_domain_excludes_a_ceremony() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let domain = StorageDomain::join(dir.path(), "coop maintenance").unwrap();
+        assert!(
+            icn_core::DataDirLock::acquire(dir.path(), "runtime-root provisioning").is_err(),
+            "a joined maintenance command must exclude a ceremony"
+        );
+        drop(domain);
+        icn_core::DataDirLock::acquire(dir.path(), "runtime-root provisioning")
+            .expect("and release when the command ends");
+    }
+
+    /// A ceremony in flight refuses the maintenance commands, and vice versa.
+    #[test]
+    fn a_held_root_refuses_the_maintenance_commands() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let _ceremony =
+            icn_core::DataDirLock::acquire(dir.path(), "runtime-root provisioning").unwrap();
+        for holder in ["coop maintenance", "treasury maintenance"] {
+            let err = StorageDomain::join(dir.path(), holder)
+                .err()
+                .unwrap_or_else(|| panic!("{holder} must be refused while a ceremony holds"));
+            assert!(
+                format!("{err:#}").contains("already holds"),
+                "the refusal must name the conflict"
+            );
+        }
+        assert!(
+            StorageDomain::create(dir.path(), "init-coop").is_err(),
+            "init-coop must be refused too"
+        );
+    }
+
+    /// An absent root reports emptiness, but can never become a way in.
+    ///
+    /// The commands are contracted to report an empty result for a data
+    /// directory that does not exist, and must not materialize one to hold a
+    /// lock in. The window that leaves — the root appearing immediately
+    /// afterwards — is closed at the open rather than at the join.
+    #[test]
+    fn an_absent_root_holds_nothing_and_opens_nothing() {
+        let scratch = tempfile::TempDir::new().unwrap();
+        let absent = scratch.path().join("never-created");
+
+        let domain = StorageDomain::join(&absent, "coop maintenance")
+            .expect("an absent root must not be an error");
+        assert!(
+            !absent.exists(),
+            "joining must not have materialized the data directory"
+        );
+
+        // Something creates it — a ceremony, say — and takes it properly.
+        std::fs::create_dir_all(absent.join("store")).unwrap();
+        let _ceremony =
+            icn_core::DataDirLock::acquire(&absent, "runtime-root provisioning").unwrap();
+
+        let err = match domain.open_store(&absent.join("store").join("cooperative")) {
+            Ok(_) => panic!("an unlocked open must be refused, not performed"),
+            Err(e) => e,
+        };
+        assert!(
+            format!("{err:#}").contains("no exclusion was taken"),
+            "the refusal must say why: {err:#}"
+        );
+    }
+
+    /// The lock names a directory, so an open outside it is unprotected.
+    #[test]
+    fn a_store_outside_the_locked_root_is_refused() {
+        let scratch = tempfile::TempDir::new().unwrap();
+        let root = scratch.path().join("data");
+        std::fs::create_dir_all(&root).unwrap();
+        let elsewhere = scratch.path().join("elsewhere");
+        std::fs::create_dir_all(&elsewhere).unwrap();
+
+        let domain = StorageDomain::join(&root, "coop maintenance").unwrap();
+        let err = match domain.open_store(&elsewhere.join("ledger")) {
+            Ok(_) => panic!("a database outside the held root must be refused"),
+            Err(e) => e,
+        };
+        assert!(
+            format!("{err:#}").contains("outside the data directory"),
+            "the refusal must say where it landed: {err:#}"
+        );
+    }
+
+    /// Including one reached through a link that leaves the root.
+    ///
+    /// Containment is judged on the resolved path, so a `store/ledger` symlink
+    /// pointing at another database cannot borrow this root's exclusion.
+    #[cfg(unix)]
+    #[test]
+    fn a_store_linked_out_of_the_locked_root_is_refused() {
+        let scratch = tempfile::TempDir::new().unwrap();
+        let root = scratch.path().join("data");
+        std::fs::create_dir_all(root.join("store")).unwrap();
+        let outside = scratch.path().join("outside-ledger");
+        std::fs::create_dir_all(&outside).unwrap();
+        std::os::unix::fs::symlink(&outside, root.join("store").join("ledger")).unwrap();
+
+        let domain = StorageDomain::join(&root, "treasury maintenance").unwrap();
+        assert!(
+            domain
+                .open_store(&root.join("store").join("ledger"))
+                .is_err(),
+            "an open that resolves out of the locked root must be refused"
+        );
+    }
+
+    /// A database that does not exist yet is fine — sled creates it — provided
+    /// the part of its path that does exist is inside the root.
+    #[test]
+    fn a_store_that_does_not_exist_yet_is_admitted_when_it_is_inside_the_root() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let domain = StorageDomain::create(dir.path(), "init-coop").unwrap();
+        domain
+            .open_store(&dir.path().join("store").join("trust"))
+            .expect("a creating open inside the held root must be admitted");
     }
 }

--- a/icn/bins/icnctl/src/main.rs
+++ b/icn/bins/icnctl/src/main.rs
@@ -2388,15 +2388,26 @@ impl StorageDomain {
     /// legitimately creates the directory, so there is no owning account to
     /// defer to yet.
     fn create(data_dir: &Path, holder: &str) -> Result<Self> {
-        // A non-directory path is the gate's refusal here too. `create`
-        // legitimately makes the root when it is absent, so only that one shape
-        // is diverted.
+        // Classified before anything is created, including by the account guard
+        // below. Every step from here on makes something *inside* this path — an
+        // ownership probe, a coordination file — and creating inside a regular
+        // file reports `ENOTDIR` named after whichever artefact happened to go
+        // first, burying the operator's actual mistake. The N2-A gate refuses a
+        // misconfigured `--data-dir` by name, so it is what speaks here.
+        //
+        // The `bail!` after it is a fail-closed net, not dead code: it is what
+        // happens if the gate ever stops refusing this shape.
         if matches!(classify_root(data_dir, holder)?, RootShape::NotADirectory) {
-            return Ok(Self::Unheld {
-                data_dir: data_dir.to_path_buf(),
-                why: "the --data-dir path is not a directory",
-            });
+            enforce_n2a_gate(data_dir, holder)?;
+            bail!(
+                "Refusing to run {holder}: {} exists but is not a directory.",
+                data_dir.display()
+            );
         }
+        // The account guard belongs here rather than at the call site: it is
+        // part of what taking a creating acquisition *means*, and leaving it
+        // outside let it run before the classification above and produce the
+        // very error that classification exists to prevent.
         institution_runtime_root::refuse_if_new_files_would_not_belong_to_the_data_root_account(
             data_dir,
         )?;
@@ -3591,11 +3602,17 @@ async fn main() -> Result<()> {
             // The creating shape, not the joining one: this command
             // legitimately creates the data root on a fresh machine, so there
             // is no owning account to defer to yet.
-            institution_runtime_root::refuse_if_new_files_would_not_belong_to_the_data_root_account(
-                &data_dir,
-            )?;
-            let _init_coop_config = icn_core::DataDirLock::acquire_config(&data_dir, "init-coop")?;
+            //
+            // Storage before configuration here, which is the opposite of the
+            // order elsewhere. `DataDirLock`'s own documentation states that the
+            // ordering is for readability rather than safety — every acquisition
+            // is non-blocking, so a crossed pair gets an immediate refusal and a
+            // deadlock is not reachable. What the swap buys is that
+            // `StorageDomain::create` classifies the path *before* anything is
+            // created inside it, so a misconfigured `--data-dir` is still the
+            // gate's refusal to make rather than a coordination-file `ENOTDIR`.
             let domain = StorageDomain::create(&data_dir, "init-coop")?;
+            let _init_coop_config = icn_core::DataDirLock::acquire_config(&data_dir, "init-coop")?;
             // Inside the lock, so nothing can open these stores between the
             // gate's verdict and the work it clears.
             enforce_n2a_gate(&data_dir, "init-coop")?;

--- a/icn/bins/icnctl/tests/exclusion_domain_test.rs
+++ b/icn/bins/icnctl/tests/exclusion_domain_test.rs
@@ -1,0 +1,433 @@
+//! Local commands that touch a data root must be inside its exclusion domain
+//! (icn#2758, icn#2759).
+//!
+//! #2749 introduced `DataDirLock` and the ceremony that depends on it. These
+//! tests cover the two holes that were left outside it, through the **real
+//! binary** and the real dispatch rather than through the handlers:
+//!
+//! * `icnctl restore --force` replaced a data root while another process held
+//!   it, and renamed that root out from under the lock file — so the holder's
+//!   `flock(2)` travelled into the backup directory while a fresh, unlocked
+//!   file appeared at the stable pathname. Two valid exclusive locks, no
+//!   contention (icn#2758).
+//! * `coop`, `treasury` and `init-coop` crossed the N2-A gate and then opened
+//!   the ceremony's own sled databases holding nothing. Sled's per-database
+//!   lock was the only thing between them and a ceremony — and a ceremony
+//!   deliberately drops its handles to re-read state, so there is an interval
+//!   in which sled locks nothing (icn#2759).
+//!
+//! **What makes these evidence.** The holder is taken with the same
+//! `DataDirLock` the daemon and the ceremony take, in this process, and the
+//! command under test is a separate real `icnctl` invocation. A refusal
+//! therefore comes from ICN's own exclusion protocol, not from `flock`
+//! arranged to look like one.
+//!
+//! The negative control matters as much as the positives: `backup` reads the
+//! same tree and is deliberately **not** brought into the domain, because
+//! serializing every observer against every holder is the over-correction
+//! #2749 had to undo twice.
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
+use std::path::{Path, PathBuf};
+use std::process::{Command, Output};
+
+use tempfile::TempDir;
+
+fn icnctl_bin() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_icnctl"))
+}
+
+/// An `icnctl` invocation with every `ICN_DEV_*` authority shortcut removed, so
+/// no dev bypass can be what makes a case pass.
+fn icnctl(data_dir: &Path) -> Command {
+    let mut cmd = Command::new(icnctl_bin());
+    for (key, _) in std::env::vars() {
+        if key.starts_with("ICN_DEV_") {
+            cmd.env_remove(&key);
+        }
+    }
+    cmd.env("RUST_LOG", "off")
+        .env("ICN_GATEWAY", "http://127.0.0.1:1")
+        .env_remove("ICN_TOKEN")
+        .arg("--data-dir")
+        .arg(data_dir);
+    cmd
+}
+
+fn combined(out: &Output) -> String {
+    format!(
+        "{}{}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr)
+    )
+}
+
+/// A data root with enough in it to be worth protecting.
+fn seeded_root(root: &Path) {
+    std::fs::create_dir_all(root.join("store")).unwrap();
+    std::fs::write(root.join("icn.toml"), b"# fixture\n").unwrap();
+    std::fs::write(root.join("store").join("marker"), b"original\n").unwrap();
+}
+
+/// Produce a backup archive with the real `icnctl backup`.
+fn archive_from(source: &Path, output: &Path) {
+    let out = icnctl(source).arg("backup").arg(output).output().unwrap();
+    assert!(out.status.success(), "backup failed: {}", combined(&out));
+}
+
+#[cfg(unix)]
+fn inode_at(path: &Path) -> Option<(u64, u64)> {
+    use std::os::unix::fs::MetadataExt as _;
+    std::fs::symlink_metadata(path)
+        .ok()
+        .map(|m| (m.dev(), m.ino()))
+}
+
+/// The refusal every holder of this domain produces.
+fn assert_refused_by_the_domain(out: &Output, what: &str) {
+    let text = combined(out);
+    assert!(
+        !out.status.success(),
+        "{what} must be refused while another process holds the data root, but it succeeded:\n{text}"
+    );
+    assert!(
+        text.contains("already holds"),
+        "{what} must be refused by the exclusion domain and say so; got:\n{text}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// icn#2758 — restore
+// ---------------------------------------------------------------------------
+
+/// `icnctl restore --force` must not replace a root another ICN process holds.
+///
+/// Reproduces the reported sequence with the real command: a genuine
+/// `DataDirLock` holder, then `restore --force` against the same root.
+#[test]
+fn restore_force_is_refused_while_a_real_holder_has_the_data_root() {
+    let scratch = TempDir::new().unwrap();
+    let source = scratch.path().join("source");
+    seeded_root(&source);
+    let archive = scratch.path().join("backup.tar");
+    archive_from(&source, &archive);
+
+    let dest = scratch.path().join("data");
+    seeded_root(&dest);
+
+    let holder = icn_core::DataDirLock::acquire(&dest, "a running daemon").unwrap();
+    let out = icnctl(&dest)
+        .arg("restore")
+        .arg(&archive)
+        .arg("--force")
+        .output()
+        .unwrap();
+    assert_refused_by_the_domain(&out, "restore --force");
+
+    // The refusal must come before anything is moved.
+    assert_eq!(
+        std::fs::read(dest.join("store").join("marker")).unwrap(),
+        b"original\n",
+        "a refused restore must leave the data root untouched"
+    );
+    assert!(
+        !std::fs::read_dir(scratch.path())
+            .unwrap()
+            .filter_map(|e| e.ok())
+            .any(|e| e.file_name().to_string_lossy().starts_with("data.backup-")),
+        "a refused restore must not have moved anything aside"
+    );
+
+    drop(holder);
+    let out = icnctl(&dest)
+        .arg("restore")
+        .arg(&archive)
+        .arg("--force")
+        .output()
+        .unwrap();
+    assert!(
+        out.status.success(),
+        "restore must proceed once the holder releases: {}",
+        combined(&out)
+    );
+}
+
+/// The exclusion anchor must survive a real `restore --force`.
+///
+/// The recorded witness on icn#2758 showed dev/ino `2049/3957598` travelling
+/// into `data.backup-…` while `2049/3957606` appeared at the stable path. This
+/// asserts the inode at that path is unchanged — a fresh one there is the
+/// split, whether or not a second holder happens to arrive.
+#[cfg(unix)]
+#[test]
+fn a_real_restore_leaves_the_exclusion_anchor_where_it_found_it() {
+    let scratch = TempDir::new().unwrap();
+    let source = scratch.path().join("source");
+    seeded_root(&source);
+    let archive = scratch.path().join("backup.tar");
+    archive_from(&source, &archive);
+
+    let dest = scratch.path().join("data");
+    seeded_root(&dest);
+
+    // Establish the anchor through a real acquisition, then release it so the
+    // restore is allowed to run at all.
+    let lock_path = {
+        let held = icn_core::DataDirLock::acquire(&dest, "a daemon").unwrap();
+        held.path().to_path_buf()
+    };
+    let before = inode_at(&lock_path).expect("the anchor must exist");
+
+    let out = icnctl(&dest)
+        .arg("restore")
+        .arg(&archive)
+        .arg("--force")
+        .output()
+        .unwrap();
+    assert!(
+        out.status.success(),
+        "restore must succeed: {}",
+        combined(&out)
+    );
+
+    assert_eq!(
+        inode_at(&lock_path),
+        Some(before),
+        "the data root's exclusion anchor must be the same file after a restore; a new inode \
+         at this path is exactly the split icn#2758 reports"
+    );
+}
+
+/// Nor when the archive itself carries one.
+///
+/// A backup taken after #2749 contains `.icn-data-dir.lock`, because
+/// `append_dir_all` includes dotfiles. Unpacking that entry would replace the
+/// very inode this restore is holding — the same split reached through
+/// extraction instead of through `rename`. The entry is skipped, which costs
+/// nothing: these files are always empty, so the one standing at that path
+/// hashes identically to the archived one and the checksum still verifies.
+#[cfg(unix)]
+#[test]
+fn a_restore_does_not_unpack_over_the_anchor_it_is_holding() {
+    let scratch = TempDir::new().unwrap();
+    let source = scratch.path().join("source");
+    seeded_root(&source);
+    // Mint and release, so the archive carries a coordination file.
+    drop(icn_core::DataDirLock::acquire(&source, "an earlier command").unwrap());
+    assert!(
+        source.join(".icn-data-dir.lock").exists(),
+        "the fixture archive must contain a coordination file"
+    );
+    let archive = scratch.path().join("backup.tar");
+    archive_from(&source, &archive);
+
+    let dest = scratch.path().join("data");
+    seeded_root(&dest);
+    let lock_path = {
+        let held = icn_core::DataDirLock::acquire(&dest, "a daemon").unwrap();
+        held.path().to_path_buf()
+    };
+    let before = inode_at(&lock_path).expect("the anchor must exist");
+
+    let out = icnctl(&dest)
+        .arg("restore")
+        .arg(&archive)
+        .arg("--force")
+        .output()
+        .unwrap();
+    assert!(
+        out.status.success(),
+        "an archive carrying coordination files must still restore and verify: {}",
+        combined(&out)
+    );
+    assert_eq!(
+        inode_at(&lock_path),
+        Some(before),
+        "extracting an archived coordination file must not replace the anchor this restore \
+         holds"
+    );
+}
+
+/// Restoring one archive twice must not overwrite the first restore's backup.
+///
+/// The moved-aside directory is named after the archive's own timestamp, so the
+/// second run picks the same name. Entry-by-entry moves would write into it file
+/// by file; the command refuses by name instead.
+#[test]
+fn a_second_restore_of_the_same_archive_refuses_rather_than_overwriting_the_backup() {
+    let scratch = TempDir::new().unwrap();
+    let source = scratch.path().join("source");
+    seeded_root(&source);
+    let archive = scratch.path().join("backup.tar");
+    archive_from(&source, &archive);
+
+    let dest = scratch.path().join("data");
+    seeded_root(&dest);
+    std::fs::write(dest.join("only-in-the-first-root"), b"keep me\n").unwrap();
+
+    let out = icnctl(&dest)
+        .arg("restore")
+        .arg(&archive)
+        .arg("--force")
+        .output()
+        .unwrap();
+    assert!(out.status.success(), "first restore: {}", combined(&out));
+
+    let backup = std::fs::read_dir(scratch.path())
+        .unwrap()
+        .filter_map(|e| e.ok())
+        .find(|e| e.file_name().to_string_lossy().starts_with("data.backup-"))
+        .expect("the first restore must have moved the old contents aside")
+        .path();
+
+    let out = icnctl(&dest)
+        .arg("restore")
+        .arg(&archive)
+        .arg("--force")
+        .output()
+        .unwrap();
+    assert!(
+        !out.status.success(),
+        "a second restore of the same archive must refuse: {}",
+        combined(&out)
+    );
+    assert!(
+        std::fs::read(backup.join("only-in-the-first-root")).unwrap() == b"keep me\n",
+        "the first restore's moved-aside copy must be intact"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// icn#2759 — the local store openers
+// ---------------------------------------------------------------------------
+
+/// Every command that opens this root's stores is refused while it is held.
+///
+/// One table rather than four tests: the property is that the set is *complete*,
+/// and listing the commands together is what makes an omission visible.
+#[test]
+fn the_local_store_openers_are_refused_while_the_data_root_is_held() {
+    let openers: [&[&str]; 5] = [
+        &["coop", "entity-report", "--json"],
+        &["coop", "entity-unknown-legacy-report", "--json"],
+        &["coop", "entity-backfill-surrogates", "--json"],
+        &["treasury", "entity-backfill-report", "--json"],
+        &["treasury", "entity-backfill-apply", "--json"],
+    ];
+
+    for args in openers {
+        let scratch = TempDir::new().unwrap();
+        let data_dir = scratch.path().join("data");
+        seeded_root(&data_dir);
+
+        let holder =
+            icn_core::DataDirLock::acquire(&data_dir, "runtime-root provisioning").unwrap();
+        let out = icnctl(&data_dir).args(args).output().unwrap();
+        assert_refused_by_the_domain(&out, &format!("`icnctl {}`", args.join(" ")));
+
+        drop(holder);
+        let out = icnctl(&data_dir).args(args).output().unwrap();
+        assert!(
+            out.status.success(),
+            "`icnctl {}` must succeed once the holder releases: {}",
+            args.join(" "),
+            combined(&out)
+        );
+    }
+}
+
+/// `init-coop` opens the trust store the ceremony writes its authority edges
+/// into, and writes the `icn.toml` the ceremony publishes into. Both locks.
+#[test]
+fn init_coop_is_refused_while_the_data_root_is_held() {
+    let scratch = TempDir::new().unwrap();
+    let data_dir = scratch.path().join("data");
+    seeded_root(&data_dir);
+
+    let holder = icn_core::DataDirLock::acquire(&data_dir, "runtime-root provisioning").unwrap();
+    let out = icnctl(&data_dir)
+        .args(["init-coop", "--name", "Blocked", "--yes", "--no-start"])
+        .output()
+        .unwrap();
+    assert_refused_by_the_domain(&out, "init-coop");
+    drop(holder);
+}
+
+/// And by a ceremony holding only the *configuration* of that directory.
+///
+/// `init-coop`'s check-then-write on `icn.toml` is the stale-snapshot shape the
+/// federation writers had before `ManagedConfigEdit`: it can find the file
+/// absent, a ceremony can publish one carrying `[cooperative]`, and this can
+/// then write over it. That writer contends for the configuration lock, not the
+/// storage one.
+#[test]
+fn init_coop_is_refused_by_a_configuration_holder_alone() {
+    let scratch = TempDir::new().unwrap();
+    let data_dir = scratch.path().join("data");
+    seeded_root(&data_dir);
+
+    let publisher =
+        icn_core::DataDirLock::acquire_config(&data_dir, "runtime-root provisioning").unwrap();
+    let out = icnctl(&data_dir)
+        .args(["init-coop", "--name", "Blocked", "--yes", "--no-start"])
+        .output()
+        .unwrap();
+    assert_refused_by_the_domain(&out, "init-coop against a configuration publisher");
+    drop(publisher);
+}
+
+// ---------------------------------------------------------------------------
+// The boundary: what deliberately stays outside the domain
+// ---------------------------------------------------------------------------
+
+/// Readers are not serialized by this repair.
+///
+/// `backup` walks the very tree `restore` replaces. Bringing it into the
+/// exclusion would be convenient and wrong: #2749 twice had to remove creating
+/// acquisition from read paths after an unconditional lock turned a mistaken
+/// command into a permanent daemon startup failure. A torn archive taken
+/// against a live daemon is a real but *different* question, recorded rather
+/// than silently answered here.
+#[test]
+fn a_read_only_observer_is_still_admitted_while_the_root_is_held() {
+    let scratch = TempDir::new().unwrap();
+    let data_dir = scratch.path().join("data");
+    seeded_root(&data_dir);
+
+    let _holder = icn_core::DataDirLock::acquire(&data_dir, "a running daemon").unwrap();
+    let out = icnctl(&data_dir)
+        .arg("backup")
+        .arg(scratch.path().join("out.tar"))
+        .output()
+        .unwrap();
+    assert!(
+        out.status.success(),
+        "reading a held data root must not be refused: {}",
+        combined(&out)
+    );
+}
+
+/// A maintenance command must not mint a data directory just to hold a lock.
+///
+/// The read-only contract these commands already had: a root that does not
+/// exist reports an empty result and creates nothing. The window that leaves is
+/// closed at the store open, not by materializing a directory here.
+#[test]
+fn an_absent_data_root_still_reports_empty_and_creates_nothing() {
+    let scratch = TempDir::new().unwrap();
+    let absent = scratch.path().join("never-created");
+
+    let out = icnctl(&absent)
+        .args(["treasury", "entity-backfill-report", "--json"])
+        .output()
+        .unwrap();
+    assert!(
+        out.status.success(),
+        "an absent data root must report empty, not fail: {}",
+        combined(&out)
+    );
+    assert!(
+        !absent.exists(),
+        "a read-only report must not have created the data directory"
+    );
+}

--- a/icn/bins/icnctl/tests/exclusion_domain_test.rs
+++ b/icn/bins/icnctl/tests/exclusion_domain_test.rs
@@ -376,6 +376,62 @@ fn init_coop_is_refused_by_a_configuration_holder_alone() {
     drop(publisher);
 }
 
+/// A misconfigured `--data-dir` is the N2-A gate's refusal to make, for every
+/// command that now joins the domain.
+///
+/// Joining happens before the gate — deliberately, so nothing can open these
+/// stores between the gate's verdict and the work it clears. That ordering made
+/// the join speak for a path that is not a directory: the ownership probe
+/// creates a file, and creating a file *inside* a regular file reports `ENOTDIR`
+/// named after the probe, burying the operator's actual mistake.
+///
+/// Both entry points are covered because they were wrong for different reasons
+/// and were fixed at different places: `join` classified too late, and
+/// `init-coop` ran the account guard at the call site *before* the classifying
+/// constructor, which left that constructor's own guard unreachable.
+#[test]
+fn a_data_dir_that_is_not_a_directory_is_refused_by_the_gate_not_by_a_probe() {
+    for args in [
+        vec!["coop", "entity-report"],
+        vec!["treasury", "entity-backfill-report"],
+        vec!["init-coop", "--name", "X", "--yes", "--no-start"],
+    ] {
+        let scratch = TempDir::new().unwrap();
+        let not_a_dir = scratch.path().join("data-dir-is-a-file");
+        std::fs::write(&not_a_dir, b"oops").unwrap();
+
+        let out = icnctl(&not_a_dir).args(&args).output().unwrap();
+        let text = combined(&out);
+        assert!(
+            !out.status.success(),
+            "`icnctl {}` must refuse a --data-dir that is not a directory:\n{text}",
+            args.join(" ")
+        );
+        assert!(
+            text.contains("N2-A startup gate refused"),
+            "`icnctl {}` must be refused BY THE GATE, not by a coordination probe:\n{text}",
+            args.join(" ")
+        );
+        assert!(
+            !text.contains("identity-probe"),
+            "`icnctl {}` must not report the ownership probe's ENOTDIR instead:\n{text}",
+            args.join(" ")
+        );
+        // Nothing was created beside it, and the file itself is untouched.
+        assert_eq!(std::fs::read(&not_a_dir).unwrap(), b"oops");
+        let left: Vec<_> = std::fs::read_dir(scratch.path())
+            .unwrap()
+            .filter_map(|e| e.ok())
+            .map(|e| e.file_name())
+            .collect();
+        assert_eq!(
+            left.len(),
+            1,
+            "a refused command must not have minted anything beside the path: {left:?}"
+        );
+    }
+}
+
 // ---------------------------------------------------------------------------
 // The boundary: what deliberately stays outside the domain
 // ---------------------------------------------------------------------------

--- a/icn/bins/icnctl/tests/institutional_runtime_root_test.rs
+++ b/icn/bins/icnctl/tests/institutional_runtime_root_test.rs
@@ -57,6 +57,101 @@ fn daemon_ledger_store_path(data_dir: &Path) -> PathBuf {
 }
 
 // ---------------------------------------------------------------------------
+// What a refused operation must not have done
+// ---------------------------------------------------------------------------
+
+/// Every entry under a data root, identified the way a change would show up:
+/// relative path -> (dev, ino, len, mtime).
+///
+/// # Why this replaced "the coordination files are absent"
+///
+/// Four refusal witnesses below used to assert that `.icn-data-dir.lock` and
+/// `.icn-config.lock` did not exist after a refused ceremony. That was never the
+/// property under test — it was a *proxy* for "the refused run created nothing"
+/// — and it stopped being a sound one when `init-coop` joined the exclusion
+/// domain (icn#2759) and began legitimately creating both files in the very
+/// fixture these tests build. Absence then said something about `init-coop`
+/// rather than about the ceremony.
+///
+/// The replacement is strictly stronger, not weaker. The old assertion proved
+/// two named files were missing; this proves that **no** entry under the root
+/// was added, removed, replaced or rewritten by the operation under test —
+/// coordination files included, keyed on **inode** rather than existence, so a
+/// same-path replacement is caught as well. Pre-existing coordination machinery
+/// is allowed; unauthorised change by the refused operation is not.
+///
+/// The root directory's own metadata is deliberately not recorded. The account
+/// guard legitimately creates and unlinks a probe file there before refusing, so
+/// the directory's mtime moves on a correct refusal; what must hold is that no
+/// *entry* survives it, which is exactly what the map says.
+fn artefact_snapshot(dir: &Path) -> std::collections::BTreeMap<PathBuf, (u64, u64, u64, i64)> {
+    use std::os::unix::fs::MetadataExt as _;
+
+    fn walk(
+        here: &Path,
+        base: &Path,
+        out: &mut std::collections::BTreeMap<PathBuf, (u64, u64, u64, i64)>,
+    ) {
+        let Ok(entries) = std::fs::read_dir(here) else {
+            return;
+        };
+        for entry in entries.flatten() {
+            let path = entry.path();
+            // `symlink_metadata`: a link is its own entry, and following one
+            // would report the target's identity instead of the link's.
+            let Ok(meta) = std::fs::symlink_metadata(&path) else {
+                continue;
+            };
+            out.insert(
+                path.strip_prefix(base).unwrap_or(&path).to_path_buf(),
+                (meta.dev(), meta.ino(), meta.len(), meta.mtime()),
+            );
+            if meta.is_dir() {
+                walk(&path, base, out);
+            }
+        }
+    }
+
+    let mut out = std::collections::BTreeMap::new();
+    walk(dir, dir, &mut out);
+    out
+}
+
+/// Assert an operation changed nothing under the root.
+///
+/// `minted` names the artefacts that must not merely be *unchanged* but must not
+/// exist at all — key material a refused ceremony must never have produced. The
+/// snapshot alone would pass if such a file had somehow existed beforehand, so
+/// the two claims are made separately rather than collapsed.
+fn assert_refusal_touched_nothing(
+    dir: &Path,
+    before: &std::collections::BTreeMap<PathBuf, (u64, u64, u64, i64)>,
+    minted: &[&str],
+) {
+    let after = artefact_snapshot(dir);
+    if &after != before {
+        let added: Vec<_> = after.keys().filter(|k| !before.contains_key(*k)).collect();
+        let removed: Vec<_> = before.keys().filter(|k| !after.contains_key(*k)).collect();
+        let changed: Vec<_> = after
+            .iter()
+            .filter(|(k, v)| before.get(*k).is_some_and(|b| b != *v))
+            .map(|(k, _)| k)
+            .collect();
+        panic!(
+            "the refused operation must not have created, removed, replaced or rewritten \
+             anything under {}.\n  added:   {added:?}\n  removed: {removed:?}\n  changed: {changed:?}",
+            dir.display()
+        );
+    }
+    for artefact in minted {
+        assert!(
+            !dir.join(artefact).exists(),
+            "{artefact} must not exist: a refused ceremony mints no key material"
+        );
+    }
+}
+
+// ---------------------------------------------------------------------------
 // Process helpers
 // ---------------------------------------------------------------------------
 
@@ -2486,30 +2581,28 @@ fn provisioning_refuses_when_it_would_change_the_configurations_group() {
         );
     }
 
+    let snapshot = artefact_snapshot(data_dir);
+
     let refused = combined(&provision_runtime_root(data_dir, "Wrong Account Coop"));
     assert!(
         refused.contains("would change which account owns it"),
         "provisioning must refuse rather than silently re-owning the file:\n{refused}"
     );
 
-    // The refusal must land before anything durable exists, so an operator is
+    // The refusal must land before anything durable happens, so an operator is
     // not left with a half-provisioned directory to clean up.
-    for artefact in ["genesis-trust-root.age", "treasury.age"] {
-        assert!(
-            !data_dir.join(artefact).exists(),
-            "{artefact} must not have been minted before the refusal"
-        );
-    }
-    // And before the coordination files, which are retained after release. A
-    // ceremony that took them under the wrong account and only then refused
-    // would leave behind files the daemon's own account cannot reopen — turning
-    // a mistaken `sudo` into a permanent startup failure.
-    for lock in [".icn-config.lock", ".icn-data-dir.lock"] {
-        assert!(
-            !data_dir.join(lock).exists(),
-            "{lock} must not have been created before the account check refused"
-        );
-    }
+    //
+    // The coordination files are the sharpest case and the snapshot covers them
+    // by inode: a ceremony that took them under the wrong account and only then
+    // refused would leave behind files the daemon's own account cannot reopen,
+    // turning a mistaken `sudo` into a permanent startup failure. What it may
+    // not do is create or replace one — which is a different statement from
+    // "none exists", now that `init-coop` legitimately creates both.
+    assert_refusal_touched_nothing(
+        data_dir,
+        &snapshot,
+        &["genesis-trust-root.age", "treasury.age"],
+    );
     let after = std::fs::symlink_metadata(&cfg).unwrap();
     {
         use std::os::unix::fs::MetadataExt as _;
@@ -2629,6 +2722,7 @@ fn a_hard_linked_configuration_is_refused_before_anything_is_provisioned() {
     let before = std::fs::symlink_metadata(&cfg).unwrap();
     assert_eq!(before.nlink(), 2, "fixture: the alias must share the inode");
     let before_bytes = std::fs::read(&cfg).unwrap();
+    let snapshot = artefact_snapshot(data_dir);
 
     let refused = combined(&provision_runtime_root(data_dir, "Aliased Coop"));
     assert!(
@@ -2636,19 +2730,13 @@ fn a_hard_linked_configuration_is_refused_before_anything_is_provisioned() {
         "an aliased configuration must be refused:\n{refused}"
     );
 
-    // Refused before anything durable exists — including the coordination files,
-    // which are retained after release.
-    for artefact in [
-        "genesis-trust-root.age",
-        "treasury.age",
-        ".icn-config.lock",
-        ".icn-data-dir.lock",
-    ] {
-        assert!(
-            !data_dir.join(artefact).exists(),
-            "{artefact} must not exist after the refusal"
-        );
-    }
+    // Refused before anything durable happens — including to the coordination
+    // files, which are retained after release.
+    assert_refusal_touched_nothing(
+        data_dir,
+        &snapshot,
+        &["genesis-trust-root.age", "treasury.age"],
+    );
 
     // Neither name was rewritten, and they are still one inode.
     let after = std::fs::symlink_metadata(&cfg).unwrap();
@@ -3365,6 +3453,8 @@ fn provisioning_refuses_when_new_files_would_not_belong_to_the_data_root_account
         );
     }
 
+    let snapshot = artefact_snapshot(data_dir);
+
     let refused = combined(&provision_runtime_root(data_dir, "Wrong Root Account Coop"));
     assert!(
         refused.contains("that the account owning it cannot use"),
@@ -3375,18 +3465,13 @@ fn provisioning_refuses_when_new_files_would_not_belong_to_the_data_root_account
         "and it must not be the configuration-file guard standing in for it:\n{refused}"
     );
 
-    // Refused before anything durable exists, including the retained lock files.
-    for artefact in [
-        "genesis-trust-root.age",
-        "treasury.age",
-        ".icn-config.lock",
-        ".icn-data-dir.lock",
-    ] {
-        assert!(
-            !data_dir.join(artefact).exists(),
-            "{artefact} must not exist after the refusal"
-        );
-    }
+    // Refused before anything durable happens, the retained coordination files
+    // included.
+    assert_refusal_touched_nothing(
+        data_dir,
+        &snapshot,
+        &["genesis-trust-root.age", "treasury.age"],
+    );
 }
 
 /// A symlinked data root is judged by its target, not by the link.
@@ -3531,24 +3616,26 @@ fn a_blocked_publication_temp_path_is_refused_before_anything_is_minted() {
 
     std::fs::create_dir(data_dir.join("icn.toml.genesis-tmp")).unwrap();
 
+    // Taken with the fixture fully staged and immediately before the operation
+    // under test, so the comparison speaks for that operation and nothing else.
+    let before = artefact_snapshot(data_dir);
+
     let refused = combined(&provision_runtime_root(data_dir, "Blocked Tmp Coop"));
     assert!(
         refused.contains("is not a regular file"),
         "the blocked temporary path must be refused:\n{refused}"
     );
 
-    for artefact in [
-        "genesis-trust-root.age",
-        "treasury.age",
-        ".icn-config.lock",
-        ".icn-data-dir.lock",
-    ] {
-        assert!(
-            !data_dir.join(artefact).exists(),
-            "{artefact} must not exist — the refusal has to precede the first durable write, \
-             or the operator is left with a root to clean up by hand"
-        );
-    }
+    // The refusal has to precede the first durable write, or the operator is
+    // left with a root to clean up by hand. That includes the coordination
+    // files: a ceremony that took them and only then refused would leave
+    // retained `0600` artefacts behind. It may not create them here — but it may
+    // equally not disturb ones an earlier participant legitimately created.
+    assert_refusal_touched_nothing(
+        data_dir,
+        &before,
+        &["genesis-trust-root.age", "treasury.age"],
+    );
 }
 
 /// An empty `[cooperative]` table is unconfigured, not a conflict.

--- a/icn/crates/icn-core/src/data_dir_lock.rs
+++ b/icn/crates/icn-core/src/data_dir_lock.rs
@@ -152,6 +152,17 @@ fn set_created_mode(_path: &Path) -> Result<()> {
 pub struct DataDirLock {
     _file: std::fs::File,
     path: PathBuf,
+    /// Which file this guard actually locked, as the kernel identifies it.
+    ///
+    /// `flock(2)` attaches to an open file description, while this domain's
+    /// identity is a **pathname**. `rename(2)` of the data root separates the
+    /// two: the locked inode travels into the renamed directory while the
+    /// stable path is free to receive a fresh, unlocked file, so two processes
+    /// can hold valid exclusive locks over what each believes is the same root
+    /// and never contend (icn#2758). Recording the inode here is what lets a
+    /// holder ask whether its exclusion still covers the path it named.
+    #[cfg(unix)]
+    anchor: (u64, u64),
 }
 
 impl DataDirLock {
@@ -262,6 +273,38 @@ impl DataDirLock {
             Sharing::Exclusive,
             &Self::storage_refusal(data_dir, holder),
         )
+    }
+
+    /// Join the storage domain, minting the coordination file only when this
+    /// account may.
+    ///
+    /// The create-or-join-or-refuse decision, as **one** definition. Three
+    /// outcomes, and every caller that opens this root's stores needs all
+    /// three:
+    ///
+    /// * new files here would belong to the account that owns the root — create
+    ///   the lock and hold it, the ordinary case;
+    /// * they would not — join an existing lock, because minting one would
+    ///   leave a `0600` file the owning account cannot reopen and the daemon
+    ///   would then refuse to start;
+    /// * they would not and there is none to join — **refuse**. Proceeding
+    ///   unlocked is the failure this domain exists to prevent, not a fallback.
+    ///
+    /// This is the same shape `runtime-root show` has had since #2749, lifted
+    /// here rather than copied: the sweep that added it to inspection is the
+    /// one that missed the maintenance commands (icn#2759), and a rule written
+    /// once at the primitive is a rule a later caller cannot spell differently.
+    ///
+    /// Not a substitute for [`refuse_if_new_files_would_not_belong_to_the_data_root_account`],
+    /// which *refuses* a wrong-account run outright. That is the right answer
+    /// for a ceremony about to mint durable state; this is the right answer for
+    /// a command that only has to be inside the domain while it looks.
+    pub fn acquire_joining_or_creating(data_dir: &Path, holder: &str) -> Result<Self> {
+        if new_files_here_belong_to_the_directory_account(data_dir)? {
+            Self::acquire(data_dir, holder)
+        } else {
+            Self::acquire_without_creating(data_dir, holder)
+        }
     }
 
     /// Join the configuration domain as a reader, but never create the file.
@@ -596,9 +639,78 @@ impl DataDirLock {
             Sharing::Shared => file.try_lock_shared(),
         };
         match taken {
-            Ok(()) => Ok(Self { _file: file, path }),
+            Ok(()) => {
+                // Read from the *descriptor*, not the path. The whole point of
+                // the anchor is that the two can disagree later, so taking it
+                // from the path would record what this guard is supposed to be
+                // able to detect having changed.
+                #[cfg(unix)]
+                let anchor = {
+                    use std::os::unix::fs::MetadataExt as _;
+                    let meta = file.metadata().with_context(|| {
+                        format!(
+                            "Failed to identify the lock {} after taking it, so this guard \
+                             could not establish which file its exclusion covers",
+                            path.display()
+                        )
+                    })?;
+                    (meta.dev(), meta.ino())
+                };
+                Ok(Self {
+                    _file: file,
+                    path,
+                    #[cfg(unix)]
+                    anchor,
+                })
+            }
             Err(_) => bail!("{refusal}"),
         }
+    }
+
+    /// Does this guard still exclude a process arriving at the path it names?
+    ///
+    /// True when the lock file at [`Self::path`] is still the inode this guard
+    /// locked. False once something has replaced or moved it — after which this
+    /// guard excludes nobody, because a newcomer resolving the same pathname
+    /// opens a different file and takes an uncontended lock on it.
+    ///
+    /// The claim is deliberately narrow: it says the *anchor* is intact, not
+    /// that the state under the root is unchanged.
+    #[cfg(unix)]
+    pub fn still_anchored(&self) -> bool {
+        use std::os::unix::fs::MetadataExt as _;
+        std::fs::symlink_metadata(&self.path)
+            .map(|m| (m.dev(), m.ino()) == self.anchor)
+            .unwrap_or(false)
+    }
+
+    /// Non-Unix makes no anchor claim, exactly as it makes no mode claim.
+    #[cfg(not(unix))]
+    pub fn still_anchored(&self) -> bool {
+        true
+    }
+
+    /// Refuse rather than act on an exclusion that has stopped covering its
+    /// path.
+    ///
+    /// Call this before any step whose correctness depends on being the only
+    /// writer — committing a completion marker, above all. A holder that has
+    /// lost its anchor is not merely unlucky: it is about to write into a
+    /// directory that is no longer the one its pathname resolves to, while some
+    /// other process legitimately owns that pathname.
+    pub fn assert_still_anchored(&self, what: &str) -> Result<()> {
+        if self.still_anchored() {
+            return Ok(());
+        }
+        bail!(
+            "Refusing to continue {what}: the exclusion this process holds no longer covers \
+             {}.\n\
+             The lock file it took has been moved or replaced — a data-root rename, a restore, \
+             or a manual repair — so another ICN process can now hold that same path without \
+             contending with this one. Anything written from here would land outside the \
+             directory that path now names. Re-run once the data root is settled.",
+            self.path.display()
+        );
     }
 
     /// The lock file this guard holds.
@@ -742,6 +854,32 @@ pub fn identity_new_files_receive(dir: &Path) -> Result<AccessIdentity> {
         .with_context(|| format!("Failed to inspect {}", probe.display()));
     let _ = std::fs::remove_file(&probe);
     identity
+}
+
+/// May this account mint a retained coordination file in this directory?
+///
+/// The boolean form of the same question
+/// [`refuse_if_new_files_would_not_belong_to_the_data_root_account`] answers by
+/// refusing — for callers whose answer to "no" is *join instead of create*
+/// rather than *stop*.
+///
+/// A directory that does not exist is an **error** here, not a pass. The
+/// refusing form lets an absent root through because its caller is about to
+/// create that root itself and has a better message for the failure; a caller
+/// asking this is about to open state it expects to already be there.
+#[cfg(unix)]
+pub fn new_files_here_belong_to_the_directory_account(dir: &Path) -> Result<bool> {
+    let owner =
+        data_root_account(dir).with_context(|| format!("Failed to inspect {}", dir.display()))?;
+    Ok(matches!(
+        classify_ownership_transfer(owner, identity_new_files_receive(dir)?),
+        OwnershipTransfer::Preserved
+    ))
+}
+
+#[cfg(not(unix))]
+pub fn new_files_here_belong_to_the_directory_account(_dir: &Path) -> Result<bool> {
+    Ok(true)
 }
 
 /// Refuse when this account would create files the owning account cannot use.
@@ -1125,5 +1263,197 @@ mod tests {
         let _storage = DataDirLock::acquire(data_root.path(), "the daemon").unwrap();
         DataDirLock::acquire_config(config_root.path(), "a ceremony")
             .expect("a storage lock on another root cannot protect this directory");
+    }
+
+    // -----------------------------------------------------------------------
+    // icn#2758: the anchor. `flock(2)` binds to an open file description; this
+    // domain's identity is a pathname. These pin the gap between the two.
+    // -----------------------------------------------------------------------
+
+    #[cfg(unix)]
+    fn inode_at(path: &Path) -> Option<(u64, u64)> {
+        use std::os::unix::fs::MetadataExt as _;
+        std::fs::symlink_metadata(path)
+            .ok()
+            .map(|m| (m.dev(), m.ino()))
+    }
+
+    /// A held lock stays held, and stays *anchored*, when nothing moves it.
+    ///
+    /// The control for the two below. Without it, "not anchored" could be an
+    /// artefact of the check rather than of the rename.
+    #[cfg(unix)]
+    #[test]
+    fn an_undisturbed_holder_remains_anchored() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let held = DataDirLock::acquire(dir.path(), "a daemon").unwrap();
+        assert!(held.still_anchored(), "nothing moved; the anchor must hold");
+        held.assert_still_anchored("this witness")
+            .expect("an intact anchor must not refuse");
+        // And it is still a real lock, not merely a file that exists.
+        assert!(
+            DataDirLock::acquire(dir.path(), "a second process").is_err(),
+            "the holder must still exclude a newcomer"
+        );
+    }
+
+    /// Renaming the data root splits the domain: the holder keeps the inode,
+    /// the pathname gets a fresh one, and both locks are valid at once.
+    ///
+    /// This is icn#2758's mechanism, reproduced at the primitive rather than
+    /// through `icnctl restore`. Two things are asserted and they are different
+    /// claims: that a second holder is admitted at the same pathname (the harm),
+    /// and that `still_anchored` reports the split (the detection).
+    #[cfg(unix)]
+    #[test]
+    fn a_renamed_root_splits_the_domain_and_the_anchor_reports_it() {
+        let parent = tempfile::TempDir::new().unwrap();
+        let root = parent.path().join("data");
+        std::fs::create_dir(&root).unwrap();
+
+        let first = DataDirLock::acquire(&root, "a daemon").unwrap();
+        let held_inode = inode_at(first.path()).expect("the lock file must exist");
+        assert!(first.still_anchored());
+
+        // Exactly what `restore --force` used to do.
+        let moved = parent.path().join("data.backup");
+        std::fs::rename(&root, &moved).unwrap();
+        std::fs::create_dir(&root).unwrap();
+
+        // The holder's lock travelled with the inode.
+        assert_eq!(
+            inode_at(&moved.join(LOCK_FILE_NAME)),
+            Some(held_inode),
+            "the locked inode must have moved into the renamed directory"
+        );
+
+        // And the stable pathname is now free for the taking.
+        let second = DataDirLock::acquire(&root, "a second process")
+            .expect("the split is exactly that a newcomer is admitted at the same path");
+        assert_ne!(
+            inode_at(second.path()),
+            Some(held_inode),
+            "the newcomer must be holding a different file — that is the split"
+        );
+
+        // Two valid exclusive locks over one pathname, neither contending. The
+        // anchor check is what makes that visible to the holder that lost it.
+        assert!(
+            !first.still_anchored(),
+            "the first holder's exclusion no longer covers the path it names"
+        );
+        assert!(
+            second.still_anchored(),
+            "the newcomer's exclusion does cover it"
+        );
+        let refusal = first
+            .assert_still_anchored("this witness")
+            .expect_err("a holder that has lost its anchor must refuse");
+        let msg = format!("{refusal:#}");
+        assert!(
+            msg.contains("no longer covers"),
+            "the refusal must say the exclusion stopped covering the path: {msg}"
+        );
+    }
+
+    /// Replacing the lock file in place loses the anchor just as a rename does.
+    ///
+    /// The rename is the sequence that was observed in the field; the general
+    /// property is about the *inode*, so a same-path replacement must be caught
+    /// too. It is also the hazard an archive extraction would create by
+    /// unpacking over a coordination file.
+    #[cfg(unix)]
+    #[test]
+    fn replacing_the_lock_file_in_place_also_loses_the_anchor() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let held = DataDirLock::acquire(dir.path(), "a daemon").unwrap();
+        let path = held.path().to_path_buf();
+
+        std::fs::remove_file(&path).unwrap();
+        std::fs::write(&path, b"").unwrap();
+
+        assert!(
+            !held.still_anchored(),
+            "a same-path replacement is the same loss of exclusion as a rename"
+        );
+    }
+
+    /// The shared side records an anchor too.
+    ///
+    /// Readers are not exempt: a daemon holding the configuration shared is
+    /// acting on bytes from a directory, and if that directory is renamed its
+    /// exclusion stops covering the path a publisher will resolve.
+    #[cfg(unix)]
+    #[test]
+    fn a_shared_configuration_holder_is_anchored_as_well() {
+        let parent = tempfile::TempDir::new().unwrap();
+        let root = parent.path().join("config");
+        std::fs::create_dir(&root).unwrap();
+
+        let reader = DataDirLock::acquire_config_shared_if_manageable(&root, "the daemon")
+            .unwrap()
+            .expect("manageable");
+        assert!(reader.still_anchored());
+
+        std::fs::rename(&root, parent.path().join("config.moved")).unwrap();
+        std::fs::create_dir(&root).unwrap();
+
+        assert!(
+            !reader.still_anchored(),
+            "a reader whose directory was renamed no longer excludes a publisher at that path"
+        );
+        DataDirLock::acquire_config(&root, "a ceremony")
+            .expect("which is demonstrated by the publisher being admitted");
+    }
+
+    /// The create-or-join decision is one definition, and it really acquires.
+    ///
+    /// Under the test account, new files in a fresh directory belong to it, so
+    /// this takes the creating arm — the arm every maintenance command uses on
+    /// an ordinary deployment. What matters is that it produces a lock that
+    /// excludes, not merely a boolean.
+    #[test]
+    fn joining_or_creating_yields_a_lock_that_excludes() {
+        let dir = tempfile::TempDir::new().unwrap();
+        assert!(
+            new_files_here_belong_to_the_directory_account(dir.path()).unwrap(),
+            "a directory this test just created must be owned by this account"
+        );
+        let held =
+            DataDirLock::acquire_joining_or_creating(dir.path(), "coop maintenance").unwrap();
+        assert!(
+            DataDirLock::acquire(dir.path(), "a ceremony").is_err(),
+            "the joining-or-creating acquire must be a real exclusive hold"
+        );
+        drop(held);
+        DataDirLock::acquire(dir.path(), "a ceremony").expect("and must release like any other");
+    }
+
+    /// It joins an existing lock rather than insisting on creating one.
+    #[test]
+    fn joining_or_creating_joins_a_lock_that_is_already_there() {
+        let dir = tempfile::TempDir::new().unwrap();
+        // Mint and release, so the file exists with no holder.
+        drop(DataDirLock::acquire(dir.path(), "an earlier command").unwrap());
+        let path = DataDirLock::lock_path(dir.path());
+        assert!(path.exists());
+        let held =
+            DataDirLock::acquire_joining_or_creating(dir.path(), "coop maintenance").unwrap();
+        assert_eq!(held.path(), path, "it must join the file that is there");
+    }
+
+    /// A directory that does not exist is an error, not a silent pass.
+    ///
+    /// The refusing form deliberately lets an absent root through, because its
+    /// caller is about to create that root. A caller asking *this* is about to
+    /// open state it expects to find, so "I could not tell" must not read as
+    /// "yes".
+    #[test]
+    fn the_create_or_join_question_has_no_answer_for_a_root_that_is_not_there() {
+        let dir = tempfile::TempDir::new().unwrap();
+        assert!(
+            new_files_here_belong_to_the_directory_account(&dir.path().join("absent")).is_err(),
+            "an unanswerable ownership question must not resolve to permission"
+        );
     }
 }

--- a/icn/crates/icn-core/src/lib.rs
+++ b/icn/crates/icn-core/src/lib.rs
@@ -36,6 +36,7 @@ pub use apps::{
     Reducer, Request, Response, RuntimeError, Service, StateDelta, StateSnapshot,
 };
 pub mod data_dir_lock;
+pub use data_dir_lock::new_files_here_belong_to_the_directory_account;
 pub use data_dir_lock::refuse_if_new_files_would_not_belong_to_the_data_root_account;
 pub use data_dir_lock::DataDirLock;
 #[cfg(unix)]


### PR DESCRIPTION
<!-- ICN-DELIVERY-LIFECYCLE:BEGIN -->
```
ICN DELIVERY LIFECYCLE
State:                READY FOR REVIEW
Lane:                 S1 institutional runtime root — external blockers #2758 + #2759
Acceptance contract:  Every local operation that can observe or mutate state conflicting with
                      an active institutional ceremony participates in one coherent exclusion
                      protocol, and that protocol's identity cannot be moved out from under the
                      pathname it names — while genuinely read-only operations stay unserialized.
Base:                 main. #2749 merged as squash fc9e7b8b6 on 2026-09-12; this was rebased
                      --onto main dropping the parent's commits, and the resulting diff is
                      sha256-identical to the pre-rebase diff. Zero semantic drift.
Review generation:    FULL @ a2a4c73ae -> adversarial diff pass found a dead guard
                      -> fixed @ a773d2d91 (init-coop's account guard ran before the
                      classification meant to precede it; M10 KILLED)
                      -> rebased onto main @ a7e048eac, content unchanged
Known blockers:       None structural. Required CI now runs: this PR targets main, so the 11
                      required contexts materialise for the first time. The earlier
                      "0/11 required contexts" note described the stacked base and no longer
                      applies.
Follow-up ledger:     #2775 (the class), and one new issue for the backup-side reader question
                      deliberately left outside this lane.
```
<!-- ICN-DELIVERY-LIFECYCLE:END -->

### The one red check, dispositioned

`Build and verify` (non-required) fails with a website layout audit:
`/for-cooperatives @ 768px — overflow: +6px, span.ladder-here`. It fails
**identically on this PR's base**, #2749's frozen `0b3f64006`, and this branch
touches zero web files (`git diff --name-only` over `web/`, `*.tsx`, `*.css`,
`*.astro` returns nothing). Pre-existing on the base, not introduced here, and
not a required context.

**Merge posture: not requested.** This closes the two external blockers #2749 names;
it does not merge, modify or unblock #2749 itself.

## Two issues, three mechanisms

They are not one defect wearing two hats, and treating them as one would have
produced the wrong fix.

1. **Non-participation** — #2759, and half of #2758. A local path opens or
   rewrites data-root state without ever taking `DataDirLock`. The domain simply
   does not cover it.
2. **Anchor migration** — #2758's load-bearing half. A path *does* participate,
   but `flock(2)` binds to an open file description while the domain's identity
   is a pathname. `rename(2)` of the data root divorces the two. This one cannot
   be fixed by remembering to take a lock, which is why #2758 was right that it
   was not fixable inside #2749.
3. **Stale-snapshot configuration writes** — the second facet recorded on #2759.
   **Already fixed at the freeze head** by `ManagedConfigEdit` (#2749 commit
   `14193f640`); that comment predates the commit. The sweep missed `init-coop`,
   which has the identical check-then-write shape, and that is repaired here.

## What changed

### `restore` joins the domain, and stops moving it (#2758)

Both locks over the destination, before anything is read or moved: restore
rewrites the storage under the root **and** republishes `<data_dir>/icn.toml`, and
a daemon holding this directory's configuration with its storage elsewhere does
not contend for the storage lock at all.

Then: **the contents move aside, the root does not.** `<data_dir>` keeps its
inode and keeps the coordination files this process locked, so exclusion is
continuous over the stable pathname with **no instant in which that path is
unlocked**.

Two alternatives were considered and rejected, for reasons worth recording:

* *Rename, then re-acquire at the fresh path.* Leaves a window between two
  syscalls in which a third party takes the root.
* *Anchor the lock outside the data root*, which is #2758's own suggested shape.
  The only rename-proof place is the parent directory, which is `root`-owned on
  every shipped deployment while the data root is owned by the service account. A
  service-account daemon could not create its own lock there — and #2749 has
  twice had to undo a lock decision that turned into a permanent daemon startup
  failure. Removing the rename buys the same continuity without touching where
  every other holder coordinates.

The extraction also skips archived coordination entries, because unpacking one
replaces the inode this restore is holding — the same split reached through
extraction instead of through `rename`. It is checksum-neutral (no ICN process
writes to these files), and coordination files restore *minted*, which the archive
never carried, are excluded from the comparison so pre-#2749 archives still verify.

### The store openers join the domain, at the opener (#2759)

`StorageDomain` holds the lock and is the only way to open a data-root sled
database in `icnctl`. It refuses a database that resolves outside the locked root.
"Take the lock here" is the rule that was already being forgotten — the #2749
history is an ownership guard added to three sites and missed at a fourth, twice —
so the question is answered where the open happens.

Six paths brought in: the five `coop`/`treasury` maintenance commands, and
`init-coop` (not in the reported list; it opens the trust store the ceremony
writes authority edges into, and check-then-writes the `icn.toml` the ceremony
publishes).

### The invariant, stated exactly

What this establishes: **every `icnctl` path that opens a sled database under a
live data root, or replaces that root's contents, holds `DataDirLock` over that
root while it does — and no operation named by #2758 or #2759 can move the lock's
identity off the pathname it protects.**

What it does **not** establish, found by re-checking the invariant rather than
assuming it: that the anchor is safe from *every* shipped command.
`icnctl snapshot delete '../.icn-data-dir.lock'` unlinks the live coordination
file and reproduces the #2758 split through `unlink` instead of `rename`. That
argument is joined onto the store path with no containment check at all, so the
same command also deletes `identity.age` and files outside the data root — a
broader defect than this lane, pre-existing on `main`, and filed as **#2779**
rather than patched here. A lock-file-only carve-out would have made this PR look
complete while leaving the worse half standing.

The consequence is worth stating plainly because it bounds what caller discipline
can buy: a holder that faithfully calls `assert_still_anchored()` is still
defeated by #2779, because the anchor it checks has been removed by an unrelated
command. **The primitive cannot defend its own invariant while any command can
unlink the file that carries it.**

### The invariant is checked, not assumed

`DataDirLock` records the `(dev, ino)` of the file it locked and exposes
`still_anchored()` / `assert_still_anchored()`. Restore checks both guards before
reporting success; the ceremony checks both before committing its receipt.
Removing the rename is what makes the split unreachable; these checks are what
make a reintroduction visible instead of silent.

## The two cautions were constraints, not advice

**Nothing was blanket-locked.** `backup`, `snapshot`, `status` and every
gateway-RPC command are untouched. `a_read_only_observer_is_still_admitted_while_the_root_is_held`
pins that `backup` still runs against a held root.

**No read path became newly exclusive at the storage layer.** Every command
brought in already crossed `enforce_n2a_gate`, whose `audit_one` opens each sled
root *exclusively* and then drops the handle — its own source comment says so. A
live daemon already refused them. What changes is membership of the domain a
holder can be in **without** holding sled handles: the ceremony between its
phases, and `restore`.

**An absent root is modelled, not special-cased.** Four existing tests require
these commands to report empty against a data directory that does not exist, and
to create nothing. `StorageDomain::AbsentRoot` holds nothing and creates nothing —
and its `open_store` **refuses**, so the root appearing a millisecond later cannot
turn absence into an unlocked open.

## What is deliberately NOT here

* **#2775 is not implemented.** The class becomes unrepresentable when the
  *primitive* rejects a creating acquisition that has not answered the ownership
  question. Proved here: these six instances participate, each pinned by a
  witness, and one binary's data-root opens cannot reach sled without a guard.
  Not proved: that the class is prevented.
* **`icnctl backup` stays outside the domain.** A backup taken against a live
  daemon can be torn. Real, and a different question — filed separately rather
  than answered by over-serializing.
* **Link safety inside an existing database.** `open_store` answers containment,
  not the per-entry link question `open_store_refusing_links` answers for the
  ceremony. Unifying them is worthwhile and is not this lane.
* **No change to institutional genesis, `EntityId`, founding acts, membership,
  gateway authority, federation semantics, remote bootstrap, daemon config
  consumption or authority migration.**

## Verification (executed at `a773d2d91`)

* `cargo fmt --all --check` clean
* `cargo clippy -p icnctl -p icnd -p icn-core --all-targets` — 0 warnings
* **86 suites, 1081 passed, 0 failed, 43 ignored** across `icn-core` + `icnctl` +
  `icnd`, run with `--no-fail-fast`. Zero `SKIPPED` notices, so no privileged
  witness was silently counted as a pass.
* **Mutation ledger: 10 applied, 10 KILLED, 0 survived, 0 invalid.** Every
  mutation sha256-verified as actually applied; every selection proven green
  before scoring.
* CI gate scripts run locally, all green: `check-meaning-firewall.sh`,
  `firewall_denylist.py`, `test_firewall_taxonomy.py`, `compliance_linter.py`,
  `check-agent-context-spine.py`, `check-truth-spine.py`,
  `test_public_docs_boundary.py`, `check-delivery-lifecycle.py`,
  `test_context_spine_enforcement.py`.

### Scope of that test run, stated rather than implied

`-p icn-core -p icnctl -p icnd`, not `--workspace`. The `icn-core` change is
purely additive — one private struct field, three new methods, one new `pub fn`,
one new `pub use` — and a grep for every symbol this branch touches returns
exactly those three crates. A full `--workspace --tests` link does not fit on
this VM's 79 GB build volume alongside the other active lanes; the workspace-wide
claim belongs to CI's `Test` job on a clean runner and is **not** made here.

### Two verification defects found and fixed, recorded because they nearly hid results

**The mutation harness restored a file to a corrupted baseline.** It backed up
once *per edit*, so a mutation touching one file twice captured the
already-half-mutated state as its "pristine" copy — and because the verification
hashes were keyed by path, the restore check compared against that same corrupted
value and passed. Two mutations ran against a contaminated tree. They scored
**INVALID (did not compile)** rather than SURVIVED, which is the only reason it
did not become a false green. Fixed to one backup per file; source restored from
`HEAD`; every anchor re-derived against post-`rustfmt` text; all selections
re-baselined before rescoring.

**A guard that could never run.** The adversarial diff pass over the complete
change found that `StorageDomain::create`'s non-directory branch was unreachable:
the init-coop dispatch called the account guard at the *call site*, one line
above the constructor that classifies, so the ownership probe still fired first
and the constructor's own guard was dead code that looked like protection.
Verified against the real binary rather than inferred, fixed at `a773d2d91` by
moving the guard into the constructor, and pinned by M10. It is the lane's own
lesson turned on the lane's own fix: a rule kept at the call site is a rule that
gets run in the wrong order.

**`cargo test` is fail-fast across targets.** An earlier run reported "78 suites,
1007 passed, 4 failed" — which reads like a full accounting and was not: every
target after the first failure was skipped, and a real regression
(`n2a_gate_coverage_test`) sat in one of them. Caught on the next run and fixed
at `a2a4c73ae`. Verification from here uses `--no-fail-fast`.

## Honest limits

* **The contents move is not atomic** the way the single directory rename was. A
  failure part-way names both directories so an operator can see where the
  contents are. A second restore of the same archive is refused by name rather
  than allowed to overwrite the first run's backup entry by entry.
* **`still_anchored()` remains caller-invoked, and that is residual policy at call
  sites.** Four assertion calls (the ceremony's two guards, restore's two) against
  roughly ten production holders that never assert. Classified deliberately: this
  is `remember-to-do-it` / `policy-in-call-sites`, **#2775's existing class, not a
  new one**, and it is not what establishes the invariant — the absence of
  anchor-migrating operations is. The check converts a silent split into a refusal
  for the callers that opt in; it is also point-in-time, so it could never be a
  guarantee even if every holder called it. Routed to #2775 with the reasoning
  rather than redesigned here.
* **The `assert_still_anchored` call sites have no independent mutation kill.**
  The predicate itself is killed at the primitive
  (`a_renamed_root_splits_the_domain_and_the_anchor_reports_it`), but nothing in
  the repaired code renames a root any more, so removing a call site alone
  survives. It is defence in depth and is reported as such rather than credited
  with a kill it did not earn.
* **A symlinked `--data-dir`** now has its target's contents moved while the
  backup directory is created beside the link; on different filesystems that
  fails closed. Previously the link itself was renamed, orphaning the target.
  Better, but not claimed as fixed or tested.
* **Advisory locking is not a boundary against a privileged local adversary**, as
  #2749 already states.
* **`icnctl backup` is deliberately still outside the domain** and a backup taken
  against a live daemon can be torn. Real, different, and filed rather than
  answered by over-serializing.

Refs #2749. Closes #2758. Closes #2759.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


