### PR TITLE
fix(ops-mcp): an unverified or uncommitted orientation source is not a healthy one

### DIFF
--- a/ops/mcp/src/diagnostics/doctor.ts
+++ b/ops/mcp/src/diagnostics/doctor.ts
@@ -1,6 +1,7 @@
 import { join } from "node:path";
 import { buildEnvironmentReport } from "./environment-report.js";
 import { buildStateIndex } from "./state-index.js";
+import { describeSourceRevision } from "./source-revision.js";
 import { runCommand } from "../utils/commands.js";
 
 export type DoctorCheck = {
@@ -290,7 +291,19 @@ export async function buildDoctorReport(repoRoot: string): Promise<DoctorReport>
     checks.push({ id: "gh", severity: "ok", message: "gh CLI available." });
   }
 
-  const cleanliness = classifyTreeCleanliness(env.git.branch, env.git.porcelainLines);
+  // The cleanliness verdict is fed by the HARDENED probe, not by buildEnvironmentReport's plain
+  // `git status --porcelain`. That plain probe honours the inspected repository's own settings,
+  // so `status.showUntrackedFiles=no` or a redirected `core.worktree` makes it report zero lines
+  // for a tree that is not clean — and a classifier cannot be more trustworthy than the
+  // measurement it is handed. describeSourceRevision pins --work-tree, forces
+  // --untracked-files=normal, sanitises the environment, and returns null rather than a number
+  // when it could not establish the answer, which is the "unknown" this classifier already
+  // treats as not-healthy.
+  //
+  // Deliberately not duplicating the hardening here: one hardened probe feeding every
+  // orientation verdict is the point, and a second copy would be a second thing to get wrong.
+  const source = await describeSourceRevision(repoRoot);
+  const cleanliness = classifyTreeCleanliness(env.git.branch, source.dirty_paths);
   // `env.git.dirtySummary` is "dirty (N paths)" rather than a file list, so appending it would
   // only restate the count this message already carries.
   checks.push({

--- a/ops/mcp/src/diagnostics/doctor.ts
+++ b/ops/mcp/src/diagnostics/doctor.ts
@@ -34,6 +34,55 @@ export const MAIN_STALE_ERROR_COMMITS = 25;
 export const FEATURE_BASE_STALE_WARN_COMMITS = 50;
 
 /**
+ * Classify how trustworthy a checkout's working tree is for serving orientation.
+ *
+ * This is the sibling of classifyTreeFreshness and deliberately mirrors its rules, because the
+ * two answer halves of one question: can what is read from this tree be trusted? Freshness asks
+ * "is it the right revision"; cleanliness asks "is it only that revision".
+ *
+ * `porcelainLines` of null means the probe could not run — that is "unknown", never "fine".
+ */
+export function classifyTreeCleanliness(
+  branch: string | null,
+  porcelainLines: number | null
+): { severity: DoctorCheck["severity"]; message: string; detail?: string; repair?: string } {
+  if (porcelainLines === null) {
+    // `warn`, not `ok`, for exactly the reason the freshness check gives one function below:
+    // the report folds only severity, so "ok" here renders the whole environment healthy on the
+    // strength of a check that did not run. An unrun check is missing evidence, not a pass.
+    return {
+      severity: "warn",
+      message:
+        "Git porcelain unavailable; worktree cleanliness is UNVERIFIED (not confirmed clean).",
+      repair: "git status --porcelain  # find out why the probe failed, then re-run doctor",
+    };
+  }
+  if (porcelainLines === 0) {
+    return { severity: "ok", message: "Worktree clean." };
+  }
+  if (branch === "main") {
+    // A checkout on main is the one serving canonical docs and ops/state. Uncommitted edits
+    // there mean readers are being handed content that exists in no commit at all — strictly
+    // worse than being behind, because it is unreviewable rather than merely old. The same
+    // main-versus-feature asymmetry the freshness check already applies.
+    return {
+      severity: "error",
+      message: `Checkout is on main with ${porcelainLines} uncommitted path(s) — canonical docs and ops/state served from here do not match any commit.`,
+      detail:
+        "Treat anything read from this tree as unverified: it is neither origin/main nor any reviewed revision.",
+      repair: "git status  # commit, stash, or restore before serving orientation from this tree",
+    };
+  }
+  // On a feature branch or a detached checkout, uncommitted edits are the work in progress.
+  const what =
+    branch === null || branch === "HEAD" ? "Detached checkout" : "Feature branch";
+  return {
+    severity: "warn",
+    message: `${what} has ${porcelainLines} uncommitted path(s) (expected during active work).`,
+  };
+}
+
+/**
  * Classify how stale a checkout is relative to origin/main.
  *
  * `behindCount` of NaN means origin/main could not be resolved (no remote ref,
@@ -241,27 +290,17 @@ export async function buildDoctorReport(repoRoot: string): Promise<DoctorReport>
     checks.push({ id: "gh", severity: "ok", message: "gh CLI available." });
   }
 
-  if (env.git.porcelainLines === null) {
-    checks.push({
-      id: "dirty_tree",
-      severity: "ok",
-      message: "Git porcelain unavailable; dirty-tree check skipped.",
-    });
-  } else if (env.git.porcelainLines > 0) {
-    checks.push({
-      id: "dirty_tree",
-      severity: "warn",
-      message: `Dirty worktree: ${env.git.dirtySummary}`,
-    });
-    suggested.push("git status — commit or stash before switching tasks if required by workflow.");
-    top = maxSeverity(top, "warn");
-  } else {
-    checks.push({
-      id: "dirty_tree",
-      severity: "ok",
-      message: "Worktree clean.",
-    });
-  }
+  const cleanliness = classifyTreeCleanliness(env.git.branch, env.git.porcelainLines);
+  // `env.git.dirtySummary` is "dirty (N paths)" rather than a file list, so appending it would
+  // only restate the count this message already carries.
+  checks.push({
+    id: "dirty_tree",
+    severity: cleanliness.severity,
+    message: cleanliness.message,
+    ...(cleanliness.detail ? { detail: cleanliness.detail } : {}),
+  });
+  if (cleanliness.repair) suggested.push(cleanliness.repair);
+  top = maxSeverity(top, cleanliness.severity);
 
   // Tree freshness. `dirty_tree` above answers "are there uncommitted edits?",
   // which is trivially "no" for a checkout nobody has touched in weeks — so a

--- a/ops/mcp/src/tests/doctor-cleanliness.test.ts
+++ b/ops/mcp/src/tests/doctor-cleanliness.test.ts
@@ -1,0 +1,155 @@
+import { afterAll, describe, it, expect } from "vitest";
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { buildDoctorReport, classifyTreeCleanliness } from "../diagnostics/doctor.js";
+
+// The input space here is genuinely small — four kinds of branch by three states of the
+// porcelain probe — so it is enumerated EXHAUSTIVELY rather than sampled. A table of
+// hand-picked cases would leave the reader wondering which combination was omitted; a full
+// cross-product cannot.
+
+const BRANCHES: { label: string; value: string | null }[] = [
+  { label: "main", value: "main" },
+  { label: "feature branch", value: "claude/some-work" },
+  { label: "detached (HEAD)", value: "HEAD" },
+  { label: "detached (null)", value: null },
+];
+
+const PORCELAIN: { label: string; value: number | null }[] = [
+  { label: "unprobed (null)", value: null },
+  { label: "clean (0)", value: 0 },
+  { label: "dirty (3)", value: 3 },
+];
+
+/** The full expected verdict for every point in the space. */
+function expected(branch: string | null, lines: number | null): "ok" | "warn" | "error" {
+  if (lines === null) return "warn"; // unknown is never fine
+  if (lines === 0) return "ok";
+  return branch === "main" ? "error" : "warn";
+}
+
+describe("classifyTreeCleanliness — exhaustive over the whole input space", () => {
+  const cases = BRANCHES.flatMap((b) => PORCELAIN.map((p) => ({ b, p })));
+
+  it("enumerates every combination (guards against the table silently shrinking)", () => {
+    expect(cases).toHaveLength(BRANCHES.length * PORCELAIN.length);
+    expect(cases).toHaveLength(12);
+  });
+
+  it.each(cases)("$b.label + $p.label", ({ b, p }) => {
+    const got = classifyTreeCleanliness(b.value, p.value);
+    expect(got.severity).toBe(expected(b.value, p.value));
+  });
+
+  // The invariant, asserted over the space rather than at a point: the ONLY way to be reported
+  // healthy is to have actually been measured clean. Everything else is warn or error.
+  it("never reports ok unless cleanliness was confirmed", () => {
+    for (const { b, p } of cases) {
+      const got = classifyTreeCleanliness(b.value, p.value);
+      if (got.severity === "ok") {
+        expect(p.value, `ok returned for porcelain=${p.label} on ${b.label}`).toBe(0);
+      }
+    }
+  });
+});
+
+describe("classifyTreeCleanliness — the specific regressions it exists to prevent", () => {
+  it("reports an unrunnable probe as UNVERIFIED, not as a skipped check that passes", () => {
+    const got = classifyTreeCleanliness("main", null);
+    // The previous implementation returned severity "ok" with the message
+    // "dirty-tree check skipped." Because the report folds only severity, that rendered the
+    // whole environment healthy on the strength of a check that never ran.
+    expect(got.severity).not.toBe("ok");
+    expect(got.message).toMatch(/UNVERIFIED/);
+  });
+
+  it("fails a main checkout that is serving uncommitted content", () => {
+    const got = classifyTreeCleanliness("main", 43);
+    // 43 is the real number observed on this host's MCP-serving checkout.
+    expect(got.severity).toBe("error");
+    expect(got.message).toMatch(/do not match any commit/);
+    expect(got.detail).toMatch(/unverified/i);
+  });
+
+  it("does not punish a feature lane for having work in it", () => {
+    const got = classifyTreeCleanliness("claude/some-work", 43);
+    expect(got.severity).toBe("warn");
+    expect(got.message).toMatch(/expected during active work/);
+  });
+
+  it("describes a detached checkout as detached rather than as a feature branch", () => {
+    for (const b of [null, "HEAD"]) {
+      const got = classifyTreeCleanliness(b, 2);
+      expect(got.message).toMatch(/^Detached checkout/);
+    }
+  });
+
+  it("offers a repair only when there is something to repair", () => {
+    expect(classifyTreeCleanliness("main", 0).repair).toBeUndefined();
+    expect(classifyTreeCleanliness("main", null).repair).toBeTruthy();
+    expect(classifyTreeCleanliness("main", 5).repair).toBeTruthy();
+  });
+});
+
+// Wiring. The tests above prove the classifier; they say nothing about whether the report
+// actually asks it. A correct helper that nothing calls would pass every one of them, so the
+// severity is asserted end-to-end through buildDoctorReport.
+describe("buildDoctorReport — the classifier is actually wired into the verdict", () => {
+  const temps: string[] = [];
+  function repo(branch: string, dirty: boolean): string {
+    const d = mkdtempSync(path.join(tmpdir(), "icn-doctor-"));
+    temps.push(d);
+    const git = (...a: string[]): void => {
+      execFileSync("git", [
+        "-c", "user.email=t@e.invalid", "-c", "user.name=T",
+        "-c", "init.defaultBranch=main", "-c", "commit.gpgsign=false",
+        ...a,
+      ], { cwd: d, stdio: "ignore" });
+    };
+    git("init", ".");
+    writeFileSync(path.join(d, "README.md"), "seed\n");
+    git("add", "README.md");
+    git("commit", "-m", "seed");
+    if (branch !== "main") git("checkout", "-b", branch);
+    if (dirty) writeFileSync(path.join(d, "README.md"), "uncommitted edit\n");
+    return d;
+  }
+  afterAll(() => {
+    for (const d of temps) rmSync(d, { recursive: true, force: true });
+  });
+
+  // NOTE ON WHAT IS ASSERTED HERE. The top-level `report.severity` is NOT used as evidence: a
+  // synthetic temp repo legitimately errors on node_modules, better-sqlite3 and the portability
+  // script, so it reads "error" whatever the dirty check says. Asserting it would pass for the
+  // wrong reason. The discriminating fact is that the dirty_tree CHECK exists and its severity
+  // moves with the branch — which is only possible if the classifier is actually being called
+  // with it.
+  it("emits a dirty_tree check whose severity tracks the branch", async () => {
+    const onMain = await buildDoctorReport(repo("main", true));
+    const onLane = await buildDoctorReport(repo("claude/work", true));
+
+    const mainCheck = onMain.checks.find((c) => c.id === "dirty_tree");
+    const laneCheck = onLane.checks.find((c) => c.id === "dirty_tree");
+
+    expect(mainCheck, "dirty_tree check must be present").toBeDefined();
+    expect(laneCheck, "dirty_tree check must be present").toBeDefined();
+    expect(mainCheck?.severity).toBe("error");
+    expect(laneCheck?.severity).toBe("warn");
+    // Identical trees apart from the branch: the difference can only come from the classifier.
+    expect(mainCheck?.severity).not.toBe(laneCheck?.severity);
+  });
+
+  it("states the uncommitted path count so the verdict is actionable", async () => {
+    const report = await buildDoctorReport(repo("main", true));
+    const check = report.checks.find((c) => c.id === "dirty_tree");
+    expect(check?.message).toMatch(/1 uncommitted path\(s\)/);
+  });
+
+  it("reports a clean main checkout as ok", async () => {
+    const report = await buildDoctorReport(repo("main", false));
+    const check = report.checks.find((c) => c.id === "dirty_tree");
+    expect(check?.severity).toBe("ok");
+  });
+});

--- a/ops/mcp/src/tests/doctor-cleanliness.test.ts
+++ b/ops/mcp/src/tests/doctor-cleanliness.test.ts
@@ -153,3 +153,62 @@ describe("buildDoctorReport — the classifier is actually wired into the verdic
     expect(check?.severity).toBe("ok");
   });
 });
+
+// The classifier can only be as trustworthy as the measurement it is handed. buildEnvironmentReport
+// runs a PLAIN `git status --porcelain`, which honours the inspected repository's own settings —
+// so a repo can hide its dirt from it. These assert the doctor is fed the hardened probe instead.
+describe("buildDoctorReport — a repository cannot hide its dirt from the verdict", () => {
+  const temps: string[] = [];
+  function repo(configure: (git: (...a: string[]) => void, dir: string) => void): string {
+    const d = mkdtempSync(path.join(tmpdir(), "icn-doctor-adv-"));
+    temps.push(d);
+    const git = (...a: string[]): void => {
+      execFileSync("git", [
+        "-c", "user.email=t@e.invalid", "-c", "user.name=T",
+        "-c", "init.defaultBranch=main", "-c", "commit.gpgsign=false", ...a,
+      ], { cwd: d, stdio: "ignore" });
+    };
+    git("init", ".");
+    writeFileSync(path.join(d, "README.md"), "seed\n");
+    git("add", "README.md");
+    git("commit", "-m", "seed");
+    configure(git, d);
+    return d;
+  }
+  afterAll(() => {
+    for (const d of temps) rmSync(d, { recursive: true, force: true });
+  });
+
+  it("sees untracked content a repo configured to hide it", async () => {
+    const d = repo((git, dir) => {
+      git("config", "status.showUntrackedFiles", "no");
+      writeFileSync(path.join(dir, "smuggled.json"), "{}\n");
+    });
+
+    // Control: the plain probe the doctor USED to depend on reports nothing.
+    const plain = execFileSync("git", ["status", "--porcelain"], { cwd: d, encoding: "utf-8" }).trim();
+    expect(plain, "control: the config must actually hide it from a plain probe").toBe("");
+
+    const report = await buildDoctorReport(d);
+    const check = report.checks.find((c) => c.id === "dirty_tree");
+    // On main with hidden-but-real dirt, the verdict must not be "clean".
+    expect(check?.severity).toBe("error");
+  });
+
+  it("sees modifications a redirected core.worktree would conceal", async () => {
+    const decoy = mkdtempSync(path.join(tmpdir(), "icn-doctor-decoy-"));
+    temps.push(decoy);
+    writeFileSync(path.join(decoy, "README.md"), "seed\n");
+    const d = repo((git, dir) => {
+      writeFileSync(path.join(dir, "README.md"), "locally modified\n");
+      git("config", "core.worktree", decoy);
+    });
+
+    const plain = execFileSync("git", ["status", "--porcelain"], { cwd: d, encoding: "utf-8" }).trim();
+    expect(plain, "control: core.worktree must actually redirect the plain probe").toBe("");
+
+    const report = await buildDoctorReport(d);
+    const check = report.checks.find((c) => c.id === "dirty_tree");
+    expect(check?.severity).toBe("error");
+  });
+});


### PR DESCRIPTION
# Pull Request

## Delivery

- **Delivery lane**: STANDARD
- **Acceptance contract**: the doctor never reports an unverified or uncommitted orientation source as healthy; a checkout serving canonical truth that is dirty fails rather than warns.
- **Explicit non-goals**: does not touch the host-local `icn-dev-doctor` script, does not change staleness thresholds, does not alter any other check.

<!-- ICN-DELIVERY-LIFECYCLE:BEGIN -->
```
ICN DELIVERY LIFECYCLE
State:                READY_FOR_REVIEW
Lane:                 STANDARD
Acceptance contract:  unverified or uncommitted orientation sources are not reported healthy
Review generation:    generation 1 requested
Freeze head:          9fada2b0f
Known blockers:       -
Follow-up ledger:     host-local icn-dev-doctor is outside this repo (see Findings)
```
<!-- ICN-DELIVERY-LIFECYCLE:END -->

## Problem

The doctor is what tells an operator whether this host can be trusted for orientation. Its dirty-tree check had a fail-open in exactly the place the previous two slices spent their time closing:

```ts
if (env.git.porcelainLines === null) {
  checks.push({ id: "dirty_tree", severity: "ok",
                message: "Git porcelain unavailable; dirty-tree check skipped." });
}
```

The report folds only `severity`, so **a check that never ran rendered the whole environment healthy.** Missing evidence presented as a pass — the same shape as reporting an unprobed tree clean (R1-A) and returning a truncated blob as success (R1-B).

And it was already known to be wrong *one function away*: `classifyTreeFreshness` returns `warn` for an unresolvable `origin/main`, with a comment saying `"ok"` there would reintroduce "a confident health verdict over truth nobody verified." The cleanliness branch did not follow its own sibling.

## Claim

An orientation source that is unverified, or that serves content existing in no commit, is not reported as healthy.

## Scope

`classifyTreeCleanliness(branch, porcelainLines)` extracted as a pure sibling of `classifyTreeFreshness` — the two are halves of one question: freshness asks *"is this the right revision"*, cleanliness asks *"is it **only** that revision"*.

| state | before | after | why |
|---|---|---|---|
| probe could not run | **`ok`** | `warn` — "UNVERIFIED (not confirmed clean)" | an unrun check is missing evidence, not a pass |
| clean | `ok` | `ok` | unchanged |
| dirty **on main** | `warn` | **`error`** | a checkout serving canonical docs and `ops/state` with uncommitted edits hands readers content that exists in no commit — strictly worse than being behind, because it is *unreviewable* rather than merely old |
| dirty on feature/detached | `warn` | `warn` | edits there are the work |

The main-versus-feature asymmetry is not new policy: `classifyTreeFreshness` already applies it. This makes the siblings consistent.

Also dropped the `dirtySummary` append — it is `"dirty (N paths)"`, not a file list, so it only restated the count the new message already carries.

## Out of scope

- The **host-local** `icn-dev-doctor` (`~/bin/`, not in this repository) — see Findings.
- Staleness thresholds (`MAIN_STALE_ERROR_COMMITS` etc.) — untouched.
- Every other doctor check.

## Verification

**Exhaustive, not sampled.** The input space is 4 branch kinds × 3 probe states = 12, small enough to enumerate completely — with a guard asserting the table *is* the full cross-product, so it cannot silently shrink, and a property asserting the only route to `ok` is a confirmed-clean measurement.

**Mutation evidence** — each fails the suite:

| mutation | result |
|---|---|
| unknown probe no longer flagged | 2 tests fail |
| dirty-on-main downgraded to `warn` | 3 tests fail |
| **report stops passing the branch to the classifier** (classifier still correct) | 1 test fails |

That last one matters: a correct pure function that nothing calls would pass every unit test.

**An assertion deliberately NOT made.** The end-to-end tests do not assert `report.severity`. A synthetic temp repo legitimately errors on `node_modules`, `better-sqlite3` and the portability script, so that field reads `error` regardless — asserting it would pass for the wrong reason. The discriminating fact is that `dirty_tree`'s severity *moves with the branch* on otherwise identical trees.

**Live, against this host's MCP-serving checkout:**

```
dirty_tree     : error | on main with 43 uncommitted path(s) — ... do not match any commit
tree_freshness : error | on main but 26 commit(s) behind origin/main
report severity: error
```

Previously `dirty_tree` was `warn`. This is what the audit's R1 verification asked for.

`tsc` exit 0 · **22 new tests** · full suite **391** · 17/17 drift-gate scripts · `drift-check.sh` PASS.

## Findings (classified, not folded into this PR)

**The host-local half of R1-C is not in this repository.** `icn-dev-doctor` lives at `~/bin/icn-dev-doctor` and is not tracked here; neither is `repo-sync`. The audit's R1 verification names *that* script, but the repo-side analogue — and the one agents actually call — is `icn_ops_doctor`, which is what this PR fixes. Making the host script fail on a dirty/behind `mcp-host`, and auto-fast-forwarding it, remain **host changes outside any PR**.

## Related
- Refs: development audit R1 (slice C). Follows #2774 (R1-A) and #2776 (R1-B).

## Layer classification
- [x] ops/coordination (process, refinery, hygiene)

## Type of change
- [x] Bug fix
- [x] Tests

## Risk

Low, with one deliberate consequence: `icn_ops_doctor` will now return `error` for a dirty checkout on `main`, where it previously returned `warn`. That is the point of the change — the current MCP host is exactly such a checkout. Rollback is reverting the commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
